### PR TITLE
Install wasm-pack from prebuilt release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,18 @@
-name: Build and Test
+name: Build, Test, and Deploy
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,53 +22,115 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('wasm/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-registry-
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('wasm/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
 
-    - name: Cache cargo index
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-index-
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: wasm/target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('wasm/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-target-
 
-    - name: Cache cargo build
-      uses: actions/cache@v4
-      with:
-        path: wasm/target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-
+      - name: Cache WASM package
+        uses: actions/cache@v4
+        with:
+          path: wasm/pkg
+          key: ${{ runner.os }}-wasm-pkg-release-${{ hashFiles('scripts/vercel-build.sh', 'wasm/Cargo.lock', 'wasm/Cargo.toml', 'wasm/src/**') }}
 
-    - name: Install wasm-pack
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build or reuse WASM package
+        run: ./scripts/vercel-build.sh
 
-    - name: Build WASM module
-      working-directory: ./wasm
-      run: wasm-pack build --target web --out-dir pkg --dev
+      - name: Install Rust toolchain for tests
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
-    - name: Run tests
-      working-directory: ./wasm
-      run: cargo test --verbose
+      - name: Run tests
+        working-directory: ./wasm
+        run: cargo test --verbose
 
-    - name: Upload WASM artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wasm-module
-        path: wasm/pkg/
-        retention-days: 7
+      - name: Upload WASM package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg
+          path: wasm/pkg/
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 14
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download WASM package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: wasm/pkg
+
+      - name: Check Vercel secrets
+        id: vercel-secrets
+        run: |
+          if [[ -n "$VERCEL_ORG_ID" && -n "$VERCEL_PROJECT_ID" && -n "$VERCEL_TOKEN" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping Vercel deploy because VERCEL_ORG_ID, VERCEL_PROJECT_ID, or VERCEL_TOKEN is missing."
+          fi
+
+      - name: Install Vercel CLI
+        if: steps.vercel-secrets.outputs.enabled == 'true'
+        run: npm install --global vercel@latest
+
+      - name: Resolve Vercel environment
+        if: steps.vercel-secrets.outputs.enabled == 'true'
+        id: vercel-env
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+            echo "prod-flag=--prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=preview" >> "$GITHUB_OUTPUT"
+            echo "prod-flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pull Vercel environment
+        if: steps.vercel-secrets.outputs.enabled == 'true'
+        run: vercel pull --yes --environment="${{ steps.vercel-env.outputs.environment }}" --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel output
+        if: steps.vercel-secrets.outputs.enabled == 'true'
+        run: vercel build ${{ steps.vercel-env.outputs.prod-flag }} --token="$VERCEL_TOKEN"
+
+      - name: Deploy Vercel prebuilt output
+        if: steps.vercel-secrets.outputs.enabled == 'true'
+        id: vercel-deploy
+        run: |
+          deployment_url="$(vercel deploy --prebuilt ${{ steps.vercel-env.outputs.prod-flag }} --token="$VERCEL_TOKEN")"
+          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+          echo "Deployed to $deployment_url" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 export CARGO_HOME="/rust"
 export RUSTUP_HOME="/rust"
 export PATH="$CARGO_HOME/bin:$PATH"
+WASM_PACK_VERSION="0.14.0"
 
 # shellcheck disable=SC1091
 . /rust/env
@@ -13,7 +14,31 @@ rustup default stable
 rustup target add wasm32-unknown-unknown --toolchain stable
 
 if ! command -v wasm-pack >/dev/null 2>&1; then
-  cargo install wasm-pack --locked
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      wasm_pack_arch="x86_64"
+      ;;
+    aarch64 | arm64)
+      wasm_pack_arch="aarch64"
+      ;;
+    *)
+      echo "Unsupported architecture for prebuilt wasm-pack: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  wasm_pack_target="${wasm_pack_arch}-unknown-linux-musl"
+  wasm_pack_archive="wasm-pack-v${WASM_PACK_VERSION}-${wasm_pack_target}.tar.gz"
+  wasm_pack_url="https://github.com/wasm-bindgen/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${wasm_pack_archive}"
+  wasm_pack_tmp="$(mktemp -d)"
+
+  curl --proto '=https' --tlsv1.2 -fsSL "$wasm_pack_url" -o "$wasm_pack_tmp/$wasm_pack_archive"
+  tar -xzf "$wasm_pack_tmp/$wasm_pack_archive" -C "$wasm_pack_tmp"
+  mkdir -p "$CARGO_HOME/bin"
+  install -m 0755 \
+    "$wasm_pack_tmp/wasm-pack-v${WASM_PACK_VERSION}-${wasm_pack_target}/wasm-pack" \
+    "$CARGO_HOME/bin/wasm-pack"
+  rm -rf "$wasm_pack_tmp"
 fi
 
 cd wasm

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,13 +1,48 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export CARGO_HOME="/rust"
-export RUSTUP_HOME="/rust"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -z "${CARGO_HOME:-}" && -f /rust/env ]]; then
+  export CARGO_HOME="/rust"
+fi
+if [[ -z "${RUSTUP_HOME:-}" && -f /rust/env ]]; then
+  export RUSTUP_HOME="/rust"
+fi
+export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
 export PATH="$CARGO_HOME/bin:$PATH"
 WASM_PACK_VERSION="0.14.0"
 
-# shellcheck disable=SC1091
-. /rust/env
+for rust_env in "$CARGO_HOME/env" "$RUSTUP_HOME/env" /rust/env; do
+  if [[ -f "$rust_env" ]]; then
+    # shellcheck disable=SC1090
+    . "$rust_env"
+    break
+  fi
+done
+
+wasm_package_hash() {
+  (
+    cd "$REPO_ROOT"
+    {
+      printf '%s\0' scripts/vercel-build.sh wasm/Cargo.lock wasm/Cargo.toml
+      find wasm/src -type f -print0 | sort -z
+    } | xargs -0 sha256sum
+  ) | sha256sum | cut -d ' ' -f1
+}
+
+wasm_hash="$(wasm_package_hash)"
+wasm_pkg_dir="$REPO_ROOT/wasm/pkg"
+
+if [[
+  -f "$wasm_pkg_dir/.source-hash" &&
+  -f "$wasm_pkg_dir/wasm_gerber_processor.js" &&
+  -f "$wasm_pkg_dir/wasm_gerber_processor_bg.wasm" &&
+  "$(cat "$wasm_pkg_dir/.source-hash")" == "$wasm_hash"
+]]; then
+  echo "Reusing cached wasm/pkg for source hash $wasm_hash"
+  exit 0
+fi
 
 rustup toolchain install stable --profile minimal
 rustup default stable
@@ -41,5 +76,6 @@ if ! command -v wasm-pack >/dev/null 2>&1; then
   rm -rf "$wasm_pack_tmp"
 fi
 
-cd wasm
+cd "$REPO_ROOT/wasm"
 wasm-pack build --target web --out-dir pkg --release
+printf '%s\n' "$wasm_hash" > pkg/.source-hash

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "buildCommand": "./scripts/vercel-build.sh",
-  "ignoreCommand": "if [ -n \"$VERCEL_GIT_COMMIT_SHA\" ] && [ \"$GITHUB_ACTIONS\" != \"true\" ]; then exit 0; fi; exit 1",
+  "ignoreCommand": "test \"$GITHUB_ACTIONS\" != \"true\"",
   "outputDirectory": "."
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "buildCommand": "./scripts/vercel-build.sh",
-  "ignoreCommand": "test \"$GITHUB_ACTIONS\" != \"true\"",
-  "outputDirectory": "."
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "buildCommand": "./scripts/vercel-build.sh",
+  "ignoreCommand": "if [ -n \"$VERCEL_GIT_COMMIT_SHA\" ] && [ \"$GITHUB_ACTIONS\" != \"true\" ]; then exit 0; fi; exit 1",
   "outputDirectory": "."
 }


### PR DESCRIPTION
## Summary
- Move Vercel deployment into GitHub Actions using `vercel build` and `vercel deploy --prebuilt`.
- Cache `wasm/pkg` by the Rust/WASM source hash and upload it as a workflow artifact for the deploy job.
- Make `scripts/vercel-build.sh` reuse `wasm/pkg` when `.source-hash` matches, so UI-only changes avoid Rust/WASM rebuilds.
- Keep `wasm-pack` installation on the prebuilt release path when a rebuild is needed.
- Ignore Vercel Git integration builds outside GitHub Actions to avoid duplicate deployments.

## Required secrets
- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `VERCEL_PROJECT_ID`

The current run has `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID`, but deploy was skipped because `VERCEL_TOKEN` is not set.

## Validation
- `bash -n scripts/vercel-build.sh`
- Verified cached `wasm/pkg` skip path locally with `.source-hash`
- `git diff --check`
- GitHub Actions build job passed in 21s on PR #6