### PR TITLE
Add remote demo archive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,34 @@ WASM/WebGL2-based Gerber file viewer for PCB visualization.
 
 [Website](https://wasm-gerber-viewer.vercel.app/)
 
+## Samples
+
+These sample links open remote Gerber zip archives with the viewer's `?url=`
+query parameter. The archives are loaded from their upstream sources and are not
+bundled in this repository.
+
+### Sample 1
+
+[Open KLP-5e ESP32 Sensor Board](https://wasm-gerber-viewer.vercel.app/?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffutureshocked%2FKLP-5e-ESP32-sensor-board%2Fmain%2FKiCad%2520project%2Fdfm%2Fgerber.zip)
+
+Source:
+
+- Project: [KLP-5e ESP32 Sensor Board](https://github.com/futureshocked/KLP-5e-ESP32-sensor-board)
+- Copyright: Copyright (c) 2025, Peter Dalmaris
+- License: CERN-OHL-S v2.0
+- Archive: <https://raw.githubusercontent.com/futureshocked/KLP-5e-ESP32-sensor-board/main/KiCad%20project/dfm/gerber.zip>
+
+### Sample 2
+
+[Open Xassette-Asterisk](https://wasm-gerber-viewer.vercel.app/?url=https%3A%2F%2Fprocessor-cdn.kitspace.org%2Fv6%2FSdtElectronics%2FXassette-Asterisk%2F6ccd88501c99e2339571de744d003d571be47fad%2F_%2FXassette-Asterisk-6ccd885-gerbers.zip)
+
+Source:
+
+- Project: [Xassette-Asterisk](https://github.com/SdtElectronics/Xassette-Asterisk)
+- Copyright: SdtElectronics
+- License: CERN-OHL-W v2.0
+- Archive: <https://processor-cdn.kitspace.org/v6/SdtElectronics/Xassette-Asterisk/6ccd88501c99e2339571de744d003d571be47fad/_/Xassette-Asterisk-6ccd885-gerbers.zip>
+
 ## Features
 
 - High-performance rendering for large Gerber files (>10 MB)
@@ -78,18 +106,6 @@ The following Gerber commands are not implemented yet:
 
 - **%AB** - Aperture Block definitions
 - **%LR** - Layer Rotation transformations
-
-## Source
-
-The Demo button loads Gerber files from the
-[KLP-5e ESP32 Sensor Board](https://github.com/futureshocked/KLP-5e-ESP32-sensor-board)
-project.
-
-- Copyright: Copyright (c) 2025, Peter Dalmaris
-- License: CERN-OHL-S v2.0
-- Source archive:
-  <https://raw.githubusercontent.com/futureshocked/KLP-5e-ESP32-sensor-board/main/KiCad%20project/dfm/gerber.zip>
-- The demo archive is loaded from the upstream repository and is not bundled in this repository.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ The following Gerber commands are not implemented yet:
 - **%AB** - Aperture Block definitions
 - **%LR** - Layer Rotation transformations
 
+## Source
+
+The Demo button loads Gerber files from the
+[KLP-5e ESP32 Sensor Board](https://github.com/futureshocked/KLP-5e-ESP32-sensor-board)
+project.
+
+- Copyright: Copyright (c) 2025, Peter Dalmaris
+- License: CERN-OHL-S v2.0
+- Source archive:
+  <https://raw.githubusercontent.com/futureshocked/KLP-5e-ESP32-sensor-board/main/KiCad%20project/dfm/gerber.zip>
+- The demo archive is loaded from the upstream repository and is not bundled in this repository.
+
 ## License
 
 [MIT License](LICENSE)

--- a/css/style.css
+++ b/css/style.css
@@ -15,6 +15,8 @@
   --warning: #facc15;
   --panel-width: 381px;
   --panel-height: 420px;
+  --panel-overlay-width: var(--panel-width);
+  --panel-overlay-height: var(--panel-height);
   --panel-collapsed-height: 95px;
   --toolbar-height: 58px;
   --status-height: 34px;
@@ -341,6 +343,14 @@ button {
   pointer-events: auto;
 }
 
+.empty-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  pointer-events: auto;
+}
+
 .empty-state strong {
   color: var(--text);
   font-size: 18px;
@@ -440,7 +450,7 @@ button {
 
 .workspace:has(.side-panel:not(.collapsed)) .empty-state,
 .workspace:has(.side-panel:not(.collapsed)) .canvas-status {
-  right: var(--panel-width);
+  right: var(--panel-overlay-width);
 }
 
 .side-panel {
@@ -560,6 +570,14 @@ button {
 .layer-panel-controls {
   display: grid;
   gap: 12px;
+  flex: 0 0 auto;
+}
+
+.diagnostic-toolbar {
+  justify-content: flex-end;
+}
+
+.diagnostic-toolbar .chip-button {
   flex: 0 0 auto;
 }
 
@@ -868,12 +886,12 @@ button {
 
   .workspace:has(.side-panel:not(.collapsed)) .empty-state {
     right: 0;
-    bottom: var(--panel-height);
+    bottom: var(--panel-overlay-height);
   }
 
   .workspace:has(.side-panel:not(.collapsed)) .canvas-status {
     right: 0;
-    bottom: var(--panel-height);
+    bottom: var(--panel-overlay-height);
   }
 
   .side-panel {

--- a/css/style.css
+++ b/css/style.css
@@ -343,14 +343,6 @@ button {
   pointer-events: auto;
 }
 
-.empty-state-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 8px;
-  pointer-events: auto;
-}
-
 .empty-state strong {
   color: var(--text);
   font-size: 18px;

--- a/index.html
+++ b/index.html
@@ -144,16 +144,10 @@
             <div class="empty-state-icon"><i data-lucide="layers-3"></i></div>
             <strong>No Layers Loaded</strong>
             <span class="empty-state-note" id="empty-file-size-limit"></span>
-            <div class="empty-state-actions">
-              <button type="button" class="tool-button primary" id="empty-upload-btn">
-                <i data-lucide="folder-open"></i>
-                <span>Open Files</span>
-              </button>
-              <button type="button" class="tool-button" id="empty-demo-btn">
-                <i data-lucide="circuit-board"></i>
-                <span>Demo</span>
-              </button>
-            </div>
+            <button type="button" class="tool-button primary" id="empty-upload-btn">
+              <i data-lucide="folder-open"></i>
+              <span>Open Files</span>
+            </button>
           </div>
 
           <div class="drop-overlay" id="drop-overlay">

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             type="file"
             id="file-input"
             multiple
-            accept="text/*,.gdo,.gbr,.ger,.art,.gtl,.gbl,.gts,.gbs,.gto,.gbo,.gtp,.gbp,.cmp,.drd,.gko,.plc,.sol,.stc,.sts"
+            accept="text/*,application/zip,application/x-zip-compressed,.zip,.gdo,.gbr,.ger,.art,.gtl,.gbl,.gts,.gbs,.gto,.gbo,.gtp,.gbp,.cmp,.drd,.gko,.plc,.sol,.stc,.sts"
           />
           <button
             type="button"
@@ -144,10 +144,16 @@
             <div class="empty-state-icon"><i data-lucide="layers-3"></i></div>
             <strong>No Layers Loaded</strong>
             <span class="empty-state-note" id="empty-file-size-limit"></span>
-            <button type="button" class="tool-button primary" id="empty-upload-btn">
-              <i data-lucide="folder-open"></i>
-              <span>Open Files</span>
-            </button>
+            <div class="empty-state-actions">
+              <button type="button" class="tool-button primary" id="empty-upload-btn">
+                <i data-lucide="folder-open"></i>
+                <span>Open Files</span>
+              </button>
+              <button type="button" class="tool-button" id="empty-demo-btn">
+                <i data-lucide="circuit-board"></i>
+                <span>Demo</span>
+              </button>
+            </div>
           </div>
 
           <div class="drop-overlay" id="drop-overlay">
@@ -257,6 +263,12 @@
             </section>
 
             <section class="panel-section" data-panel="diagnostics">
+              <div class="section-toolbar diagnostic-toolbar">
+                <button class="chip-button danger" id="clear-diagnostics-btn" type="button">
+                  <i data-lucide="eraser"></i>
+                  <span>Clear</span>
+                </button>
+              </div>
               <ul class="diagnostic-list" id="diagnostic-list"></ul>
             </section>
 
@@ -286,6 +298,7 @@
     </div>
 
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
     <script type="module">
       import { GerberViewer } from "./js/main.js";
 

--- a/index.html
+++ b/index.html
@@ -205,13 +205,13 @@
                     <i data-lucide="check-check"></i>
                     <span>All</span>
                   </button>
-                  <button class="chip-button" id="select-front-btn" type="button">
+                  <button class="chip-button" id="select-top-btn" type="button">
                     <i data-lucide="panel-top"></i>
-                    <span>Front</span>
+                    <span>Top</span>
                   </button>
-                  <button class="chip-button" id="select-back-btn" type="button">
+                  <button class="chip-button" id="select-bottom-btn" type="button">
                     <i data-lucide="panel-bottom"></i>
-                    <span>Back</span>
+                    <span>Bottom</span>
                   </button>
                   <button class="chip-button" id="unselect-all-btn" type="button">
                     <i data-lucide="eye-off"></i>
@@ -237,27 +237,27 @@
 
             <section class="panel-section" data-panel="filter">
               <div class="filter-form">
-                <label class="filter-field" for="front-filter-input">
-                  <span>Front</span>
+                <label class="filter-field" for="top-filter-input">
+                  <span>Top</span>
                   <input
                     type="text"
-                    id="front-filter-input"
+                    id="top-filter-input"
                     autocomplete="off"
                     spellcheck="false"
                   />
                 </label>
-                <label class="filter-field" for="back-filter-input">
-                  <span>Back</span>
+                <label class="filter-field" for="bottom-filter-input">
+                  <span>Bottom</span>
                   <input
                     type="text"
-                    id="back-filter-input"
+                    id="bottom-filter-input"
                     autocomplete="off"
                     spellcheck="false"
                   />
                 </label>
                 <p class="filter-note">
                   <span>Use comma or space separated text. Prefix with # for case-sensitive matching.</span>
-                  <span>Example: front #BACK</span>
+                  <span>Example: top #BOT</span>
                 </p>
               </div>
             </section>

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,33 @@
 const NOTIFICATION_DURATION_MS = 2000;
 const MAX_FILE_SIZE_BYTES = 300 * 1024 * 1024;
+const DEMO_ARCHIVE_NAME = "ucamco-librepcb-sample-2.zip";
+const DEMO_ARCHIVE_PATH =
+  "https://raw.githubusercontent.com/futureshocked/KLP-5e-ESP32-sensor-board/main/KiCad%20project/dfm/gerber.zip";
+const ZIP_MIME_TYPES = new Set([
+  "application/zip",
+  "application/x-zip-compressed",
+]);
+const GERBER_FILE_EXTENSIONS = new Set([
+  ".art",
+  ".cmp",
+  ".drd",
+  ".gbl",
+  ".gbo",
+  ".gbr",
+  ".gbs",
+  ".gbp",
+  ".gdo",
+  ".ger",
+  ".gko",
+  ".gtl",
+  ".gto",
+  ".gtp",
+  ".gts",
+  ".plc",
+  ".sol",
+  ".stc",
+  ".sts",
+]);
 
 export class GerberViewer {
   constructor() {
@@ -26,6 +54,7 @@ export class GerberViewer {
     this.selectBackBtn = document.getElementById("select-back-btn");
     this.unselectAllBtn = document.getElementById("unselect-all-btn");
     this.clearAllBtn = document.getElementById("clear-all-btn");
+    this.clearDiagnosticsBtn = document.getElementById("clear-diagnostics-btn");
     this.alphaSlider = document.getElementById("alpha-slider");
     this.alphaValue = document.getElementById("alpha-value");
     this.layerList = document.getElementById("layer-list");
@@ -39,6 +68,7 @@ export class GerberViewer {
     this.workspaceStatus = document.getElementById("workspace-status");
     this.emptyState = document.getElementById("empty-state");
     this.emptyFileSizeLimit = document.getElementById("empty-file-size-limit");
+    this.emptyDemoBtn = document.getElementById("empty-demo-btn");
     this.dropOverlay = document.getElementById("drop-overlay");
     this.measurementOverlay = document.getElementById("measurement-overlay");
     this.visibleLayerCount = document.getElementById("visible-layer-count");
@@ -195,6 +225,10 @@ export class GerberViewer {
       this.fileInput.click();
     });
 
+    this.emptyDemoBtn.addEventListener("click", () => {
+      this.loadDemoArchive();
+    });
+
     this.fileInput.addEventListener("change", (e) => {
       if (e.target.files.length > 0) {
         this.handleFileUpload(e.target.files);
@@ -262,6 +296,10 @@ export class GerberViewer {
 
     this.clearAllBtn.addEventListener("click", () => {
       this.clearAllLayers();
+    });
+
+    this.clearDiagnosticsBtn.addEventListener("click", () => {
+      this.clearDiagnostics();
     });
 
     // Alpha slider
@@ -483,6 +521,10 @@ export class GerberViewer {
   }
 
   addDiagnostic(level, title, detail = "") {
+    if (level === "info") {
+      return;
+    }
+
     this.diagnostics.unshift({
       level,
       title,
@@ -516,6 +558,11 @@ export class GerberViewer {
       item.append(title, detail);
       this.diagnosticList.appendChild(item);
     }
+  }
+
+  clearDiagnostics() {
+    this.diagnostics = [];
+    this.updateUiState();
   }
 
   setActivePanel(panelName) {
@@ -772,6 +819,45 @@ export class GerberViewer {
       `Max ${this.formatFileSize(MAX_FILE_SIZE_BYTES)} per file`;
   }
 
+  async loadDemoArchive() {
+    if (this.layers.length > 0 || this.emptyDemoBtn.disabled) {
+      return;
+    }
+
+    this.emptyDemoBtn.disabled = true;
+    this.setWorkspaceStatus("Loading demo");
+
+    try {
+      const response = await fetch(DEMO_ARCHIVE_PATH);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} while loading ${DEMO_ARCHIVE_PATH}`);
+      }
+
+      const demoArchive = new File([await response.blob()], DEMO_ARCHIVE_NAME, {
+        type: "application/zip",
+      });
+      const layerSources = await this.collectZipLayerSources(demoArchive);
+      const results = await Promise.all(
+        layerSources.map((source) =>
+          this.loadLayerSource(source.name, source.readText),
+        ),
+      );
+      const loadedCount = results.filter(Boolean).length;
+
+      if (loadedCount > 0) {
+        this.renderLayerList();
+        this.render();
+        this.fitView();
+        this.addDiagnostic("info", "Demo loaded", `${loadedCount} processed`);
+      }
+    } catch (error) {
+      this.handleLayerLoadError(DEMO_ARCHIVE_NAME, error);
+    } finally {
+      this.emptyDemoBtn.disabled = false;
+      this.updateUiState();
+    }
+  }
+
   async handleFileUpload(files) {
     const oversizedFiles = [];
     const validFiles = [];
@@ -796,39 +882,143 @@ export class GerberViewer {
       this.showFileSizeWarning(oversizedFiles);
     }
 
-    // Process valid files in parallel
     if (validFiles.length > 0) {
-      const promises = validFiles.map(async (file) => {
-        try {
-          const content = await file.text();
-          await this.addLayer(file.name, content);
-        } catch (error) {
-          const message = this.getErrorMessage(error);
-          if (this.isNoGeometryError(message)) {
-            console.warn(`Skipped file ${file.name}:`, error);
-            this.addDiagnostic("warning", file.name, message);
-            return;
-          }
+      const layerSources = await this.collectLayerSources(validFiles);
 
-          console.error(`Failed to load file ${file.name}:`, error);
-          this.addDiagnostic("error", file.name, message);
-          this.showError(`Failed to load file ${file.name}: ${message}`);
+      if (layerSources.length > 0) {
+        const results = await Promise.all(
+          layerSources.map((source) =>
+            this.loadLayerSource(source.name, source.readText),
+          ),
+        );
+        const loadedCount = results.filter(Boolean).length;
+
+        if (loadedCount > 0) {
+          this.renderLayerList();
+          this.render();
+          this.fitView();
+          this.addDiagnostic("info", "Files loaded", `${loadedCount} processed`);
         }
-      });
-
-      await Promise.all(promises);
-
-      // Render once after all layers are added
-      this.renderLayerList();
-      this.render();
-      this.fitView();
-      this.addDiagnostic("info", "Files loaded", `${validFiles.length} processed`);
+      }
     }
 
     this.updateUiState();
 
     // Clear file input
     this.fileInput.value = "";
+  }
+
+  async collectLayerSources(files) {
+    const layerSources = [];
+
+    for (const file of files) {
+      if (this.isZipFile(file)) {
+        layerSources.push(...(await this.collectZipLayerSources(file)));
+        continue;
+      }
+
+      layerSources.push({
+        name: file.name,
+        readText: () => file.text(),
+      });
+    }
+
+    return layerSources;
+  }
+
+  async collectZipLayerSources(file) {
+    if (!window.JSZip) {
+      this.handleLayerLoadError(file.name, new Error("ZIP support failed to load"));
+      return [];
+    }
+
+    try {
+      const zip = await window.JSZip.loadAsync(file);
+      const entries = Object.values(zip.files)
+        .filter(
+          (entry) =>
+            !entry.dir &&
+            !this.isArchiveMetadataPath(entry.name) &&
+            this.isSupportedGerberPath(entry.name),
+        )
+        .sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, {
+            numeric: true,
+            sensitivity: "base",
+          }),
+        );
+
+      if (entries.length === 0) {
+        this.addDiagnostic(
+          "warning",
+          file.name,
+          "No supported Gerber files found in archive",
+        );
+        return [];
+      }
+
+      this.addDiagnostic(
+        "info",
+        file.name,
+        `${entries.length} Gerber files found in archive`,
+      );
+
+      return entries.map((entry) => ({
+        name: `${file.name}/${entry.name}`,
+        readText: () => entry.async("string"),
+      }));
+    } catch (error) {
+      this.handleLayerLoadError(file.name, error);
+      return [];
+    }
+  }
+
+  async loadLayerSource(name, readText) {
+    try {
+      const content = await readText();
+      await this.addLayer(name, content);
+      return true;
+    } catch (error) {
+      this.handleLayerLoadError(name, error);
+      return false;
+    }
+  }
+
+  handleLayerLoadError(name, error) {
+    const message = this.getErrorMessage(error);
+    if (this.isNoGeometryError(message)) {
+      console.warn(`Skipped file ${name}:`, error);
+      this.addDiagnostic("warning", name, message);
+      return;
+    }
+
+    console.error(`Failed to load file ${name}:`, error);
+    this.addDiagnostic("error", name, message);
+    this.showError(`Failed to load file ${name}: ${message}`);
+  }
+
+  isZipFile(file) {
+    return this.getFileExtension(file.name) === ".zip" || ZIP_MIME_TYPES.has(file.type);
+  }
+
+  isSupportedGerberPath(path) {
+    return GERBER_FILE_EXTENSIONS.has(this.getFileExtension(path));
+  }
+
+  isArchiveMetadataPath(path) {
+    const normalizedPath = path.replaceAll("\\", "/");
+    const fileName = normalizedPath.split("/").pop() ?? normalizedPath;
+    return normalizedPath.startsWith("__MACOSX/") || fileName.startsWith("._");
+  }
+
+  getFileExtension(path) {
+    const fileName = path.split(/[\\/]/).pop() ?? path;
+    const dotIndex = fileName.lastIndexOf(".");
+    if (dotIndex <= 0) {
+      return "";
+    }
+
+    return fileName.slice(dotIndex).toLowerCase();
   }
 
   formatFileSize(bytes) {
@@ -1904,6 +2094,7 @@ export class GerberViewer {
 
   setDrawerWidth(width, { commitLayout = true } = {}) {
     const clampedWidth = this.clampDrawerWidth(width);
+    this.dropZone.style.setProperty("--panel-overlay-width", `${clampedWidth}px`);
     if (commitLayout) {
       this.drawerCurrentWidth = clampedWidth;
       this.drawerPendingWidth = null;
@@ -1936,6 +2127,7 @@ export class GerberViewer {
 
   setDrawerHeight(height, { commitLayout = true } = {}) {
     const clampedHeight = this.clampDrawerHeight(height);
+    this.dropZone.style.setProperty("--panel-overlay-height", `${clampedHeight}px`);
     if (commitLayout) {
       this.drawerCurrentHeight = clampedHeight;
       this.drawerPendingHeight = null;

--- a/js/main.js
+++ b/js/main.js
@@ -50,8 +50,8 @@ export class GerberViewer {
     this.measurementUnitToggle = document.getElementById("measurement-unit-toggle");
     this.fullscreenBtn = document.getElementById("fullscreen-btn");
     this.selectAllBtn = document.getElementById("select-all-btn");
-    this.selectFrontBtn = document.getElementById("select-front-btn");
-    this.selectBackBtn = document.getElementById("select-back-btn");
+    this.selectTopBtn = document.getElementById("select-top-btn");
+    this.selectBottomBtn = document.getElementById("select-bottom-btn");
     this.unselectAllBtn = document.getElementById("unselect-all-btn");
     this.clearAllBtn = document.getElementById("clear-all-btn");
     this.clearDiagnosticsBtn = document.getElementById("clear-diagnostics-btn");
@@ -76,8 +76,8 @@ export class GerberViewer {
     this.cursorReadout = document.getElementById("cursor-readout");
     this.boundsReadout = document.getElementById("bounds-readout");
     this.diagnosticsCount = document.getElementById("diagnostics-count");
-    this.frontFilterInput = document.getElementById("front-filter-input");
-    this.backFilterInput = document.getElementById("back-filter-input");
+    this.topFilterInput = document.getElementById("top-filter-input");
+    this.bottomFilterInput = document.getElementById("bottom-filter-input");
     this.panelTabs = Array.from(document.querySelectorAll("[data-panel-tab]"));
     this.panelSections = Array.from(document.querySelectorAll("[data-panel]"));
 
@@ -282,12 +282,12 @@ export class GerberViewer {
       this.selectAllLayerCheckboxes();
     });
 
-    this.selectFrontBtn.addEventListener("click", () => {
-      this.selectLayersByFilter("front");
+    this.selectTopBtn.addEventListener("click", () => {
+      this.selectLayersByFilter("top");
     });
 
-    this.selectBackBtn.addEventListener("click", () => {
-      this.selectLayersByFilter("back");
+    this.selectBottomBtn.addEventListener("click", () => {
+      this.selectLayersByFilter("bottom");
     });
 
     this.unselectAllBtn.addEventListener("click", () => {
@@ -309,12 +309,12 @@ export class GerberViewer {
       this.updateGlobalAlpha(alpha);
     });
 
-    this.frontFilterInput.addEventListener("input", () => {
-      this.updateLayerFilter("front", this.frontFilterInput.value);
+    this.topFilterInput.addEventListener("input", () => {
+      this.updateLayerFilter("top", this.topFilterInput.value);
     });
 
-    this.backFilterInput.addEventListener("input", () => {
-      this.updateLayerFilter("back", this.backFilterInput.value);
+    this.bottomFilterInput.addEventListener("input", () => {
+      this.updateLayerFilter("bottom", this.bottomFilterInput.value);
     });
 
     this.notificationCloseBtn.addEventListener("click", () => {
@@ -403,8 +403,8 @@ export class GerberViewer {
 
   loadLayerFilters() {
     const defaults = {
-      front: "front top .gtl .gto .gts .gtp #TOP",
-      back: "back bottom .gbl .gbo .gbs .gbp #BOT",
+      top: "top .gtl .gto .gts .gtp #TOP",
+      bottom: "bottom .gbl .gbo .gbs .gbp #BOT",
     };
 
     try {
@@ -412,8 +412,18 @@ export class GerberViewer {
         window.localStorage.getItem(this.layerFilterStorageKey) || "{}",
       );
       return {
-        front: typeof stored.front === "string" ? stored.front : defaults.front,
-        back: typeof stored.back === "string" ? stored.back : defaults.back,
+        top:
+          typeof stored.top === "string"
+            ? stored.top
+            : typeof stored.front === "string"
+              ? stored.front
+              : defaults.top,
+        bottom:
+          typeof stored.bottom === "string"
+            ? stored.bottom
+            : typeof stored.back === "string"
+              ? stored.back
+              : defaults.bottom,
       };
     } catch {
       return defaults;
@@ -428,8 +438,8 @@ export class GerberViewer {
   }
 
   syncFilterInputs() {
-    this.frontFilterInput.value = this.layerFilters.front;
-    this.backFilterInput.value = this.layerFilters.back;
+    this.topFilterInput.value = this.layerFilters.top;
+    this.bottomFilterInput.value = this.layerFilters.bottom;
   }
 
   updateLayerFilter(kind, value) {
@@ -964,7 +974,7 @@ export class GerberViewer {
       );
 
       return entries.map((entry) => ({
-        name: `${file.name}/${entry.name}`,
+        name: this.getBaseFileName(entry.name),
         readText: () => entry.async("string"),
       }));
     } catch (error) {
@@ -1012,13 +1022,17 @@ export class GerberViewer {
   }
 
   getFileExtension(path) {
-    const fileName = path.split(/[\\/]/).pop() ?? path;
+    const fileName = this.getBaseFileName(path);
     const dotIndex = fileName.lastIndexOf(".");
     if (dotIndex <= 0) {
       return "";
     }
 
     return fileName.slice(dotIndex).toLowerCase();
+  }
+
+  getBaseFileName(path) {
+    return path.split(/[\\/]/).pop() ?? path;
   }
 
   formatFileSize(bytes) {
@@ -1143,6 +1157,11 @@ export class GerberViewer {
       this.layers.push(layer);
       this.updateUiState();
     } catch (error) {
+      if (this.isNoGeometryError(this.getErrorMessage(error))) {
+        console.warn(`[Layer] Skipped layer ${name}:`, error);
+        throw error;
+      }
+
       console.error(`[Layer] Failed to add layer ${name}:`, error);
       throw error;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,5 @@
 const NOTIFICATION_DURATION_MS = 2000;
 const MAX_FILE_SIZE_BYTES = 300 * 1024 * 1024;
-const DEMO_ARCHIVE_NAME = "ucamco-librepcb-sample-2.zip";
-const DEMO_ARCHIVE_PATH =
-  "https://raw.githubusercontent.com/futureshocked/KLP-5e-ESP32-sensor-board/main/KiCad%20project/dfm/gerber.zip";
 const ZIP_MIME_TYPES = new Set([
   "application/zip",
   "application/x-zip-compressed",
@@ -68,7 +65,6 @@ export class GerberViewer {
     this.workspaceStatus = document.getElementById("workspace-status");
     this.emptyState = document.getElementById("empty-state");
     this.emptyFileSizeLimit = document.getElementById("empty-file-size-limit");
-    this.emptyDemoBtn = document.getElementById("empty-demo-btn");
     this.dropOverlay = document.getElementById("drop-overlay");
     this.measurementOverlay = document.getElementById("measurement-overlay");
     this.visibleLayerCount = document.getElementById("visible-layer-count");
@@ -192,6 +188,7 @@ export class GerberViewer {
     this.updateMeasurementUnitControl();
     this.updateViewFlipControls();
     this.render();
+    this.loadInitialUrlSource();
   }
 
   resizeCanvas() {
@@ -223,10 +220,6 @@ export class GerberViewer {
 
     this.emptyUploadBtn.addEventListener("click", () => {
       this.fileInput.click();
-    });
-
-    this.emptyDemoBtn.addEventListener("click", () => {
-      this.loadDemoArchive();
     });
 
     this.fileInput.addEventListener("change", (e) => {
@@ -829,43 +822,56 @@ export class GerberViewer {
       `Max ${this.formatFileSize(MAX_FILE_SIZE_BYTES)} per file`;
   }
 
-  async loadDemoArchive() {
-    if (this.layers.length > 0 || this.emptyDemoBtn.disabled) {
+  async loadInitialUrlSource() {
+    const sourceUrl = this.getInitialSourceUrl();
+    if (!sourceUrl) return;
+
+    try {
+      const url = new URL(sourceUrl);
+      await this.loadRemoteSource(url);
+    } catch (error) {
+      this.handleLayerLoadError(sourceUrl, error);
+    }
+  }
+
+  getInitialSourceUrl() {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("url") || params.get("source") || params.get("file");
+  }
+
+  async loadRemoteSource(url) {
+    this.setWorkspaceStatus("Loading remote file");
+    const response = await fetch(url.href);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} while loading ${url.href}`);
+    }
+
+    const fileName = this.getBaseFileName(decodeURIComponent(url.pathname));
+    const file = new File([await response.blob()], fileName, {
+      type: response.headers.get("content-type") || "",
+    });
+
+    const layerSources = await this.collectLayerSources([file]);
+    if (layerSources.length === 0) {
+      this.updateUiState();
       return;
     }
 
-    this.emptyDemoBtn.disabled = true;
-    this.setWorkspaceStatus("Loading demo");
+    const results = await Promise.all(
+      layerSources.map((source) =>
+        this.loadLayerSource(source.name, source.readText),
+      ),
+    );
+    const loadedCount = results.filter(Boolean).length;
 
-    try {
-      const response = await fetch(DEMO_ARCHIVE_PATH);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status} while loading ${DEMO_ARCHIVE_PATH}`);
-      }
-
-      const demoArchive = new File([await response.blob()], DEMO_ARCHIVE_NAME, {
-        type: "application/zip",
-      });
-      const layerSources = await this.collectZipLayerSources(demoArchive);
-      const results = await Promise.all(
-        layerSources.map((source) =>
-          this.loadLayerSource(source.name, source.readText),
-        ),
-      );
-      const loadedCount = results.filter(Boolean).length;
-
-      if (loadedCount > 0) {
-        this.renderLayerList();
-        this.render();
-        this.fitView();
-        this.addDiagnostic("info", "Demo loaded", `${loadedCount} processed`);
-      }
-    } catch (error) {
-      this.handleLayerLoadError(DEMO_ARCHIVE_NAME, error);
-    } finally {
-      this.emptyDemoBtn.disabled = false;
-      this.updateUiState();
+    if (loadedCount > 0) {
+      this.renderLayerList();
+      this.render();
+      this.fitView();
+      this.addDiagnostic("info", "Remote file loaded", `${loadedCount} processed`);
     }
+
+    this.updateUiState();
   }
 
   async handleFileUpload(files) {


### PR DESCRIPTION
## Summary
- Add ZIP upload support and load the Demo board from a CORS-enabled raw GitHub archive
- Add Demo attribution in README Source section under CERN-OHL-S v2.0
- Add diagnostics clear control and suppress info diagnostics
- Update layer terminology from front/back to top/bottom and show ZIP entries as file names only
- Keep canvas status and empty state responsive while resizing the drawer

## Test
- node --check js/main.js