### PR TITLE
Add snap resize drawer controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,7 +17,10 @@
   --panel-height: 420px;
   --panel-overlay-width: var(--panel-width);
   --panel-overlay-height: var(--panel-height);
-  --panel-collapsed-height: 95px;
+  --panel-collapsed-width: 76px;
+  --panel-collapsed-height: 102px;
+  --panel-snap-threshold: 50px;
+  --panel-bottom-collapse-threshold: 200px;
   --toolbar-height: 58px;
   --status-height: 34px;
   --radius: 8px;
@@ -445,6 +448,11 @@ button {
   right: var(--panel-overlay-width);
 }
 
+.workspace:has(.side-panel.collapsed) .empty-state,
+.workspace:has(.side-panel.collapsed) .canvas-status {
+  right: var(--panel-collapsed-width);
+}
+
 .side-panel {
   width: var(--panel-width);
   min-width: 0;
@@ -466,9 +474,8 @@ button {
 .side-panel.collapsed {
   min-width: 0;
   overflow: hidden;
-  pointer-events: none;
-  transform: translateX(100%);
-  border-left: 0;
+  pointer-events: auto;
+  transform: translateX(calc(100% - var(--panel-collapsed-width)));
 }
 
 .side-panel.resizing {
@@ -477,6 +484,89 @@ button {
 
 .side-panel.resizing {
   user-select: none;
+}
+
+.side-panel.collapsed .panel-tabs,
+.side-panel.collapsed .layer-list-scroll {
+  display: none;
+}
+
+.side-panel.collapsed .panel-section {
+  display: none;
+}
+
+.side-panel.collapsed .panel-content {
+  width: var(--panel-collapsed-width);
+}
+
+.side-panel.collapsed .panel-section[data-panel="layers"] {
+  display: flex;
+  padding: 10px;
+}
+
+.side-panel.collapsed .layer-panel-controls {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.side-panel.collapsed .section-toolbar {
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 7px;
+}
+
+.side-panel.collapsed .section-toolbar .chip-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 36px;
+  min-width: 0;
+  padding: 0;
+}
+
+.side-panel.collapsed .section-toolbar .chip-button:nth-child(n + 4) {
+  display: none;
+}
+
+.side-panel.collapsed .section-toolbar .chip-button span {
+  display: none;
+}
+
+.side-panel.collapsed .alpha-control {
+  width: 44px;
+  min-height: 168px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 8px 4px;
+}
+
+.side-panel.collapsed .alpha-control .field-row {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.side-panel.collapsed .alpha-control .field-row span {
+  display: none;
+}
+
+.side-panel.collapsed .alpha-control .field-row strong {
+  min-width: 0;
+  text-align: right;
+}
+
+.side-panel.collapsed #alpha-slider {
+  width: 20px;
+  height: 118px;
+  writing-mode: vertical-lr;
+  direction: rtl;
 }
 
 .resize-handle {
@@ -886,6 +976,12 @@ button {
     bottom: var(--panel-overlay-height);
   }
 
+  .workspace:has(.side-panel.collapsed) .empty-state,
+  .workspace:has(.side-panel.collapsed) .canvas-status {
+    right: 0;
+    bottom: var(--panel-collapsed-height);
+  }
+
   .side-panel {
     position: fixed;
     left: 0;
@@ -943,30 +1039,33 @@ button {
     border-top: 1px solid var(--line);
   }
 
-  .side-panel.collapsed .panel-tabs,
-  .side-panel.collapsed .layer-list-scroll {
-    display: none;
-  }
-
-  .side-panel.collapsed .panel-section {
-    display: none;
-  }
-
   .side-panel.collapsed .panel-section[data-panel="layers"] {
-    display: flex;
     padding: 8px 10px;
   }
 
+  .side-panel.collapsed .panel-content {
+    width: auto;
+  }
+
   .side-panel.collapsed .layer-panel-controls {
+    height: auto;
+    display: grid;
+    align-items: stretch;
     gap: 8px;
   }
 
-  .side-panel.collapsed .section-toolbar .chip-button {
-    display: inline-flex;
+  .side-panel.collapsed .section-toolbar {
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+    margin-top: 7px;
   }
 
-  .side-panel.collapsed .section-toolbar .chip-button:nth-child(n + 4) {
-    display: none;
+  .side-panel.collapsed .section-toolbar .chip-button {
+    flex: 1;
+    width: auto;
+    height: auto;
+    padding: 0 6px;
   }
 
   .side-panel.collapsed .section-toolbar .chip-button span {
@@ -974,6 +1073,9 @@ button {
   }
 
   .side-panel.collapsed .alpha-control {
+    width: auto;
+    min-height: 0;
+    display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     gap: 8px;
@@ -998,6 +1100,10 @@ button {
   .side-panel.collapsed #alpha-slider {
     grid-column: 1;
     grid-row: 1;
+    width: 100%;
+    height: auto;
+    writing-mode: horizontal-tb;
+    direction: ltr;
   }
 
   .resize-handle {
@@ -1006,7 +1112,7 @@ button {
     top: -5px;
     bottom: auto;
     width: auto;
-    height: 10px;
+    height: 20px;
     cursor: ns-resize;
   }
 

--- a/index.html
+++ b/index.html
@@ -195,23 +195,23 @@
             <section class="panel-section active" data-panel="layers">
               <div class="layer-panel-controls">
                 <div class="section-toolbar">
-                  <button class="chip-button" id="select-all-btn" type="button">
+                  <button class="chip-button" id="select-all-btn" type="button" title="All">
                     <i data-lucide="check-check"></i>
                     <span>All</span>
                   </button>
-                  <button class="chip-button" id="select-top-btn" type="button">
+                  <button class="chip-button" id="select-top-btn" type="button" title="Top">
                     <i data-lucide="panel-top"></i>
                     <span>Top</span>
                   </button>
-                  <button class="chip-button" id="select-bottom-btn" type="button">
+                  <button class="chip-button" id="select-bottom-btn" type="button" title="Bottom">
                     <i data-lucide="panel-bottom"></i>
                     <span>Bottom</span>
                   </button>
-                  <button class="chip-button" id="unselect-all-btn" type="button">
+                  <button class="chip-button" id="unselect-all-btn" type="button" title="None">
                     <i data-lucide="eye-off"></i>
                     <span>None</span>
                   </button>
-                  <button class="chip-button danger" id="clear-all-btn" type="button">
+                  <button class="chip-button danger" id="clear-all-btn" type="button" title="Clear">
                     <i data-lucide="trash-2"></i>
                     <span>Clear</span>
                   </button>

--- a/js/main.js
+++ b/js/main.js
@@ -127,6 +127,7 @@ export class GerberViewer {
     this.drawerMaxWidth = 600;
     this.drawerMinHeight = 300;
     this.drawerMaxHeight = 560;
+    this.drawerMobileMaxHeightRatio = 0.72;
     this.drawerCollapsedWidth = 156;
     this.drawerCollapsedHeight = 95;
     this.drawerSnapThreshold = 50;
@@ -2173,8 +2174,8 @@ export class GerberViewer {
 
   getDrawerMaxHeight() {
     const viewportLimit = Math.max(
-      this.drawerMinHeight,
-      Math.floor(window.innerHeight * 0.72),
+      1,
+      Math.floor(window.innerHeight * this.drawerMobileMaxHeightRatio),
     );
     return Math.min(this.drawerMaxHeight, viewportLimit);
   }
@@ -2184,10 +2185,10 @@ export class GerberViewer {
       return this.drawerCurrentHeight;
     }
 
-    return Math.min(
-      this.getDrawerMaxHeight(),
-      Math.max(this.drawerMinHeight, height),
-    );
+    const maxHeight = this.getDrawerMaxHeight();
+    const minHeight = Math.min(this.drawerMinHeight, maxHeight);
+
+    return Math.min(maxHeight, Math.max(minHeight, height));
   }
 
   setDrawerHeight(height, { commitLayout = true } = {}) {

--- a/js/main.js
+++ b/js/main.js
@@ -125,8 +125,12 @@ export class GerberViewer {
     this.drawerPendingHeight = null;
     this.drawerMinWidth = 200;
     this.drawerMaxWidth = 600;
-    this.drawerMinHeight = 180;
+    this.drawerMinHeight = 300;
     this.drawerMaxHeight = 560;
+    this.drawerCollapsedWidth = 156;
+    this.drawerCollapsedHeight = 95;
+    this.drawerSnapThreshold = 50;
+    this.drawerBottomCollapseThreshold = 200;
 
     // Colors
     this.colorPalette = [
@@ -2101,6 +2105,42 @@ export class GerberViewer {
     return window.matchMedia("(max-width: 760px)").matches;
   }
 
+  getCssPixelValue(propertyName, fallback) {
+    const rawValue = getComputedStyle(this.dropZone)
+      .getPropertyValue(propertyName)
+      .trim();
+    const parsedValue = parseFloat(rawValue);
+    return Number.isFinite(parsedValue) ? parsedValue : fallback;
+  }
+
+  getDrawerCollapsedWidth() {
+    return this.getCssPixelValue(
+      "--panel-collapsed-width",
+      this.drawerCollapsedWidth,
+    );
+  }
+
+  getDrawerCollapsedHeight() {
+    return this.getCssPixelValue(
+      "--panel-collapsed-height",
+      this.drawerCollapsedHeight,
+    );
+  }
+
+  getDrawerSnapThreshold() {
+    return this.getCssPixelValue(
+      "--panel-snap-threshold",
+      this.drawerSnapThreshold,
+    );
+  }
+
+  getDrawerBottomCollapseThreshold() {
+    return this.getCssPixelValue(
+      "--panel-bottom-collapse-threshold",
+      this.drawerBottomCollapseThreshold,
+    );
+  }
+
   getDrawerMaxWidth() {
     const viewportLimit = Math.max(this.drawerMinWidth, window.innerWidth - 48);
     return Math.min(this.drawerMaxWidth, viewportLimit);
@@ -2166,10 +2206,6 @@ export class GerberViewer {
 
   startDrawerResize(e) {
     e.preventDefault();
-    if (this.drawer.classList.contains("collapsed")) {
-      return;
-    }
-
     this.isResizingDrawer = true;
     this.drawer.classList.add("resizing");
     document.body.style.userSelect = "none";
@@ -2185,21 +2221,66 @@ export class GerberViewer {
 
     if (this.isMobileDrawerLayout()) {
       const clientY = e.touches ? e.touches[0].clientY : e.clientY;
-      this.setDrawerHeight(window.innerHeight - clientY, {
-        commitLayout: false,
-      });
+      this.previewDrawerResize(window.innerHeight - clientY, "height");
       return;
     }
 
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
-    const newWidth = window.innerWidth - clientX;
-    this.setDrawerWidth(newWidth, { commitLayout: false });
+    this.previewDrawerResize(window.innerWidth - clientX, "width");
+  }
+
+  previewDrawerResize(rawSize, axis) {
+    const wasCollapsed = this.drawer.classList.contains("collapsed");
+    const collapsedSize =
+      axis === "height"
+        ? this.getDrawerCollapsedHeight()
+        : this.getDrawerCollapsedWidth();
+    const collapseThreshold =
+      axis === "height"
+        ? this.getDrawerBottomCollapseThreshold()
+        : collapsedSize + this.getDrawerSnapThreshold();
+
+    if (rawSize <= collapseThreshold) {
+      this.drawer.classList.add("collapsed");
+      if (axis === "height") {
+        this.drawerPendingHeight = null;
+        this.dropZone.style.setProperty(
+          "--panel-overlay-height",
+          `${collapsedSize}px`,
+        );
+        this.drawer.style.height = `${this.drawerCurrentHeight}px`;
+      } else {
+        this.drawerPendingWidth = null;
+        this.dropZone.style.setProperty(
+          "--panel-overlay-width",
+          `${collapsedSize}px`,
+        );
+        this.drawer.style.width = `${this.drawerCurrentWidth}px`;
+      }
+      if (!wasCollapsed) {
+        this.updateDrawerToggleState();
+      }
+      return;
+    }
+
+    this.drawer.classList.remove("collapsed");
+    if (axis === "height") {
+      this.setDrawerHeight(rawSize, { commitLayout: false });
+    } else {
+      this.setDrawerWidth(rawSize, { commitLayout: false });
+    }
+    if (wasCollapsed) {
+      this.updateDrawerToggleState();
+    }
   }
 
   stopDrawerResize(e) {
     if (!this.isResizingDrawer) return;
 
-    if (this.isMobileDrawerLayout()) {
+    if (this.drawer.classList.contains("collapsed")) {
+      this.drawerPendingHeight = null;
+      this.drawerPendingWidth = null;
+    } else if (this.isMobileDrawerLayout()) {
       if (this.drawerPendingHeight !== null) {
         this.setDrawerHeight(this.drawerPendingHeight);
       }
@@ -2213,6 +2294,7 @@ export class GerberViewer {
     requestAnimationFrame(() => {
       this.drawer.classList.remove("resizing");
     });
+    this.render();
   }
 
   triggerCanvasResize() {


### PR DESCRIPTION
## Summary
- keep collapsed drawer quick controls visible for all/top/bottom and alpha
- add snap resize behavior for side and bottom drawer collapse/expand
- improve mobile resize touch target and bottom drawer thresholds

## Tests
- node --check js/main.js