### PR TITLE
refactor: Replace Triangle vertices Vec with fixed-size array

### DIFF
--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -116,14 +116,14 @@ pub fn parse_aperture(
                         let v4 = [-half_width, half_height];
 
                         aperture.primitives.push(Primitive::Triangle {
-                            vertices: vec![v1, v2, v3],
+                            vertices: [v1, v2, v3],
                             exposure: 1.0,
                             hole_x: 0.0,
                             hole_y: 0.0,
                             hole_radius: hole_diameter_mm / 2.0,
                         });
                         aperture.primitives.push(Primitive::Triangle {
-                            vertices: vec![v1, v3, v4],
+                            vertices: [v1, v3, v4],
                             exposure: 1.0,
                             hole_x: 0.0,
                             hole_y: 0.0,
@@ -191,14 +191,14 @@ pub fn parse_aperture(
                             let y2 = half_height;
 
                             aperture.primitives.push(Primitive::Triangle {
-                                vertices: vec![[x1, y1], [x2, y1], [x1, y2]],
+                                vertices: [[x1, y1], [x2, y1], [x1, y2]],
                                 exposure: 1.0,
                                 hole_x: 0.0,
                                 hole_y: 0.0,
                                 hole_radius: hole_diameter_mm / 2.0,
                             });
                             aperture.primitives.push(Primitive::Triangle {
-                                vertices: vec![[x2, y1], [x2, y2], [x1, y2]],
+                                vertices: [[x2, y1], [x2, y2], [x1, y2]],
                                 exposure: 1.0,
                                 hole_x: 0.0,
                                 hole_y: 0.0,
@@ -239,14 +239,14 @@ pub fn parse_aperture(
                             let y2 = half_rect_height;
 
                             aperture.primitives.push(Primitive::Triangle {
-                                vertices: vec![[x1, y1], [x2, y1], [x1, y2]],
+                                vertices: [[x1, y1], [x2, y1], [x1, y2]],
                                 exposure: 1.0,
                                 hole_x: 0.0,
                                 hole_y: 0.0,
                                 hole_radius: hole_diameter_mm / 2.0,
                             });
                             aperture.primitives.push(Primitive::Triangle {
-                                vertices: vec![[x2, y1], [x2, y2], [x1, y2]],
+                                vertices: [[x2, y1], [x2, y2], [x1, y2]],
                                 exposure: 1.0,
                                 hole_x: 0.0,
                                 hole_y: 0.0,
@@ -303,7 +303,7 @@ pub fn parse_aperture(
                             let y2 = radius * angle_next.sin();
 
                             aperture.primitives.push(Primitive::Triangle {
-                                vertices: vec![[0.0, 0.0], [x1, y1], [x2, y2]],
+                                vertices: [[0.0, 0.0], [x1, y1], [x2, y2]],
                                 exposure: 1.0,
                                 hole_x: 0.0,
                                 hole_y: 0.0,

--- a/wasm/src/parser/aperture_macro.rs
+++ b/wasm/src/parser/aperture_macro.rs
@@ -488,7 +488,7 @@ pub fn parse_primitive_statement(
             for i in 0..(num_vertices as usize) {
                 let next_i = (i + 1) % (num_vertices as usize);
                 let mut triangle = Primitive::Triangle {
-                    vertices: vec![[center_x, center_y], vertices[i], vertices[next_i]],
+                    vertices: [[center_x, center_y], vertices[i], vertices[next_i]],
                     exposure,
                     hole_x: 0.0,
                     hole_y: 0.0,
@@ -604,14 +604,14 @@ pub fn parse_primitive_statement(
 
             // Two triangles: (v1, v2, v3), (v1, v3, v4)
             let mut tri1 = Primitive::Triangle {
-                vertices: vec![v1, v2, v3],
+                vertices: [v1, v2, v3],
                 exposure,
                 hole_x: 0.0,
                 hole_y: 0.0,
                 hole_radius: 0.0,
             };
             let mut tri2 = Primitive::Triangle {
-                vertices: vec![v1, v3, v4],
+                vertices: [v1, v3, v4],
                 exposure,
                 hole_x: 0.0,
                 hole_y: 0.0,


### PR DESCRIPTION
- Change Triangle.vertices from Vec<[f32; 2]> to [[f32; 2]; 3]
- Add PackedPrimitive struct with type discriminant and fixed f32[12] array
- Implement conversion methods between Primitive enum and PackedPrimitive
- Update all Triangle creation sites to use array literals instead of vec!

This improves memory efficiency and cache locality for WASM runtime.