### PR TITLE
[codex] Refresh viewer UI controls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,7 @@ jobs:
             ${{ runner.os }}-cargo-build-target-
 
       - name: Cache WASM package
+        id: wasm-pkg-cache
         uses: actions/cache@v4
         with:
           path: wasm/pkg
@@ -57,12 +58,17 @@ jobs:
       - name: Build or reuse WASM package
         run: ./scripts/vercel-build.sh
 
+      - name: Check JavaScript syntax
+        run: node --check js/main.js
+
       - name: Install Rust toolchain for tests
+        if: steps.wasm-pkg-cache.outputs.cache-hit != 'true'
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
 
       - name: Run tests
+        if: steps.wasm-pkg-cache.outputs.cache-hit != 'true'
         working-directory: ./wasm
         run: cargo test --verbose
 

--- a/css/style.css
+++ b/css/style.css
@@ -14,6 +14,7 @@
   --danger: #f87171;
   --warning: #facc15;
   --panel-width: 381px;
+  --panel-height: 420px;
   --toolbar-height: 58px;
   --status-height: 34px;
   --radius: 8px;
@@ -58,10 +59,11 @@ button {
 
 .top-toolbar {
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto auto;
+  grid-template-columns: minmax(150px, max-content) minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 12px;
   min-width: 0;
+  overflow: hidden;
   padding: 8px 12px;
   border-bottom: 1px solid var(--line);
   background: rgba(17, 24, 34, 0.96);
@@ -73,10 +75,18 @@ button {
   min-width: 0;
   display: flex;
   align-items: center;
+  overflow: hidden;
+}
+
+.brand-lockup > div {
+  min-width: 0;
 }
 
 .brand-lockup h1 {
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   line-height: 1.1;
   font-size: 15px;
   font-weight: 700;
@@ -95,13 +105,21 @@ button {
 
 .toolbar-group,
 .section-toolbar {
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
 .view-actions {
+  flex: 0 0 auto;
   justify-content: flex-end;
+}
+
+.toolbar-divider {
+  width: 1px;
+  height: 28px;
+  background: var(--line);
 }
 
 .section-toolbar {
@@ -114,6 +132,7 @@ button {
 }
 
 .primary-actions {
+  justify-self: stretch;
   min-width: 0;
   overflow-x: auto;
   scrollbar-width: none;
@@ -229,6 +248,8 @@ button {
   min-width: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--panel-width);
+  overflow: hidden;
+  transition: grid-template-columns 180ms ease;
 }
 
 .viewer-surface {
@@ -416,17 +437,25 @@ button {
   container-type: inline-size;
   border-left: 1px solid var(--line);
   background: var(--surface);
+  transform: translateX(0);
+  transition: transform 180ms ease;
 }
 
 .side-panel.collapsed {
-  width: 0;
   min-width: 0;
   overflow: hidden;
+  pointer-events: none;
+  transform: translateX(100%);
   border-left: 0;
 }
 
 .workspace:has(.side-panel.collapsed) {
   grid-template-columns: minmax(0, 1fr) 0;
+}
+
+.app-shell:has(.side-panel.resizing) .workspace,
+.side-panel.resizing {
+  transition: none;
 }
 
 .side-panel.resizing {
@@ -440,6 +469,7 @@ button {
   bottom: 0;
   width: 8px;
   cursor: ew-resize;
+  touch-action: none;
   z-index: 7;
 }
 
@@ -815,13 +845,17 @@ button {
   }
 
   .top-toolbar {
-    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-columns: minmax(118px, max-content) minmax(0, 1fr) auto auto;
     padding: 8px;
-    gap: 8px;
+    gap: 6px;
   }
 
   .brand-lockup h1 {
     font-size: 14px;
+  }
+
+  .toolbar-divider {
+    height: 24px;
   }
 
   #workspace-status {
@@ -841,6 +875,7 @@ button {
   .workspace {
     position: relative;
     display: block;
+    overflow: hidden;
   }
 
   .viewer-surface {
@@ -854,24 +889,43 @@ button {
     right: 0;
     bottom: 0;
     width: auto !important;
+    height: var(--panel-height);
     max-height: min(72vh, 560px);
     z-index: 30;
     border-left: 0;
     border-top: 1px solid var(--line);
     box-shadow: 0 -18px 42px rgba(0, 0, 0, 0.34);
     transform: translateY(0);
-    transition: transform 180ms ease;
   }
 
   .side-panel.collapsed {
     width: auto;
     transform: translateY(calc(100% - 65px));
     overflow: hidden;
+    pointer-events: auto;
     border-top: 1px solid var(--line);
   }
 
   .resize-handle {
-    display: none;
+    left: 0;
+    right: 0;
+    top: -5px;
+    bottom: auto;
+    width: auto;
+    height: 10px;
+    cursor: ns-resize;
+  }
+
+  .resize-handle::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 4px;
+    width: 44px;
+    height: 3px;
+    border-radius: 999px;
+    background: var(--line);
+    transform: translateX(-50%);
   }
 
   .panel-tabs {

--- a/css/style.css
+++ b/css/style.css
@@ -15,6 +15,7 @@
   --warning: #facc15;
   --panel-width: 381px;
   --panel-height: 420px;
+  --panel-collapsed-height: 95px;
   --toolbar-height: 58px;
   --status-height: 34px;
   --radius: 8px;
@@ -133,6 +134,7 @@ button {
 
 .primary-actions {
   justify-self: stretch;
+  justify-content: flex-end;
   min-width: 0;
   overflow-x: auto;
   scrollbar-width: none;
@@ -244,15 +246,18 @@ button {
 }
 
 .workspace {
+  width: 100%;
+  height: 100%;
   min-height: 0;
   min-width: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) var(--panel-width);
+  position: relative;
+  display: block;
   overflow: hidden;
-  transition: grid-template-columns 180ms ease;
 }
 
 .viewer-surface {
+  width: 100%;
+  height: 100%;
   min-width: 0;
   min-height: 0;
   position: relative;
@@ -312,7 +317,7 @@ button {
 .measurement-overlay text {
   fill: #fff;
   stroke: #000;
-  stroke-width: 1px;
+  stroke-width: 2px;
   paint-order: stroke;
   font-size: 12px;
   font-weight: 700;
@@ -428,10 +433,19 @@ button {
   z-index: 5;
 }
 
+.workspace:has(.side-panel:not(.collapsed)) .empty-state,
+.workspace:has(.side-panel:not(.collapsed)) .canvas-status {
+  right: var(--panel-width);
+}
+
 .side-panel {
+  width: var(--panel-width);
   min-width: 0;
   min-height: 0;
-  position: relative;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   container-type: inline-size;
@@ -439,6 +453,7 @@ button {
   background: var(--surface);
   transform: translateX(0);
   transition: transform 180ms ease;
+  z-index: 30;
 }
 
 .side-panel.collapsed {
@@ -449,11 +464,6 @@ button {
   border-left: 0;
 }
 
-.workspace:has(.side-panel.collapsed) {
-  grid-template-columns: minmax(0, 1fr) 0;
-}
-
-.app-shell:has(.side-panel.resizing) .workspace,
 .side-panel.resizing {
   transition: none;
 }
@@ -845,13 +855,13 @@ button {
   }
 
   .top-toolbar {
-    grid-template-columns: minmax(118px, max-content) minmax(0, 1fr) auto auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     padding: 8px;
     gap: 6px;
   }
 
-  .brand-lockup h1 {
-    font-size: 14px;
+  .brand-lockup {
+    display: none;
   }
 
   .toolbar-divider {
@@ -873,20 +883,24 @@ button {
   }
 
   .workspace {
-    position: relative;
-    display: block;
     overflow: hidden;
   }
 
-  .viewer-surface {
-    width: 100%;
-    height: 100%;
+  .workspace:has(.side-panel:not(.collapsed)) .empty-state {
+    right: 0;
+    bottom: var(--panel-height);
+  }
+
+  .workspace:has(.side-panel:not(.collapsed)) .canvas-status {
+    right: 0;
+    bottom: var(--panel-height);
   }
 
   .side-panel {
     position: fixed;
     left: 0;
     right: 0;
+    top: auto;
     bottom: 0;
     width: auto !important;
     height: var(--panel-height);
@@ -898,12 +912,108 @@ button {
     transform: translateY(0);
   }
 
+  .panel-tabs {
+    gap: 4px;
+    padding: 6px 8px;
+  }
+
+  .panel-tab {
+    height: 38px;
+    gap: 2px;
+    padding: 3px;
+  }
+
+  .panel-section {
+    padding: 8px 10px;
+  }
+
+  .panel-section.active,
+  .layer-panel-controls {
+    gap: 8px;
+  }
+
+  .alpha-control {
+    gap: 6px;
+    padding: 5px 10px;
+  }
+
+  .info-grid {
+    gap: 6px;
+  }
+
+  .info-grid > div,
+  .file-note,
+  .filter-form {
+    padding: 8px;
+  }
+
+  .filter-form {
+    gap: 8px;
+  }
+
   .side-panel.collapsed {
     width: auto;
-    transform: translateY(calc(100% - 65px));
+    transform: translateY(calc(100% - var(--panel-collapsed-height)));
     overflow: hidden;
     pointer-events: auto;
     border-top: 1px solid var(--line);
+  }
+
+  .side-panel.collapsed .panel-tabs,
+  .side-panel.collapsed .layer-list-scroll {
+    display: none;
+  }
+
+  .side-panel.collapsed .panel-section {
+    display: none;
+  }
+
+  .side-panel.collapsed .panel-section[data-panel="layers"] {
+    display: flex;
+    padding: 8px 10px;
+  }
+
+  .side-panel.collapsed .layer-panel-controls {
+    gap: 8px;
+  }
+
+  .side-panel.collapsed .section-toolbar .chip-button {
+    display: inline-flex;
+  }
+
+  .side-panel.collapsed .section-toolbar .chip-button:nth-child(n + 4) {
+    display: none;
+  }
+
+  .side-panel.collapsed .section-toolbar .chip-button span {
+    display: inline;
+  }
+
+  .side-panel.collapsed .alpha-control {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 10px;
+  }
+
+  .side-panel.collapsed .alpha-control .field-row {
+    display: contents;
+  }
+
+  .side-panel.collapsed .alpha-control .field-row span {
+    display: none;
+  }
+
+  .side-panel.collapsed .alpha-control .field-row strong {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 38px;
+    text-align: right;
+  }
+
+  .side-panel.collapsed #alpha-slider {
+    grid-column: 1;
+    grid-row: 1;
   }
 
   .resize-handle {

--- a/css/style.css
+++ b/css/style.css
@@ -533,7 +533,7 @@ button {
 .alpha-control {
   display: grid;
   gap: 8px;
-  padding: 12px;
+  padding: 6px 12px;
   border: 1px solid var(--line);
   border-radius: 7px;
   background: var(--surface-2);
@@ -757,7 +757,7 @@ button {
 .notification {
   display: none;
   position: fixed;
-  top: calc(var(--toolbar-height) + 12px);
+  bottom: calc(var(--status-height) + 12px);
   right: calc(var(--panel-width) + 12px);
   width: min(460px, calc(100vw - var(--panel-width) - 24px));
   max-height: min(48vh, 320px);
@@ -894,7 +894,7 @@ button {
   }
 
   .notification {
-    top: calc(var(--toolbar-height) + 8px);
+    bottom: calc(var(--status-height) + 8px);
     left: 8px;
     right: 8px;
     width: auto;

--- a/index.html
+++ b/index.html
@@ -106,6 +106,8 @@
           </button>
         </div>
 
+        <div class="toolbar-divider" aria-hidden="true"></div>
+
         <div class="toolbar-group view-actions">
           <button
             type="button"

--- a/index.html
+++ b/index.html
@@ -39,6 +39,26 @@
           <button
             type="button"
             class="icon-button"
+            id="flip-horizontal-btn"
+            aria-label="Flip horizontally"
+            aria-pressed="false"
+            title="Flip horizontally"
+          >
+            <i data-lucide="flip-horizontal-2"></i>
+          </button>
+          <button
+            type="button"
+            class="icon-button"
+            id="flip-vertical-btn"
+            aria-label="Flip vertically"
+            aria-pressed="false"
+            title="Flip vertically"
+          >
+            <i data-lucide="flip-vertical-2"></i>
+          </button>
+          <button
+            type="button"
+            class="icon-button"
             id="canvas-theme-toggle"
             aria-label="Switch to white canvas"
             aria-pressed="false"

--- a/js/main.js
+++ b/js/main.js
@@ -1111,8 +1111,10 @@ export class GerberViewer {
 
     this.camera.zoom = this.clampZoom(fitView.zoom);
     this.fitViewZoom = this.camera.zoom;
-    this.camera.offsetX = -fitView.centerX * this.getViewScaleX();
-    this.camera.offsetY = -fitView.centerY * this.getViewScaleY();
+    this.camera.offsetX =
+      fitView.targetX - fitView.centerX * this.getViewScaleX();
+    this.camera.offsetY =
+      fitView.targetY - fitView.centerY * this.getViewScaleY();
 
     this.render();
     this.updateUiState();
@@ -1158,30 +1160,104 @@ export class GerberViewer {
       return null;
     }
 
+    const viewport = this.getVisibleCanvasViewport();
+    if (!viewport) return null;
+
     const boundsWidth = maxX - minX;
     const boundsHeight = maxY - minY;
     const centerX = (minX + maxX) / 2;
     const centerY = (minY + maxY) / 2;
+    const targetX = (viewport.left + viewport.right) / 2;
+    const targetY = (viewport.top + viewport.bottom) / 2;
 
     if (boundsWidth === 0 && boundsHeight === 0) {
-      return { centerX, centerY, zoom: 2.0 };
+      return { centerX, centerY, targetX, targetY, zoom: 2.0 };
     }
 
     let zoom;
     if (boundsWidth === 0) {
-      zoom = (2.0 / boundsHeight) * 0.9;
+      zoom = (viewport.height / boundsHeight) * 0.9;
     } else if (boundsHeight === 0) {
-      zoom = (2.0 / boundsWidth) * 0.9;
+      zoom = (viewport.width / boundsWidth) * 0.9;
     } else {
-      const canvasAspect = this.canvas.width / this.canvas.height;
-      const boundsAspect = boundsWidth / boundsHeight;
       zoom =
-        boundsAspect > canvasAspect
-          ? (2.0 / boundsWidth) * 0.9
-          : (2.0 / boundsHeight) * 0.9;
+        Math.min(viewport.width / boundsWidth, viewport.height / boundsHeight) *
+        0.9;
     }
 
-    return { centerX, centerY, zoom };
+    return { centerX, centerY, targetX, targetY, zoom };
+  }
+
+  getVisibleCanvasViewport() {
+    const rect = this.canvas.getBoundingClientRect();
+    if (
+      rect.width === 0 ||
+      rect.height === 0 ||
+      this.canvas.width === 0 ||
+      this.canvas.height === 0
+    ) {
+      return null;
+    }
+
+    const visibleRect = {
+      left: 0,
+      top: 0,
+      right: rect.width,
+      bottom: rect.height,
+    };
+    const drawerRect = this.drawer.getBoundingClientRect();
+    const intersectsCanvas =
+      drawerRect.right > rect.left &&
+      drawerRect.left < rect.right &&
+      drawerRect.bottom > rect.top &&
+      drawerRect.top < rect.bottom;
+
+    if (intersectsCanvas) {
+      if (this.isMobileDrawerLayout()) {
+        visibleRect.bottom = Math.max(
+          visibleRect.top + 1,
+          Math.min(visibleRect.bottom, drawerRect.top - rect.top),
+        );
+      } else {
+        visibleRect.right = Math.max(
+          visibleRect.left + 1,
+          Math.min(visibleRect.right, drawerRect.left - rect.left),
+        );
+      }
+    }
+
+    const topLeft = this.canvasLocalPointToCorrected(
+      visibleRect.left,
+      visibleRect.top,
+      rect,
+    );
+    const bottomRight = this.canvasLocalPointToCorrected(
+      visibleRect.right,
+      visibleRect.bottom,
+      rect,
+    );
+
+    return {
+      left: topLeft.x,
+      right: bottomRight.x,
+      top: topLeft.y,
+      bottom: bottomRight.y,
+      width: Math.abs(bottomRight.x - topLeft.x),
+      height: Math.abs(topLeft.y - bottomRight.y),
+    };
+  }
+
+  canvasLocalPointToCorrected(x, y, rect) {
+    const centerX = rect.width / 2;
+    const centerY = rect.height / 2;
+    const ndcX = ((x - centerX) / rect.width) * 2;
+    const ndcY = -((y - centerY) / rect.height) * 2;
+    const aspect = this.canvas.width / this.canvas.height;
+
+    return {
+      x: aspect > 1.0 ? ndcX * aspect : ndcX,
+      y: aspect > 1.0 ? ndcY : ndcY / aspect,
+    };
   }
 
   handleWheel(e) {

--- a/js/main.js
+++ b/js/main.js
@@ -95,8 +95,11 @@ export class GerberViewer {
     // Drawer resize state
     this.isResizingDrawer = false;
     this.drawerCurrentWidth = 381;
+    this.drawerCurrentHeight = 420;
     this.drawerMinWidth = 200;
     this.drawerMaxWidth = 600;
+    this.drawerMinHeight = 180;
+    this.drawerMaxHeight = 560;
 
     // Colors
     this.colorPalette = [
@@ -142,7 +145,10 @@ export class GerberViewer {
 
     // Resize Canvas
     this.resizeCanvas();
-    window.addEventListener("resize", () => this.resizeCanvas());
+    window.addEventListener("resize", () => {
+      this.resizeCanvas();
+      this.updateDrawerToggleState();
+    });
 
     this.setupEventListeners();
 
@@ -158,7 +164,11 @@ export class GerberViewer {
 
   resizeCanvas() {
     if (this.drawer && !this.drawer.classList.contains("collapsed")) {
-      this.setDrawerWidth(this.drawerCurrentWidth);
+      if (this.isMobileDrawerLayout()) {
+        this.setDrawerHeight(this.drawerCurrentHeight);
+      } else {
+        this.setDrawerWidth(this.drawerCurrentWidth);
+      }
     }
 
     const rect = this.canvas.getBoundingClientRect();
@@ -313,7 +323,7 @@ export class GerberViewer {
     });
 
     // Drawer toggle event
-    if (window.matchMedia("(max-width: 760px)").matches) {
+    if (this.isMobileDrawerLayout()) {
       this.drawer.classList.add("collapsed");
     }
     this.updateDrawerToggleState();
@@ -1799,6 +1809,10 @@ export class GerberViewer {
   }
 
   // Drawer management methods
+  isMobileDrawerLayout() {
+    return window.matchMedia("(max-width: 760px)").matches;
+  }
+
   getDrawerMaxWidth() {
     const viewportLimit = Math.max(this.drawerMinWidth, window.innerWidth - 48);
     return Math.min(this.drawerMaxWidth, viewportLimit);
@@ -1818,8 +1832,36 @@ export class GerberViewer {
   setDrawerWidth(width) {
     const clampedWidth = this.clampDrawerWidth(width);
     this.drawerCurrentWidth = clampedWidth;
+    this.drawer.style.height = "";
     this.drawer.style.width = `${clampedWidth}px`;
     this.dropZone.style.setProperty("--panel-width", `${clampedWidth}px`);
+  }
+
+  getDrawerMaxHeight() {
+    const viewportLimit = Math.max(
+      this.drawerMinHeight,
+      Math.floor(window.innerHeight * 0.72),
+    );
+    return Math.min(this.drawerMaxHeight, viewportLimit);
+  }
+
+  clampDrawerHeight(height) {
+    if (!Number.isFinite(height)) {
+      return this.drawerCurrentHeight;
+    }
+
+    return Math.min(
+      this.getDrawerMaxHeight(),
+      Math.max(this.drawerMinHeight, height),
+    );
+  }
+
+  setDrawerHeight(height) {
+    const clampedHeight = this.clampDrawerHeight(height);
+    this.drawerCurrentHeight = clampedHeight;
+    this.drawer.style.width = "";
+    this.drawer.style.height = `${clampedHeight}px`;
+    this.dropZone.style.setProperty("--panel-height", `${clampedHeight}px`);
   }
 
   startDrawerResize(e) {
@@ -1831,19 +1873,24 @@ export class GerberViewer {
     this.isResizingDrawer = true;
     this.drawer.classList.add("resizing");
     document.body.style.userSelect = "none";
-    document.body.style.cursor = "ew-resize";
+    document.body.style.cursor = this.isMobileDrawerLayout()
+      ? "ns-resize"
+      : "ew-resize";
   }
 
   resizeDrawer(e) {
     if (!this.isResizingDrawer) return;
 
-    // Get X position from mouse or touch event
+    e.preventDefault();
+
+    if (this.isMobileDrawerLayout()) {
+      const clientY = e.touches ? e.touches[0].clientY : e.clientY;
+      this.setDrawerHeight(window.innerHeight - clientY);
+      return;
+    }
+
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
-
-    // Calculate new width based on position
-    // X position from right edge of viewport
     const newWidth = window.innerWidth - clientX;
-
     this.setDrawerWidth(newWidth);
   }
 
@@ -1871,36 +1918,53 @@ export class GerberViewer {
     if (shouldOpen) {
       // Expand drawer
       this.drawer.classList.remove("collapsed");
-      this.setDrawerWidth(this.drawerCurrentWidth);
+      if (this.isMobileDrawerLayout()) {
+        this.setDrawerHeight(this.drawerCurrentHeight);
+      } else {
+        this.setDrawerWidth(this.drawerCurrentWidth);
+      }
     } else {
       // Collapse drawer
-      this.drawerCurrentWidth = this.clampDrawerWidth(
-        this.drawer.getBoundingClientRect().width || this.drawerCurrentWidth,
-      );
+      const drawerRect = this.drawer.getBoundingClientRect();
+      if (this.isMobileDrawerLayout()) {
+        this.drawerCurrentHeight = this.clampDrawerHeight(
+          drawerRect.height || this.drawerCurrentHeight,
+        );
+      } else {
+        this.drawerCurrentWidth = this.clampDrawerWidth(
+          drawerRect.width || this.drawerCurrentWidth,
+        );
+      }
       this.drawer.classList.add("collapsed");
     }
 
     this.updateDrawerToggleState();
 
     // Trigger canvas resize immediately after toggle
-    // Use requestAnimationFrame to ensure layout has updated
     requestAnimationFrame(() => {
       this.triggerCanvasResize();
     });
+    window.setTimeout(() => {
+      this.triggerCanvasResize();
+    }, 220);
   }
 
   updateDrawerToggleState() {
     const isCollapsed = this.drawer.classList.contains("collapsed");
     const label = isCollapsed ? "Show panel" : "Hide panel";
+    const iconName = this.isMobileDrawerLayout()
+      ? isCollapsed
+        ? "chevron-up"
+        : "chevron-down"
+      : isCollapsed
+        ? "panel-right-open"
+        : "panel-right-close";
     this.drawerToggleBtn.setAttribute("aria-label", label);
     this.drawerToggleBtn.setAttribute("aria-expanded", String(!isCollapsed));
     this.drawerToggleBtn.title = label;
     this.drawerToggleBtn.replaceChildren();
     const icon = document.createElement("i");
-    icon.setAttribute(
-      "data-lucide",
-      isCollapsed ? "panel-right-open" : "panel-right-close",
-    );
+    icon.setAttribute("data-lucide", iconName);
     this.drawerToggleBtn.appendChild(icon);
     this.refreshIcons();
   }

--- a/js/main.js
+++ b/js/main.js
@@ -96,6 +96,8 @@ export class GerberViewer {
     this.isResizingDrawer = false;
     this.drawerCurrentWidth = 381;
     this.drawerCurrentHeight = 420;
+    this.drawerPendingWidth = null;
+    this.drawerPendingHeight = null;
     this.drawerMinWidth = 200;
     this.drawerMaxWidth = 600;
     this.drawerMinHeight = 180;
@@ -698,7 +700,7 @@ export class GerberViewer {
     context.font = "700 12px Inter, ui-sans-serif, system-ui, sans-serif";
     context.textAlign = "center";
     context.textBaseline = "middle";
-    context.lineWidth = 2;
+    context.lineWidth = 4;
     context.strokeStyle = "#000";
     context.fillStyle = "#fff";
     context.strokeText(this.formatMeasurementLength(distance), x, y);
@@ -1829,12 +1831,17 @@ export class GerberViewer {
     );
   }
 
-  setDrawerWidth(width) {
+  setDrawerWidth(width, { commitLayout = true } = {}) {
     const clampedWidth = this.clampDrawerWidth(width);
-    this.drawerCurrentWidth = clampedWidth;
+    if (commitLayout) {
+      this.drawerCurrentWidth = clampedWidth;
+      this.drawerPendingWidth = null;
+      this.dropZone.style.setProperty("--panel-width", `${clampedWidth}px`);
+    } else {
+      this.drawerPendingWidth = clampedWidth;
+    }
     this.drawer.style.height = "";
     this.drawer.style.width = `${clampedWidth}px`;
-    this.dropZone.style.setProperty("--panel-width", `${clampedWidth}px`);
   }
 
   getDrawerMaxHeight() {
@@ -1856,12 +1863,17 @@ export class GerberViewer {
     );
   }
 
-  setDrawerHeight(height) {
+  setDrawerHeight(height, { commitLayout = true } = {}) {
     const clampedHeight = this.clampDrawerHeight(height);
-    this.drawerCurrentHeight = clampedHeight;
+    if (commitLayout) {
+      this.drawerCurrentHeight = clampedHeight;
+      this.drawerPendingHeight = null;
+      this.dropZone.style.setProperty("--panel-height", `${clampedHeight}px`);
+    } else {
+      this.drawerPendingHeight = clampedHeight;
+    }
     this.drawer.style.width = "";
     this.drawer.style.height = `${clampedHeight}px`;
-    this.dropZone.style.setProperty("--panel-height", `${clampedHeight}px`);
   }
 
   startDrawerResize(e) {
@@ -1885,25 +1897,34 @@ export class GerberViewer {
 
     if (this.isMobileDrawerLayout()) {
       const clientY = e.touches ? e.touches[0].clientY : e.clientY;
-      this.setDrawerHeight(window.innerHeight - clientY);
+      this.setDrawerHeight(window.innerHeight - clientY, {
+        commitLayout: false,
+      });
       return;
     }
 
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
     const newWidth = window.innerWidth - clientX;
-    this.setDrawerWidth(newWidth);
+    this.setDrawerWidth(newWidth, { commitLayout: false });
   }
 
   stopDrawerResize(e) {
     if (!this.isResizingDrawer) return;
 
+    if (this.isMobileDrawerLayout()) {
+      if (this.drawerPendingHeight !== null) {
+        this.setDrawerHeight(this.drawerPendingHeight);
+      }
+    } else if (this.drawerPendingWidth !== null) {
+      this.setDrawerWidth(this.drawerPendingWidth);
+    }
+
     this.isResizingDrawer = false;
-    this.drawer.classList.remove("resizing");
     document.body.style.userSelect = "";
     document.body.style.cursor = "";
-
-    // Trigger canvas resize
-    this.triggerCanvasResize();
+    requestAnimationFrame(() => {
+      this.drawer.classList.remove("resizing");
+    });
   }
 
   triggerCanvasResize() {
@@ -1939,14 +1960,6 @@ export class GerberViewer {
     }
 
     this.updateDrawerToggleState();
-
-    // Trigger canvas resize immediately after toggle
-    requestAnimationFrame(() => {
-      this.triggerCanvasResize();
-    });
-    window.setTimeout(() => {
-      this.triggerCanvasResize();
-    }, 220);
   }
 
   updateDrawerToggleState() {

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,5 @@
+const NOTIFICATION_DURATION_MS = 2000;
+
 export class GerberViewer {
   constructor() {
     // Main canvas (WebGL2)
@@ -798,30 +800,40 @@ export class GerberViewer {
   }
 
   showFileSizeWarning(oversizedFiles) {
-    this.showNotification("Warning", "warning", 8000, (messageElement) => {
-      const list = document.createElement("ul");
-      list.className = "mb-0 mt-2 ps-3";
+    this.showNotification(
+      "Warning",
+      "warning",
+      NOTIFICATION_DURATION_MS,
+      (messageElement) => {
+        const list = document.createElement("ul");
+        list.className = "mb-0 mt-2 ps-3";
 
-      oversizedFiles.forEach((file) => {
-        const item = document.createElement("li");
-        const fileName = document.createElement("strong");
-        fileName.textContent = file.name;
+        oversizedFiles.forEach((file) => {
+          const item = document.createElement("li");
+          const fileName = document.createElement("strong");
+          fileName.textContent = file.name;
 
-        item.appendChild(fileName);
-        item.append(
-          document.createTextNode(`: ${file.size} (limit: ${file.limit})`),
-        );
-        list.appendChild(item);
-      });
+          item.appendChild(fileName);
+          item.append(
+            document.createTextNode(`: ${file.size} (limit: ${file.limit})`),
+          );
+          list.appendChild(item);
+        });
 
-      messageElement.appendChild(list);
-    });
+        messageElement.appendChild(list);
+      },
+    );
   }
 
   showError(message) {
-    this.showNotification("Error", "danger", 5000, (messageElement) => {
-      messageElement.textContent = message;
-    });
+    this.showNotification(
+      "Error",
+      "danger",
+      NOTIFICATION_DURATION_MS,
+      (messageElement) => {
+        messageElement.textContent = message;
+      },
+    );
   }
 
   showNotification(title, variant, duration, renderMessage) {

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,8 @@ export class GerberViewer {
     this.selectFilesBtn = document.getElementById("select-files-btn");
     this.emptyUploadBtn = document.getElementById("empty-upload-btn");
     this.fitViewBtn = document.getElementById("fit-view-btn");
+    this.flipHorizontalBtn = document.getElementById("flip-horizontal-btn");
+    this.flipVerticalBtn = document.getElementById("flip-vertical-btn");
     this.canvasThemeToggle = document.getElementById("canvas-theme-toggle");
     this.screenshotBtn = document.getElementById("screenshot-btn");
     this.rulerToggleBtn = document.getElementById("ruler-toggle-btn");
@@ -72,6 +74,8 @@ export class GerberViewer {
       zoom: 1.0,
       offsetX: 0.0,
       offsetY: 0.0,
+      flipX: false,
+      flipY: false,
     };
     this.fitViewZoom = null;
     this.minZoom = 0.000001;
@@ -148,6 +152,7 @@ export class GerberViewer {
     this.updateUiState();
     this.updateRulerControls();
     this.updateMeasurementUnitControl();
+    this.updateViewFlipControls();
     this.render();
   }
 
@@ -187,6 +192,14 @@ export class GerberViewer {
     // Fit view button
     this.fitViewBtn.addEventListener("click", () => {
       this.fitView();
+    });
+
+    this.flipHorizontalBtn.addEventListener("click", () => {
+      this.toggleViewFlip("x");
+    });
+
+    this.flipVerticalBtn.addEventListener("click", () => {
+      this.toggleViewFlip("y");
     });
 
     this.canvasThemeToggle.addEventListener("click", () => {
@@ -532,6 +545,38 @@ export class GerberViewer {
     this.panelSections.forEach((section) => {
       section.classList.toggle("active", section.dataset.panel === panelName);
     });
+  }
+
+  getViewScaleX() {
+    return this.camera.zoom * (this.camera.flipX ? -1 : 1);
+  }
+
+  getViewScaleY() {
+    return this.camera.zoom * (this.camera.flipY ? -1 : 1);
+  }
+
+  toggleViewFlip(axis) {
+    if (axis === "x") {
+      this.camera.flipX = !this.camera.flipX;
+      this.camera.offsetX = -this.camera.offsetX;
+    } else if (axis === "y") {
+      this.camera.flipY = !this.camera.flipY;
+      this.camera.offsetY = -this.camera.offsetY;
+    }
+
+    this.render();
+    this.updateViewFlipControls();
+  }
+
+  updateViewFlipControls() {
+    this.flipHorizontalBtn.setAttribute(
+      "aria-pressed",
+      String(this.camera.flipX),
+    );
+    this.flipVerticalBtn.setAttribute(
+      "aria-pressed",
+      String(this.camera.flipY),
+    );
   }
 
   toggleCanvasTheme() {
@@ -931,8 +976,8 @@ export class GerberViewer {
       this.wasmProcessor.render(
         new Uint32Array(activeLayerIds),
         new Float32Array(colorData),
-        this.camera.zoom,
-        this.camera.zoom,
+        this.getViewScaleX(),
+        this.getViewScaleY(),
         this.camera.offsetX,
         this.camera.offsetY,
         this.globalAlpha,
@@ -1054,8 +1099,8 @@ export class GerberViewer {
 
     this.camera.zoom = this.clampZoom(fitView.zoom);
     this.fitViewZoom = this.camera.zoom;
-    this.camera.offsetX = -fitView.centerX * this.camera.zoom;
-    this.camera.offsetY = -fitView.centerY * this.camera.zoom;
+    this.camera.offsetX = -fitView.centerX * this.getViewScaleX();
+    this.camera.offsetY = -fitView.centerY * this.getViewScaleY();
 
     this.render();
     this.updateUiState();
@@ -1258,8 +1303,8 @@ export class GerberViewer {
     const aspect = this.canvas.width / this.canvas.height;
     const correctedX = aspect > 1.0 ? mouseXNDC * aspect : mouseXNDC;
     const correctedY = aspect > 1.0 ? mouseYNDC : mouseYNDC / aspect;
-    const worldX = (correctedX - this.camera.offsetX) / this.camera.zoom;
-    const worldY = (correctedY - this.camera.offsetY) / this.camera.zoom;
+    const worldX = (correctedX - this.camera.offsetX) / this.getViewScaleX();
+    const worldY = (correctedY - this.camera.offsetY) / this.getViewScaleY();
     return { x: worldX, y: worldY };
   }
 
@@ -1270,8 +1315,8 @@ export class GerberViewer {
     }
 
     const aspect = this.canvas.width / this.canvas.height;
-    const correctedX = point.x * this.camera.zoom + this.camera.offsetX;
-    const correctedY = point.y * this.camera.zoom + this.camera.offsetY;
+    const correctedX = point.x * this.getViewScaleX() + this.camera.offsetX;
+    const correctedY = point.y * this.getViewScaleY() + this.camera.offsetY;
     const ndcX = aspect > 1.0 ? correctedX / aspect : correctedX;
     const ndcY = aspect > 1.0 ? correctedY : correctedY * aspect;
     return {

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -392,8 +392,9 @@ impl Renderer {
     }
 
     /// Update camera state
-    fn update_camera(&mut self, zoom: f32, offset_x: f32, offset_y: f32) {
-        self.camera.zoom = zoom;
+    fn update_camera(&mut self, zoom_x: f32, zoom_y: f32, offset_x: f32, offset_y: f32) {
+        self.camera.zoom_x = zoom_x;
+        self.camera.zoom_y = zoom_y;
         self.camera.offset_x = offset_x;
         self.camera.offset_y = offset_y;
     }
@@ -964,13 +965,13 @@ impl Renderer {
         active_layer_ids: &[u32],
         color_data: &[f32],
         zoom_x: f32,
-        _zoom_y: f32,
+        zoom_y: f32,
         offset_x: f32,
         offset_y: f32,
         alpha: f32,
     ) -> Result<(), JsValue> {
         // Update camera state
-        self.update_camera(zoom_x, offset_x, offset_y);
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
 
         // Get canvas dimensions
         let (width, height) = self.get_canvas_size()?;

--- a/wasm/src/renderer/camera.rs
+++ b/wasm/src/renderer/camera.rs
@@ -1,6 +1,7 @@
 /// Camera transformation for viewport control
 pub struct Camera {
-    pub zoom: f32,
+    pub zoom_x: f32,
+    pub zoom_y: f32,
     pub offset_x: f32,
     pub offset_y: f32,
 }
@@ -9,7 +10,8 @@ impl Camera {
     /// Create a new camera with default settings
     pub fn new() -> Camera {
         Camera {
-            zoom: 2.0,
+            zoom_x: 2.0,
+            zoom_y: 2.0,
             offset_x: 0.0,
             offset_y: 0.0,
         }
@@ -27,9 +29,9 @@ impl Camera {
         let aspect = canvas_width as f32 / canvas_height as f32;
 
         let (scale_x, scale_y) = if aspect > 1.0 {
-            (self.zoom / aspect, self.zoom)
+            (self.zoom_x / aspect, self.zoom_y)
         } else {
-            (self.zoom, self.zoom * aspect)
+            (self.zoom_x, self.zoom_y * aspect)
         };
 
         let (offset_x, offset_y) = if aspect > 1.0 {
@@ -47,5 +49,27 @@ impl Camera {
 impl Default for Camera {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Camera;
+
+    #[test]
+    fn transform_matrix_preserves_signed_axis_zoom() {
+        let camera = Camera {
+            zoom_x: -4.0,
+            zoom_y: 3.0,
+            offset_x: 1.0,
+            offset_y: -2.0,
+        };
+
+        let transform = camera.get_transform_matrix(200, 100);
+
+        assert_eq!(transform[0], -2.0);
+        assert_eq!(transform[4], 3.0);
+        assert_eq!(transform[6], 0.5);
+        assert_eq!(transform[7], -2.0);
     }
 }


### PR DESCRIPTION
## Summary
- Move viewer notifications and mobile drawer behavior into a bottom-oriented, responsive layout
- Add view flip controls and keep ruler/camera coordinate transforms aligned with flipped rendering
- Refine toolbar spacing, drawer resizing, mobile collapsed controls, and ruler label contrast

## Validation
- `node --check js/main.js`
- `git diff --check`
- `cargo test --manifest-path wasm/Cargo.toml`
- `wasm-pack build --target web --out-dir pkg --release`