### PR TITLE
Refine layer panel empty state

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -95,8 +95,6 @@ button {
 }
 
 #workspace-status,
-.file-note span,
-.info-grid span,
 .alpha-control span {
   display: block;
   color: var(--muted);
@@ -348,6 +346,13 @@ button {
   font-size: 18px;
 }
 
+.empty-state-note {
+  margin-top: -8px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
 .empty-state-icon {
   width: 56px;
   height: 56px;
@@ -488,14 +493,14 @@ button {
 }
 
 .panel-tabs {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  display: flex;
   gap: 6px;
   padding: 10px;
   border-bottom: 1px solid var(--line);
 }
 
 .panel-tab {
+  flex: 1 1 0;
   min-width: 0;
   height: 48px;
   display: grid;
@@ -587,7 +592,6 @@ button {
 }
 
 .layer-list,
-.file-list,
 .diagnostic-list {
   list-style: none;
   margin: 0;
@@ -686,8 +690,7 @@ button {
   user-select: none;
 }
 
-.layer-label strong,
-.file-list strong {
+.layer-label strong {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -697,7 +700,6 @@ button {
 }
 
 .layer-label span,
-.file-list span,
 .diagnostic-list span {
   color: var(--muted);
   font-size: 11px;
@@ -708,46 +710,24 @@ button {
   color: #fecaca;
 }
 
-.info-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.info-grid > div,
-.file-note,
 .filter-form,
 .notification,
-.file-list li,
 .diagnostic-list li {
   border: 1px solid var(--line);
   border-radius: 7px;
   background: var(--surface-2);
 }
 
-.info-grid > div,
-.file-note,
 .filter-form {
   padding: 12px;
 }
 
-.info-grid strong,
-.file-note strong {
-  display: block;
-  margin-top: 5px;
-  color: var(--text);
-  font-size: 18px;
-  line-height: 1;
-}
-
-.file-list,
 .diagnostic-list {
   display: flex;
   flex-direction: column;
   gap: 7px;
 }
 
-.file-list li,
 .diagnostic-list li {
   display: grid;
   gap: 3px;
@@ -937,12 +917,6 @@ button {
     padding: 5px 10px;
   }
 
-  .info-grid {
-    gap: 6px;
-  }
-
-  .info-grid > div,
-  .file-note,
   .filter-form {
     padding: 8px;
   }
@@ -1039,7 +1013,6 @@ button {
   }
 
   .panel-tabs {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
     padding: 8px;
   }
 

--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
           <div class="empty-state" id="empty-state">
             <div class="empty-state-icon"><i data-lucide="layers-3"></i></div>
             <strong>No Layers Loaded</strong>
+            <span class="empty-state-note" id="empty-file-size-limit"></span>
             <button type="button" class="tool-button primary" id="empty-upload-btn">
               <i data-lucide="folder-open"></i>
               <span>Open Files</span>
@@ -178,10 +179,6 @@
             <button type="button" class="panel-tab active" data-panel-tab="layers">
               <i data-lucide="layers"></i>
               <span>Layers</span>
-            </button>
-            <button type="button" class="panel-tab" data-panel-tab="files">
-              <i data-lucide="files"></i>
-              <span>Files</span>
             </button>
             <button type="button" class="panel-tab" data-panel-tab="filter">
               <i data-lucide="list-filter"></i>
@@ -230,24 +227,6 @@
               <div class="layer-list-scroll">
                 <ul class="layer-list" id="layer-list"></ul>
               </div>
-            </section>
-
-            <section class="panel-section" data-panel="files">
-              <div class="info-grid">
-                <div>
-                  <span>Loaded</span>
-                  <strong id="loaded-file-count">0</strong>
-                </div>
-                <div>
-                  <span>Visible</span>
-                  <strong id="visible-file-count">0</strong>
-                </div>
-              </div>
-              <div class="file-note">
-                <span>Max file size</span>
-                <strong>300 MB</strong>
-              </div>
-              <ol class="file-list" id="file-list"></ol>
             </section>
 
             <section class="panel-section" data-panel="filter">

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,5 @@
 const NOTIFICATION_DURATION_MS = 2000;
+const MAX_FILE_SIZE_BYTES = 300 * 1024 * 1024;
 
 export class GerberViewer {
   constructor() {
@@ -28,7 +29,6 @@ export class GerberViewer {
     this.alphaSlider = document.getElementById("alpha-slider");
     this.alphaValue = document.getElementById("alpha-value");
     this.layerList = document.getElementById("layer-list");
-    this.fileList = document.getElementById("file-list");
     this.diagnosticList = document.getElementById("diagnostic-list");
     this.notification = document.getElementById("file-size-warning");
     this.notificationTitle = document.getElementById("warning-title");
@@ -38,14 +38,13 @@ export class GerberViewer {
     );
     this.workspaceStatus = document.getElementById("workspace-status");
     this.emptyState = document.getElementById("empty-state");
+    this.emptyFileSizeLimit = document.getElementById("empty-file-size-limit");
     this.dropOverlay = document.getElementById("drop-overlay");
     this.measurementOverlay = document.getElementById("measurement-overlay");
     this.visibleLayerCount = document.getElementById("visible-layer-count");
     this.zoomReadout = document.getElementById("zoom-readout");
     this.cursorReadout = document.getElementById("cursor-readout");
     this.boundsReadout = document.getElementById("bounds-readout");
-    this.loadedFileCount = document.getElementById("loaded-file-count");
-    this.visibleFileCount = document.getElementById("visible-file-count");
     this.diagnosticsCount = document.getElementById("diagnostics-count");
     this.frontFilterInput = document.getElementById("front-filter-input");
     this.backFilterInput = document.getElementById("back-filter-input");
@@ -155,6 +154,7 @@ export class GerberViewer {
     this.setupEventListeners();
 
     // Initial render
+    this.updateEmptyStateHint();
     this.refreshIcons();
     this.syncFilterInputs();
     this.updateUiState();
@@ -429,13 +429,10 @@ export class GerberViewer {
         ? "Ready"
         : `${visibleLayers} visible / ${totalLayers} loaded`;
     this.visibleLayerCount.textContent = `${visibleLayers} / ${totalLayers}`;
-    this.loadedFileCount.textContent = String(totalLayers);
-    this.visibleFileCount.textContent = String(visibleLayers);
     this.diagnosticsCount.textContent = String(this.diagnostics.length);
     this.emptyState.classList.toggle("is-hidden", totalLayers > 0);
     this.zoomReadout.textContent = this.formatZoom();
     this.boundsReadout.textContent = this.formatCombinedBounds();
-    this.renderFileList();
     this.renderDiagnostics();
     this.refreshIcons();
   }
@@ -519,31 +516,6 @@ export class GerberViewer {
       item.append(title, detail);
       this.diagnosticList.appendChild(item);
     }
-  }
-
-  renderFileList() {
-    this.fileList.replaceChildren();
-
-    if (this.layers.length === 0) {
-      const item = document.createElement("li");
-      const title = document.createElement("strong");
-      const detail = document.createElement("span");
-      title.textContent = "No files";
-      detail.textContent = "Ready";
-      item.append(title, detail);
-      this.fileList.appendChild(item);
-      return;
-    }
-
-    this.layers.forEach((layer, index) => {
-      const item = document.createElement("li");
-      const title = document.createElement("strong");
-      const detail = document.createElement("span");
-      title.textContent = layer.name;
-      detail.textContent = `#${index + 1} · ${layer.visible ? "visible" : "hidden"}`;
-      item.append(title, detail);
-      this.fileList.appendChild(item);
-    });
   }
 
   setActivePanel(panelName) {
@@ -795,8 +767,12 @@ export class GerberViewer {
     this.refreshIcons();
   }
 
+  updateEmptyStateHint() {
+    this.emptyFileSizeLimit.textContent =
+      `Max ${this.formatFileSize(MAX_FILE_SIZE_BYTES)} per file`;
+  }
+
   async handleFileUpload(files) {
-    const MAX_FILE_SIZE = 300 * 1024 * 1024; // 300 MB
     const oversizedFiles = [];
     const validFiles = [];
 
@@ -804,11 +780,11 @@ export class GerberViewer {
 
     // Validate file sizes
     for (const file of files) {
-      if (file.size > MAX_FILE_SIZE) {
+      if (file.size > MAX_FILE_SIZE_BYTES) {
         oversizedFiles.push({
           name: file.name,
           size: this.formatFileSize(file.size),
-          limit: this.formatFileSize(MAX_FILE_SIZE),
+          limit: this.formatFileSize(MAX_FILE_SIZE_BYTES),
         });
       } else {
         validFiles.push(file);
@@ -827,9 +803,16 @@ export class GerberViewer {
           const content = await file.text();
           await this.addLayer(file.name, content);
         } catch (error) {
+          const message = this.getErrorMessage(error);
+          if (this.isNoGeometryError(message)) {
+            console.warn(`Skipped file ${file.name}:`, error);
+            this.addDiagnostic("warning", file.name, message);
+            return;
+          }
+
           console.error(`Failed to load file ${file.name}:`, error);
-          this.addDiagnostic("error", file.name, error.message);
-          this.showError(`Failed to load file ${file.name}: ${error.message}`);
+          this.addDiagnostic("error", file.name, message);
+          this.showError(`Failed to load file ${file.name}: ${message}`);
         }
       });
 
@@ -891,6 +874,18 @@ export class GerberViewer {
         messageElement.textContent = message;
       },
     );
+  }
+
+  getErrorMessage(error) {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return String(error);
+  }
+
+  isNoGeometryError(message) {
+    return message.toLowerCase().includes("no geometry found");
   }
 
   showNotification(title, variant, duration, renderMessage) {


### PR DESCRIPTION
## Summary
- Remove the unused Files tab and its supporting UI state
- Show the configured max file size in the empty viewer state
- Treat no-geometry files as warnings without showing an error toast
- Fix panel tabs to flex evenly after removing the Files tab

## Test
- node --check js/main.js