### PR TITLE
Implement aperture block parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Modern browsers with WebGL2 support:
 
 The following Gerber commands are not implemented yet:
 
-- **%AB** - Aperture Block definitions
 - **%LR** - Layer Rotation transformations
 
 ## Source

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -30,7 +30,6 @@ pub struct GerberParser {
     pub polarity_layers: Vec<(Polarity, Vec<Primitive>)>,
     pub current_primitives: Vec<Primitive>, // Accumulating primitives for current polarity
     pub region_contours: Vec<Vec<[f32; 2]>>, // Contour points collected in Region mode
-    total_primitives: usize,                // Track total primitives for security limit
 }
 
 impl GerberParser {
@@ -43,7 +42,6 @@ impl GerberParser {
             polarity_layers: Vec::new(),
             current_primitives: Vec::new(),
             region_contours: Vec::new(),
-            total_primitives: 0,
         }
     }
 
@@ -92,23 +90,19 @@ impl GerberParser {
                 );
             }
 
+            self.enforce_primitive_limit(MAX_TOTAL_PRIMITIVES)
+                .map_err(|message| JsValue::from_str(&message))?;
             i += 1;
         }
 
         // Save last accumulated primitives by polarity
         if !self.current_primitives.is_empty() {
-            self.total_primitives += self.current_primitives.len();
-            if self.total_primitives > MAX_TOTAL_PRIMITIVES {
-                return Err(JsValue::from_str(&format!(
-                    "Too many total primitives: {} (max: {})",
-                    self.total_primitives, MAX_TOTAL_PRIMITIVES
-                )));
-            }
-
             self.polarity_layers.push((
                 self.current_state.polarity,
                 take(&mut self.current_primitives),
             ));
+            self.enforce_primitive_limit(MAX_TOTAL_PRIMITIVES)
+                .map_err(|message| JsValue::from_str(&message))?;
         }
 
         // Convert each layer to individual GerberData
@@ -121,6 +115,24 @@ impl GerberParser {
         }
 
         Ok(gerber_data_layers)
+    }
+
+    fn enforce_primitive_limit(&self, max_total_primitives: usize) -> Result<(), String> {
+        let flushed_primitives = self
+            .polarity_layers
+            .iter()
+            .map(|(_, primitives)| primitives.len())
+            .sum::<usize>();
+        let total_primitives = flushed_primitives + self.current_primitives.len();
+
+        if total_primitives > max_total_primitives {
+            return Err(format!(
+                "Too many total primitives: {} (max: {})",
+                total_primitives, max_total_primitives
+            ));
+        }
+
+        Ok(())
     }
 
     /// Convert a vector of primitives to GerberData
@@ -521,7 +533,8 @@ pub fn parse_gerber(data: &str) -> Result<Vec<GerberData>, JsValue> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_gerber;
+    use super::geometry::Primitive;
+    use super::{parse_gerber, GerberParser, Polarity};
 
     fn assert_approx_eq(actual: f32, expected: f32) {
         assert!(
@@ -544,6 +557,29 @@ mod tests {
         }
 
         (min_x, max_x, min_y, max_y)
+    }
+
+    fn test_circle() -> Primitive {
+        Primitive::Circle {
+            x: 0.0,
+            y: 0.0,
+            radius: 0.5,
+            exposure: 1.0,
+            hole_x: 0.0,
+            hole_y: 0.0,
+            hole_radius: 0.0,
+        }
+    }
+
+    #[test]
+    fn primitive_limit_counts_flushed_polarity_layers() {
+        let mut parser = GerberParser::new();
+        parser
+            .polarity_layers
+            .push((Polarity::Positive, vec![test_circle()]));
+        parser.current_primitives.push(test_circle());
+
+        assert!(parser.enforce_primitive_limit(1).is_err());
     }
 
     #[test]

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -88,6 +88,7 @@ impl GerberParser {
                     &self.apertures,
                     &mut self.current_primitives,
                     &mut self.region_contours,
+                    &mut self.polarity_layers,
                 );
             }
 
@@ -381,7 +382,17 @@ fn parse_command(
         parse_if(&line, state);
     } else if line.starts_with("%AB") {
         // Block Aperture: %ABD##*% ... %AB*%
-        // TODO: Implement full block aperture support
+        parse_aperture_block(
+            &line,
+            i,
+            length,
+            lines,
+            state,
+            apertures,
+            macros,
+            current_primitives,
+            polarity_layers,
+        );
     } else if line.starts_with("%LM") {
         // Layer mirroring: %LMN*, %LMX*, %LMY*, %LMXY*
         parse_lm(&line, state);
@@ -394,6 +405,113 @@ fn parse_command(
     } else {
         // Unknown or unsupported command
     }
+}
+
+fn flush_primitives(
+    current_primitives: &mut Vec<Primitive>,
+    polarity_layers: &mut Vec<(Polarity, Vec<Primitive>)>,
+    polarity: Polarity,
+) {
+    if !current_primitives.is_empty() {
+        polarity_layers.push((polarity, take(current_primitives)));
+    }
+}
+
+fn parse_aperture_block_code(line: &str) -> Option<String> {
+    let content = line
+        .trim()
+        .trim_start_matches('%')
+        .trim_end_matches('%')
+        .trim_end_matches('*');
+
+    let aperture_id = content.strip_prefix("ABD")?;
+    if aperture_id.is_empty() || !aperture_id.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    aperture_id.parse::<u32>().ok().map(|code| code.to_string())
+}
+
+fn is_aperture_block_close(line: &str) -> bool {
+    let content = line
+        .trim()
+        .trim_start_matches('%')
+        .trim_end_matches('%')
+        .trim_end_matches('*');
+
+    content == "AB"
+}
+
+fn parse_aperture_block(
+    line: &str,
+    i: &mut usize,
+    length: usize,
+    lines: &[&str],
+    state: &mut ParserState,
+    apertures: &mut HashMap<String, Aperture>,
+    macros: &mut HashMap<String, ApertureMacro>,
+    current_primitives: &mut Vec<Primitive>,
+    polarity_layers: &mut Vec<(Polarity, Vec<Primitive>)>,
+) {
+    let Some(block_code) = parse_aperture_block_code(line) else {
+        return;
+    };
+
+    flush_primitives(current_primitives, polarity_layers, state.polarity);
+
+    let mut block_primitives: Vec<Primitive> = Vec::new();
+    let mut block_layers: Vec<(Polarity, Vec<Primitive>)> = Vec::new();
+    let mut block_region_contours: Vec<Vec<[f32; 2]>> = Vec::new();
+
+    while *i + 1 < length {
+        *i += 1;
+        let block_line = lines[*i].trim();
+
+        if block_line.is_empty() || block_line.starts_with("G04") {
+            continue;
+        }
+
+        if block_line.starts_with('%') {
+            if is_aperture_block_close(block_line) {
+                break;
+            }
+
+            parse_command(
+                block_line,
+                i,
+                length,
+                lines,
+                state,
+                apertures,
+                macros,
+                &mut block_primitives,
+                &mut block_layers,
+            );
+        } else if block_line.starts_with('G')
+            || block_line.starts_with('D')
+            || block_line.starts_with('X')
+            || block_line.starts_with('Y')
+            || block_line.starts_with('I')
+            || block_line.starts_with('J')
+        {
+            parse_graphic_command(
+                block_line,
+                state,
+                apertures,
+                &mut block_primitives,
+                &mut block_region_contours,
+                &mut block_layers,
+            );
+        }
+    }
+
+    flush_primitives(&mut block_primitives, &mut block_layers, state.polarity);
+
+    state.x = 0.0;
+    state.y = 0.0;
+    state.pen_state = "up".to_string();
+
+    apertures.insert(block_code, Aperture::new_block(block_layers));
 }
 
 pub fn parse_gerber(data: &str) -> Result<Vec<GerberData>, JsValue> {
@@ -679,5 +797,141 @@ M02*";
         assert_eq!(layers.len(), 1);
         assert!(layers[0].is_negative);
         assert!(layers[0].triangles.vertices.len() / 2 > 60);
+    }
+
+    #[test]
+    fn aperture_block_flashes_stored_graphics_at_operation_coordinate() {
+        let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ABD20*%
+%ADD10C,1.0*%
+D10*
+X010000Y020000D03*
+%AB*%
+D20*
+X100000Y200000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("aperture block should parse");
+        let circles = &layers[0].circles;
+
+        assert_eq!(circles.x.len(), 1);
+        assert_approx_eq(circles.x[0], 11.0);
+        assert_approx_eq(circles.y[0], 22.0);
+        assert_approx_eq(circles.radius[0], 0.5);
+    }
+
+    #[test]
+    fn aperture_block_preserves_internal_polarity_order() {
+        let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ABD20*%
+%LPD*%
+%ADD10C,4.0*%
+D10*
+X000000Y000000D03*
+%LPC*%
+%ADD11C,2.0*%
+D11*
+X000000Y000000D03*
+%AB*%
+%LPD*%
+D20*
+X100000Y000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("aperture block should parse");
+
+        assert_eq!(layers.len(), 2);
+        assert!(!layers[0].is_negative);
+        assert!(layers[1].is_negative);
+        assert_eq!(layers[0].circles.x.len(), 1);
+        assert_eq!(layers[1].circles.x.len(), 1);
+        assert_approx_eq(layers[0].circles.x[0], 10.0);
+        assert_approx_eq(layers[0].circles.radius[0], 2.0);
+        assert_approx_eq(layers[1].circles.x[0], 10.0);
+        assert_approx_eq(layers[1].circles.radius[0], 1.0);
+    }
+
+    #[test]
+    fn clear_polarity_flash_toggles_aperture_block_polarity() {
+        let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ABD20*%
+%LPD*%
+%ADD10C,4.0*%
+D10*
+X000000Y000000D03*
+%LPC*%
+%ADD11C,2.0*%
+D11*
+X000000Y000000D03*
+%AB*%
+%LPC*%
+D20*
+X100000Y000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("aperture block should parse");
+
+        assert_eq!(layers.len(), 2);
+        assert!(layers[0].is_negative);
+        assert!(!layers[1].is_negative);
+        assert_eq!(layers[0].circles.x.len(), 1);
+        assert_eq!(layers[1].circles.x.len(), 1);
+        assert_approx_eq(layers[0].circles.radius[0], 2.0);
+        assert_approx_eq(layers[1].circles.radius[0], 1.0);
+    }
+
+    #[test]
+    fn nested_aperture_blocks_are_available_to_enclosing_block() {
+        let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ABD20*%
+%ADD10C,1.0*%
+D10*
+X010000Y000000D03*
+%AB*%
+%ABD21*%
+D20*
+X020000Y000000D03*
+%AB*%
+D21*
+X100000Y000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("nested aperture block should parse");
+        let circles = &layers[0].circles;
+
+        assert_eq!(circles.x.len(), 1);
+        assert_approx_eq(circles.x[0], 13.0);
+        assert_approx_eq(circles.y[0], 0.0);
+    }
+
+    #[test]
+    fn layer_scaling_transforms_aperture_block_about_origin() {
+        let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ABD20*%
+%ADD10C,1.0*%
+D10*
+X010000Y000000D03*
+%AB*%
+%LS2.0*%
+D20*
+X100000Y000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("scaled aperture block should parse");
+        let circles = &layers[0].circles;
+
+        assert_eq!(circles.x.len(), 1);
+        assert_approx_eq(circles.x[0], 12.0);
+        assert_approx_eq(circles.radius[0], 1.0);
     }
 }

--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -1,5 +1,6 @@
 use super::aperture_macro::ApertureMacro;
 use super::geometry::{scale_primitive, Primitive};
+use super::state::Polarity;
 use std::collections::HashMap;
 
 /// Aperture definition (Circle, Rectangle, Obround, Polygon, or Macro reference)
@@ -8,6 +9,7 @@ pub struct Aperture {
     pub radius: f32,
     pub primitives: Vec<Primitive>, // Aperture contains multiple basic primitives
     pub has_negative: bool,         // true if primitives contain exposure=0
+    pub block_layers: Option<Vec<(Polarity, Vec<Primitive>)>>,
 }
 
 impl Aperture {
@@ -16,6 +18,20 @@ impl Aperture {
             radius,
             primitives: Vec::new(),
             has_negative: false,
+            block_layers: None,
+        }
+    }
+
+    pub fn new_block(block_layers: Vec<(Polarity, Vec<Primitive>)>) -> Self {
+        let has_negative = block_layers
+            .iter()
+            .any(|(polarity, _)| *polarity == Polarity::Negative);
+
+        Aperture {
+            radius: 0.0,
+            primitives: Vec::new(),
+            has_negative,
+            block_layers: Some(block_layers),
         }
     }
 }

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1,9 +1,10 @@
-use crate::parser::{Aperture, FormatSpec, ParserState};
+use crate::parser::{Aperture, FormatSpec, ParserState, Polarity};
 use i_overlay::core::fill_rule::FillRule;
 use i_overlay::core::overlay_rule::OverlayRule;
 use i_overlay::float::single::SingleFloatOverlay;
 use i_triangle::float::triangulatable::Triangulatable;
 use std::collections::HashMap;
+use std::mem::take;
 
 /// Basic primitive shape - created directly by parser
 #[derive(Clone, Debug)]
@@ -719,15 +720,97 @@ fn flash_aperture_no_sr(
     }
 }
 
+fn transform_primitive_for_flash(
+    primitive: &Primitive,
+    x: f32,
+    y: f32,
+    layer_scale: f32,
+    mirror_x: bool,
+    mirror_y: bool,
+) -> Primitive {
+    let mut transformed = primitive.clone();
+    scale_primitive(&mut transformed, layer_scale);
+    mirror_primitive(&mut transformed, mirror_x, mirror_y);
+    offset_primitive_by(&transformed, x, y)
+}
+
+fn flush_primitives_to_layer(
+    primitives: &mut Vec<Primitive>,
+    polarity: Polarity,
+    polarity_layers: &mut Vec<(Polarity, Vec<Primitive>)>,
+) {
+    if !primitives.is_empty() {
+        polarity_layers.push((polarity, take(primitives)));
+    }
+}
+
+fn toggled_block_polarity(block_polarity: Polarity, flash_polarity: Polarity) -> Polarity {
+    if flash_polarity == Polarity::Negative {
+        match block_polarity {
+            Polarity::Positive => Polarity::Negative,
+            Polarity::Negative => Polarity::Positive,
+        }
+    } else {
+        block_polarity
+    }
+}
+
+fn flash_block_aperture(
+    block_layers: &[(Polarity, Vec<Primitive>)],
+    state: &ParserState,
+    primitives: &mut Vec<Primitive>,
+    polarity_layers: &mut Vec<(Polarity, Vec<Primitive>)>,
+    x: f32,
+    y: f32,
+) {
+    flush_primitives_to_layer(primitives, state.polarity, polarity_layers);
+
+    for sy in 0..state.sr_y {
+        for sx in 0..state.sr_x {
+            let flash_x = x + sx as f32 * state.sr_i;
+            let flash_y = y + sy as f32 * state.sr_j;
+
+            for (block_polarity, block_primitives) in block_layers {
+                let transformed: Vec<Primitive> = block_primitives
+                    .iter()
+                    .map(|primitive| {
+                        transform_primitive_for_flash(
+                            primitive,
+                            flash_x,
+                            flash_y,
+                            state.layer_scale,
+                            state.mirror_x,
+                            state.mirror_y,
+                        )
+                    })
+                    .collect();
+
+                if !transformed.is_empty() {
+                    polarity_layers.push((
+                        toggled_block_polarity(*block_polarity, state.polarity),
+                        transformed,
+                    ));
+                }
+            }
+        }
+    }
+}
+
 /// Flash aperture at given position - add all primitives of the aperture to the position
 pub fn flash_aperture(
     state: &ParserState,
     apertures: &HashMap<String, Aperture>,
     primitives: &mut Vec<Primitive>,
+    polarity_layers: &mut Vec<(Polarity, Vec<Primitive>)>,
     x: f32,
     y: f32,
 ) {
     if let Some(aperture) = apertures.get(&state.current_aperture) {
+        if let Some(block_layers) = aperture.block_layers.as_ref() {
+            flash_block_aperture(block_layers, state, primitives, polarity_layers, x, y);
+            return;
+        }
+
         // Step and Repeat iteration
         for sy in 0..state.sr_y {
             for sx in 0..state.sr_x {
@@ -1026,6 +1109,7 @@ pub fn parse_graphic_command(
     apertures: &HashMap<String, Aperture>,
     primitives: &mut Vec<Primitive>,
     region_contours: &mut Vec<Vec<[f32; 2]>>,
+    polarity_layers: &mut Vec<(Polarity, Vec<Primitive>)>,
 ) {
     let clean_line = line.trim_end_matches('*');
 
@@ -1227,7 +1311,7 @@ pub fn parse_graphic_command(
                 }
                 3 if !state.region_mode => {
                     // D03: Flash aperture at current position
-                    flash_aperture(state, apertures, primitives, x, y);
+                    flash_aperture(state, apertures, primitives, polarity_layers, x, y);
                 }
                 _ if d_code >= 10 => {
                     // D10+: Aperture selection


### PR DESCRIPTION
## Summary
- parse %AB aperture block definitions and store their polarity-ordered primitives
- flash aperture blocks at operation coordinates with SR, LS, LM, nested AB, and clear-polarity handling
- remove %AB from README work-in-progress list

## Tests
- cargo test