### PR TITLE
Implement layer rotation transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,6 @@ Modern browsers with WebGL2 support:
 
 - Chrome 80+, Firefox 75+, Safari 15+, Edge 80+
 
-## Work in Progress
-
-The following Gerber commands are not implemented yet:
-
-- **%LR** - Layer Rotation transformations
-
 ## Source
 
 Sample archives are loaded from their upstream sources and are not bundled in

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -10,7 +10,9 @@ pub use state::{FormatSpec, ParserState, Polarity};
 // Internal use only
 use aperture::parse_aperture;
 use aperture_macro::{parse_macro, ApertureMacro};
-use state::{parse_format_spec, parse_if, parse_lm, parse_lp, parse_ls, parse_mo, parse_sr};
+use state::{
+    parse_format_spec, parse_if, parse_lm, parse_lp, parse_lr, parse_ls, parse_mo, parse_sr,
+};
 
 use self::geometry::{parse_graphic_command, Primitive};
 use crate::shape::{Arcs, Boundary, Circles, GerberData, Thermals, Triangles};
@@ -410,7 +412,7 @@ fn parse_command(
         parse_lm(&line, state);
     } else if line.starts_with("%LR") {
         // Layer rotation: %LR45.0*
-        // TODO: Implement rotation transformation
+        parse_lr(&line, state);
     } else if line.starts_with("%LS") {
         // Layer scaling: %LS0.8*
         parse_ls(&line, state);
@@ -969,5 +971,90 @@ M02*";
         assert_eq!(circles.x.len(), 1);
         assert_approx_eq(circles.x[0], 12.0);
         assert_approx_eq(circles.radius[0], 1.0);
+    }
+
+    #[test]
+    fn layer_rotation_transforms_aperture_about_origin() {
+        let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10R,2.0X1.0*%
+%LR90*%
+D10*
+X000000Y000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("rotated aperture should parse");
+        let (min_x, max_x, min_y, max_y) = triangle_bounds(&layers[0].triangles.vertices);
+
+        assert_approx_eq(min_x, -0.5);
+        assert_approx_eq(max_x, 0.5);
+        assert_approx_eq(min_y, -1.0);
+        assert_approx_eq(max_y, 1.0);
+    }
+
+    #[test]
+    fn layer_rotation_is_applied_after_mirroring() {
+        let data = "\
+%FSLAX26Y26*%
+%MOMM*%
+%AMOFF*1,1,0.5,0.25,0*%
+%ADD10OFF*%
+%LMX*%
+%LR90*%
+D10*
+X1000000Y1000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("mirrored rotated aperture should parse");
+        let circles = &layers[0].circles;
+
+        assert_eq!(circles.x.len(), 1);
+        assert_approx_eq(circles.x[0], 1.0);
+        assert_approx_eq(circles.y[0], 0.75);
+    }
+
+    #[test]
+    fn layer_rotation_replaces_previous_value() {
+        let data = "\
+%FSLAX26Y26*%
+%MOMM*%
+%AMOFF*1,1,0.5,1,0*%
+%ADD10OFF*%
+%LR90*%
+%LR180*%
+D10*
+X000000Y000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("rotated aperture should parse");
+        let circles = &layers[0].circles;
+
+        assert_eq!(circles.x.len(), 1);
+        assert_approx_eq(circles.x[0], -1.0);
+        assert_approx_eq(circles.y[0], 0.0);
+    }
+
+    #[test]
+    fn layer_rotation_transforms_aperture_block_about_origin() {
+        let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ABD20*%
+%ADD10C,1.0*%
+D10*
+X010000Y000000D03*
+%AB*%
+%LR90*%
+D20*
+X100000Y000000D03*
+M02*";
+
+        let layers = parse_gerber(data).expect("rotated aperture block should parse");
+        let circles = &layers[0].circles;
+
+        assert_eq!(circles.x.len(), 1);
+        assert_approx_eq(circles.x[0], 10.0);
+        assert_approx_eq(circles.y[0], 1.0);
     }
 }

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -207,6 +207,73 @@ pub fn mirror_primitive(primitive: &mut Primitive, mirror_x: bool, mirror_y: boo
     }
 }
 
+/// Rotate a primitive counterclockwise around its aperture origin.
+pub fn rotate_primitive(primitive: &mut Primitive, angle: f32) {
+    if angle == 0.0 {
+        return;
+    }
+
+    let rotate_angle = |primitive_angle: &mut f32| {
+        *primitive_angle += angle;
+    };
+
+    match primitive {
+        Primitive::Circle {
+            x,
+            y,
+            hole_x,
+            hole_y,
+            ..
+        } => {
+            let mut center = [*x, *y];
+            rotate_point(&mut center, angle, 0.0, 0.0);
+            *x = center[0];
+            *y = center[1];
+
+            let mut hole = [*hole_x, *hole_y];
+            rotate_point(&mut hole, angle, 0.0, 0.0);
+            *hole_x = hole[0];
+            *hole_y = hole[1];
+        }
+        Primitive::Triangle {
+            vertices,
+            hole_x,
+            hole_y,
+            ..
+        } => {
+            for vertex in vertices.iter_mut() {
+                rotate_point(vertex, angle, 0.0, 0.0);
+            }
+
+            let mut hole = [*hole_x, *hole_y];
+            rotate_point(&mut hole, angle, 0.0, 0.0);
+            *hole_x = hole[0];
+            *hole_y = hole[1];
+        }
+        Primitive::Arc {
+            x,
+            y,
+            start_angle,
+            end_angle,
+            ..
+        } => {
+            let mut center = [*x, *y];
+            rotate_point(&mut center, angle, 0.0, 0.0);
+            *x = center[0];
+            *y = center[1];
+            rotate_angle(start_angle);
+            rotate_angle(end_angle);
+        }
+        Primitive::Thermal { x, y, rotation, .. } => {
+            let mut center = [*x, *y];
+            rotate_point(&mut center, angle, 0.0, 0.0);
+            *x = center[0];
+            *y = center[1];
+            rotate_angle(rotation);
+        }
+    }
+}
+
 /// Triangulate outline into triangles
 pub fn triangulate_outline(vertices: &[[f32; 2]], exposure: f32) -> Result<Vec<Primitive>, String> {
     if vertices.len() < 3 {
@@ -646,6 +713,7 @@ fn flash_aperture_no_sr(
     layer_scale: f32,
     mirror_x: bool,
     mirror_y: bool,
+    layer_rotation: f32,
 ) {
     // Use pre-calculated has_negative field for performance
     if aperture.has_negative {
@@ -658,6 +726,7 @@ fn flash_aperture_no_sr(
                 let mut scaled_primitive = p.clone();
                 scale_primitive(&mut scaled_primitive, layer_scale);
                 mirror_primitive(&mut scaled_primitive, mirror_x, mirror_y);
+                rotate_primitive(&mut scaled_primitive, layer_rotation);
                 let offset_p = offset_primitive_by(&scaled_primitive, x, y);
                 let poly = primitive_to_polygon(&offset_p);
                 let exposure = match &offset_p {
@@ -680,6 +749,7 @@ fn flash_aperture_no_sr(
             let mut new_primitive = primitive.clone();
             scale_primitive(&mut new_primitive, layer_scale);
             mirror_primitive(&mut new_primitive, mirror_x, mirror_y);
+            rotate_primitive(&mut new_primitive, layer_rotation);
             match &mut new_primitive {
                 Primitive::Circle {
                     x: px,
@@ -727,10 +797,12 @@ fn transform_primitive_for_flash(
     layer_scale: f32,
     mirror_x: bool,
     mirror_y: bool,
+    layer_rotation: f32,
 ) -> Primitive {
     let mut transformed = primitive.clone();
     scale_primitive(&mut transformed, layer_scale);
     mirror_primitive(&mut transformed, mirror_x, mirror_y);
+    rotate_primitive(&mut transformed, layer_rotation);
     offset_primitive_by(&transformed, x, y)
 }
 
@@ -781,6 +853,7 @@ fn flash_block_aperture(
                             state.layer_scale,
                             state.mirror_x,
                             state.mirror_y,
+                            state.layer_rotation,
                         )
                     })
                     .collect();
@@ -824,6 +897,7 @@ pub fn flash_aperture(
                     state.layer_scale,
                     state.mirror_x,
                     state.mirror_y,
+                    state.layer_rotation,
                 );
             }
         }
@@ -867,6 +941,7 @@ pub fn execute_interpolation(
                                 state.layer_scale,
                                 state.mirror_x,
                                 state.mirror_y,
+                                state.layer_rotation,
                             );
 
                             // Convert vector line with width of aperture diameter to triangle
@@ -887,6 +962,7 @@ pub fn execute_interpolation(
                                 state.layer_scale,
                                 state.mirror_x,
                                 state.mirror_y,
+                                state.layer_rotation,
                             );
                         }
                     }
@@ -913,6 +989,7 @@ pub fn execute_interpolation(
                                 state.layer_scale,
                                 state.mirror_x,
                                 state.mirror_y,
+                                state.layer_rotation,
                             );
 
                             if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
@@ -943,6 +1020,7 @@ pub fn execute_interpolation(
                                 state.layer_scale,
                                 state.mirror_x,
                                 state.mirror_y,
+                                state.layer_rotation,
                             );
                         }
                     }

--- a/wasm/src/parser/state.rs
+++ b/wasm/src/parser/state.rs
@@ -62,6 +62,8 @@ pub struct ParserState {
     // Layer Mirroring
     pub mirror_x: bool,
     pub mirror_y: bool,
+    // Layer Rotation
+    pub layer_rotation: f32,
 }
 
 impl Default for ParserState {
@@ -88,6 +90,7 @@ impl Default for ParserState {
             layer_scale: 1.0,
             mirror_x: false,
             mirror_y: false,
+            layer_rotation: 0.0,
         }
     }
 }
@@ -344,6 +347,28 @@ pub fn parse_ls(line: &str, state: &mut ParserState) {
     if let Ok(new_scale) = scale_str.parse::<f32>() {
         if new_scale > 0.0 {
             state.layer_scale = new_scale;
+        }
+    }
+}
+
+/// Parse Layer Rotation - %LR90.0*%
+/// Format: %LR[rotation_degrees]*%
+/// Rotation is counterclockwise in degrees and replaces the previous value.
+pub fn parse_lr(line: &str, state: &mut ParserState) {
+    let spec_str = line
+        .trim_start_matches('%')
+        .trim_end_matches('%')
+        .trim_end_matches('*');
+
+    if !spec_str.starts_with("LR") {
+        return;
+    }
+
+    let rotation_str = &spec_str[2..];
+
+    if let Ok(new_rotation) = rotation_str.parse::<f32>() {
+        if new_rotation.is_finite() {
+            state.layer_rotation = new_rotation.to_radians();
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement %LR load-rotation parsing as a persistent object transformation
- apply rotation after mirroring for flashes, draws, arcs, and aperture block flashes
- remove the remaining WIP command section from README

## Standard notes
- %LR uses counterclockwise degrees
- later %LR values replace earlier values instead of accumulating
- object transformations do not affect regions

## Tests
- cargo test