### PR TITLE
Harden renderer shader and context handling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2084,7 +2084,7 @@ export class GerberViewer {
 
       try {
         // remove from WASM processor and handle errors
-        if (this.wasmProcessor && !this.isWebGlContextLost) {
+        if (this.wasmProcessor) {
           this.wasmProcessor.remove_layer(layer.layerId);
         }
 
@@ -2107,7 +2107,7 @@ export class GerberViewer {
   clearAllLayers() {
     try {
       // remove all layers from WASM processor
-      if (this.wasmProcessor && !this.isWebGlContextLost) {
+      if (this.wasmProcessor) {
         this.wasmProcessor.clear();
       }
 

--- a/js/main.js
+++ b/js/main.js
@@ -194,12 +194,16 @@ export class GerberViewer {
     this.loadInitialUrlSource();
   }
 
-  createWebGlProcessor() {
-    this.gl = this.canvas.getContext("webgl2", { preserveDrawingBuffer: true });
-    if (!this.gl) {
+  createWebGlContext() {
+    const gl = this.canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+    if (!gl) {
       throw new Error("WebGL2 not supported");
     }
+    return gl;
+  }
 
+  createWebGlProcessor() {
+    this.gl = this.createWebGlContext();
     this.wasmProcessor = new this.wasmModule.GerberProcessor();
     this.wasmProcessor.init(this.gl);
   }
@@ -424,7 +428,6 @@ export class GerberViewer {
     e.preventDefault();
     this.isWebGlContextLost = true;
     this.isRestoringWebGlContext = false;
-    this.wasmProcessor = null;
     this.gl = null;
     this.addDiagnostic(
       "warning",
@@ -440,7 +443,8 @@ export class GerberViewer {
     const layerSnapshot = this.layers.map((layer) => ({
       id: layer.id,
       name: layer.name,
-      sourceContent: layer.sourceContent,
+      layerId: layer.layerId,
+      bounds: layer.bounds ? { ...layer.bounds } : null,
       visible: layer.visible,
       color: [...layer.color],
     }));
@@ -449,22 +453,18 @@ export class GerberViewer {
     this.updateUiState();
 
     try {
-      this.createWebGlProcessor();
+      this.gl = this.createWebGlContext();
+      if (!this.wasmProcessor) {
+        throw new Error("No parsed layer data available for WebGL restore");
+      }
+      this.wasmProcessor.restore_context(this.gl);
       this.isWebGlContextLost = false;
       this.resizeCanvas({ allowProcessorResize: true });
-      this.layers = [];
-
-      for (const layer of layerSnapshot) {
-        await this.addLayer(layer.name, layer.sourceContent, {
-          id: layer.id,
-          visible: layer.visible,
-          color: layer.color,
-        });
-      }
+      this.layers = layerSnapshot;
 
       this.renderLayerList();
-      this.render();
     } catch (error) {
+      this.isWebGlContextLost = true;
       const message = this.getErrorMessage(error);
       console.error("[Render] Failed to restore WebGL context:", error);
       this.addDiagnostic("error", "WebGL restore failed", message);
@@ -472,6 +472,7 @@ export class GerberViewer {
     } finally {
       this.isRestoringWebGlContext = false;
       this.updateUiState();
+      this.render();
     }
   }
 
@@ -1289,7 +1290,6 @@ export class GerberViewer {
         id: options.id ?? `layer-${this.nextLayerDomId++}`,
         layerId: layerId, // WASM layer_id
         name: name,
-        sourceContent: content,
         visible: options.visible ?? true,
         color: color,
         bounds: {

--- a/js/main.js
+++ b/js/main.js
@@ -88,9 +88,12 @@ export class GerberViewer {
     // WASM module and single processor
     this.wasmModule = null;
     this.wasmProcessor = null;
+    this.isWebGlContextLost = false;
+    this.isRestoringWebGlContext = false;
 
     // Layers
     this.layers = [];
+    this.nextLayerDomId = 0;
     this.draggedLayerId = null;
     this.layerDropIndex = null;
 
@@ -168,15 +171,7 @@ export class GerberViewer {
     await this.wasmModule.default();
     this.wasmModule.init_panic_hook();
 
-    // Create WebGL2 context
-    this.gl = this.canvas.getContext("webgl2", { preserveDrawingBuffer: true });
-    if (!this.gl) {
-      throw new Error("WebGL2 not supported");
-    }
-
-    // Initialize Gerber processor
-    this.wasmProcessor = new this.wasmModule.GerberProcessor();
-    this.wasmProcessor.init(this.gl);
+    this.createWebGlProcessor();
 
     // Resize Canvas
     this.resizeCanvas();
@@ -199,7 +194,17 @@ export class GerberViewer {
     this.loadInitialUrlSource();
   }
 
-  resizeCanvas() {
+  createWebGlProcessor() {
+    this.gl = this.canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+    if (!this.gl) {
+      throw new Error("WebGL2 not supported");
+    }
+
+    this.wasmProcessor = new this.wasmModule.GerberProcessor();
+    this.wasmProcessor.init(this.gl);
+  }
+
+  resizeCanvas({ allowProcessorResize = false } = {}) {
     if (this.drawer && !this.drawer.classList.contains("collapsed")) {
       if (this.isMobileDrawerLayout()) {
         this.setDrawerHeight(this.drawerCurrentHeight);
@@ -213,14 +218,33 @@ export class GerberViewer {
     this.canvas.width = Math.max(1, Math.round(rect.width * pixelRatio));
     this.canvas.height = Math.max(1, Math.round(rect.height * pixelRatio));
 
-    if (this.wasmProcessor) {
-      this.wasmProcessor.resize();
+    const canResizeProcessor =
+      this.wasmProcessor &&
+      !this.isWebGlContextLost &&
+      (!this.isRestoringWebGlContext || allowProcessorResize);
+    if (canResizeProcessor) {
+      try {
+        this.wasmProcessor.resize();
+      } catch (error) {
+        const message = this.getErrorMessage(error);
+        console.error("[Render] Failed to resize renderer:", error);
+        this.addDiagnostic("error", "Resize failed", message);
+      }
     }
 
     this.render();
   }
 
   setupEventListeners() {
+    this.canvas.addEventListener(
+      "webglcontextlost",
+      (e) => this.handleWebGlContextLost(e),
+      { passive: false },
+    );
+    this.canvas.addEventListener("webglcontextrestored", () => {
+      void this.handleWebGlContextRestored();
+    });
+
     // File input
     this.selectFilesBtn.addEventListener("click", () => {
       this.fileInput.click();
@@ -396,6 +420,61 @@ export class GerberViewer {
     this.dropZone.addEventListener("drop", (e) => this.handleDrop(e));
   }
 
+  handleWebGlContextLost(e) {
+    e.preventDefault();
+    this.isWebGlContextLost = true;
+    this.isRestoringWebGlContext = false;
+    this.wasmProcessor = null;
+    this.gl = null;
+    this.addDiagnostic(
+      "warning",
+      "WebGL context lost",
+      "Waiting for the browser to restore the GPU context.",
+    );
+    this.updateUiState();
+  }
+
+  async handleWebGlContextRestored() {
+    if (this.isRestoringWebGlContext) return;
+
+    const layerSnapshot = this.layers.map((layer) => ({
+      id: layer.id,
+      name: layer.name,
+      sourceContent: layer.sourceContent,
+      visible: layer.visible,
+      color: [...layer.color],
+    }));
+
+    this.isRestoringWebGlContext = true;
+    this.updateUiState();
+
+    try {
+      this.createWebGlProcessor();
+      this.isWebGlContextLost = false;
+      this.resizeCanvas({ allowProcessorResize: true });
+      this.layers = [];
+
+      for (const layer of layerSnapshot) {
+        await this.addLayer(layer.name, layer.sourceContent, {
+          id: layer.id,
+          visible: layer.visible,
+          color: layer.color,
+        });
+      }
+
+      this.renderLayerList();
+      this.render();
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      console.error("[Render] Failed to restore WebGL context:", error);
+      this.addDiagnostic("error", "WebGL restore failed", message);
+      this.showError(`Failed to restore WebGL context: ${message}`);
+    } finally {
+      this.isRestoringWebGlContext = false;
+      this.updateUiState();
+    }
+  }
+
   refreshIcons() {
     if (window.lucide) {
       window.lucide.createIcons();
@@ -490,10 +569,22 @@ export class GerberViewer {
     const totalLayers = this.layers.length;
     const visibleLayers = this.layers.filter((layer) => layer.visible).length;
 
-    this.workspaceStatus.textContent =
-      totalLayers === 0
-        ? "Ready"
-        : `${visibleLayers} visible / ${totalLayers} loaded`;
+    if (this.isRestoringWebGlContext) {
+      this.workspaceStatus.textContent = "Restoring WebGL";
+    } else if (this.isWebGlContextLost) {
+      this.workspaceStatus.textContent = "WebGL context lost";
+    } else {
+      this.workspaceStatus.textContent =
+        totalLayers === 0
+          ? "Ready"
+          : `${visibleLayers} visible / ${totalLayers} loaded`;
+    }
+
+    const rendererBusy = this.isWebGlContextLost || this.isRestoringWebGlContext;
+    this.fileInput.disabled = rendererBusy;
+    this.selectFilesBtn.disabled = rendererBusy;
+    this.emptyUploadBtn.disabled = rendererBusy;
+
     this.visibleLayerCount.textContent = `${visibleLayers} / ${totalLayers}`;
     this.diagnosticsCount.textContent = String(this.diagnostics.length);
     this.emptyState.classList.toggle("is-hidden", totalLayers > 0);
@@ -1172,8 +1263,12 @@ export class GerberViewer {
     this.notificationTitle.textContent = "Notice";
   }
 
-  async addLayer(name, content) {
+  async addLayer(name, content, options = {}) {
     try {
+      if (!this.wasmProcessor || this.isWebGlContextLost) {
+        throw new Error("WebGL renderer is not available");
+      }
+
       // add layer to WASM processor and get layer ID
       const layerId = this.wasmProcessor.add_layer(content);
       if (layerId === undefined || layerId === null) {
@@ -1183,15 +1278,19 @@ export class GerberViewer {
       // Get this layer's boundary from WASM
       const bounds = this.wasmProcessor.get_layer_boundary(layerId);
 
-      const color =
-        this.colorPalette[this.nextColorIndex % this.colorPalette.length];
-      this.nextColorIndex++;
+      const color = options.color
+        ? [...options.color]
+        : this.colorPalette[this.nextColorIndex % this.colorPalette.length];
+      if (!options.color) {
+        this.nextColorIndex++;
+      }
 
       const layer = {
-        id: `layer-${layerId}`,
+        id: options.id ?? `layer-${this.nextLayerDomId++}`,
         layerId: layerId, // WASM layer_id
         name: name,
-        visible: true,
+        sourceContent: content,
+        visible: options.visible ?? true,
         color: color,
         bounds: {
           minX: bounds.min_x,
@@ -1215,7 +1314,14 @@ export class GerberViewer {
   }
 
   render() {
-    if (!this.wasmProcessor) return;
+    if (
+      !this.wasmProcessor ||
+      this.isWebGlContextLost ||
+      this.isRestoringWebGlContext
+    ) {
+      this.renderMeasurements();
+      return;
+    }
 
     try {
       // Get selected layers
@@ -1247,8 +1353,9 @@ export class GerberViewer {
       );
       this.zoomReadout.textContent = this.formatZoom();
     } catch (error) {
+      const message = this.getErrorMessage(error);
       console.error("[Render] Failed to render:", error);
-      this.addDiagnostic("error", "Render failed", error.message);
+      this.addDiagnostic("error", "Render failed", message);
     }
 
     this.renderMeasurements();
@@ -1977,7 +2084,9 @@ export class GerberViewer {
 
       try {
         // remove from WASM processor and handle errors
-        this.wasmProcessor.remove_layer(layer.layerId);
+        if (this.wasmProcessor && !this.isWebGlContextLost) {
+          this.wasmProcessor.remove_layer(layer.layerId);
+        }
 
         // remove from JS array only if WASM removal succeeded
         this.layers.splice(index, 1);
@@ -1998,10 +2107,13 @@ export class GerberViewer {
   clearAllLayers() {
     try {
       // remove all layers from WASM processor
-      this.wasmProcessor.clear();
+      if (this.wasmProcessor && !this.isWebGlContextLost) {
+        this.wasmProcessor.clear();
+      }
 
       this.layers = [];
       this.nextColorIndex = 0;
+      this.nextLayerDomId = 0;
       this.fitViewZoom = null;
       this.renderLayerList();
       this.render();

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -45,6 +45,21 @@ impl GerberProcessor {
         Ok("init_done".to_string())
     }
 
+    /// Recreate WebGL-owned resources after browser context restoration.
+    ///
+    /// Parsed Gerber geometry is kept in Rust memory, so this does not require
+    /// JS to retain or reparse the original uploaded file contents.
+    pub fn restore_context(&mut self, gl: WebGl2RenderingContext) -> Result<String, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.restore_context(gl.clone())?;
+        } else {
+            self.renderer = Some(Renderer::new(gl.clone())?);
+        }
+
+        self.gl = Some(gl);
+        Ok("restore_done".to_string())
+    }
+
     /// Add a new layer to the renderer
     ///
     /// # Arguments

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -555,6 +555,45 @@ M02*";
 }
 
 #[test]
+fn macro_thermal_rotation_from_ucamco_sample_is_preserved() {
+    let data = "\
+%FSLAX36Y36*%
+%MOMM*%
+%AMTHERS4T*
+7,0,0,$1,$2,$3,$4*%
+%ADD40THERS4T,0.1000X0.0500X0.0200X0.00*%
+%ADD41THERS4T,0.2000X0.1000X0.0200X10.00*%
+%ADD42THERS4T,0.2500X0.2000X0.0600X30.00*%
+%ADD43THERS4T,0.2700X0.2000X0.0600X45.00*%
+D40*
+X0Y1100000D03*
+D41*
+X400000D03*
+D42*
+X800000D03*
+D43*
+X1200000D03*
+M02*";
+
+    let layers = parse_gerber(data).expect("thermal macro sample should parse");
+    let thermals = &layers[0].thermals;
+
+    assert_eq!(thermals.x.len(), 4);
+    assert_approx_eq(thermals.x[0], 0.0);
+    assert_approx_eq(thermals.x[1], 0.4);
+    assert_approx_eq(thermals.x[2], 0.8);
+    assert_approx_eq(thermals.x[3], 1.2);
+    assert_approx_eq(thermals.y[0], 1.1);
+    assert_approx_eq(thermals.outer_diameter[2], 0.25);
+    assert_approx_eq(thermals.inner_diameter[2], 0.2);
+    assert_approx_eq(thermals.gap_thickness[2], 0.06);
+    assert_approx_eq(thermals.rotation[0], 0.0);
+    assert_approx_eq(thermals.rotation[1], 10.0_f32.to_radians());
+    assert_approx_eq(thermals.rotation[2], 30.0_f32.to_radians());
+    assert_approx_eq(thermals.rotation[3], 45.0_f32.to_radians());
+}
+
+#[test]
 fn macro_expressions_support_lowercase_multiply_and_parentheses() {
     let data = "\
 %FSLAX26Y26*%

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -82,33 +82,7 @@ impl Renderer {
         let fbo = Self::create_fbo(&self.gl, width, height)?;
 
         // Create buffer caches for each polarity sublayer
-        let mut buffer_caches = Vec::new();
-        for _ in 0..gerber_data.len() {
-            buffer_caches.push(BufferCache {
-                triangle_vao: None,
-                triangle_vertex_buffer: None,
-                triangle_index_buffer: None,
-                triangle_hole_center_buffer: None,
-                triangle_hole_radius_buffer: None,
-                circle_vao: None,
-                circle_center_buffer: None,
-                circle_radius_buffer: None,
-                circle_hole_center_buffer: None,
-                circle_hole_radius_buffer: None,
-                arc_vao: None,
-                arc_center_buffer: None,
-                arc_radius_buffer: None,
-                arc_start_angle_buffer: None,
-                arc_sweep_angle_buffer: None,
-                arc_thickness_buffer: None,
-                thermal_vao: None,
-                thermal_center_buffer: None,
-                thermal_outer_diameter_buffer: None,
-                thermal_inner_diameter_buffer: None,
-                thermal_gap_thickness_buffer: None,
-                thermal_rotation_buffer: None,
-            });
-        }
+        let buffer_caches = Self::create_buffer_caches(gerber_data.len());
 
         let layer_metadata = LayerMetadata {
             gerber_data,
@@ -365,14 +339,7 @@ impl Renderer {
 
         // Remove layer metadata (which will drop cached WebGL resources)
         if let Some(layer) = self.layers[layer_id].take() {
-            // Delete framebuffer and texture
-            self.gl.delete_framebuffer(Some(&layer.fbo.framebuffer));
-            self.gl.delete_texture(Some(&layer.fbo.texture));
-
-            // Delete all cached buffers and VAOs
-            for cache in layer.buffer_caches {
-                self.delete_buffer_cache(cache);
-            }
+            Self::delete_layer_gpu_resources(&self.gl, layer);
         }
 
         self.layer_count -= 1;
@@ -385,87 +352,105 @@ impl Renderer {
 
         // Delete all cached resources for each layer
         for layer in layers {
-            // Delete framebuffer and texture
-            self.gl.delete_framebuffer(Some(&layer.fbo.framebuffer));
-            self.gl.delete_texture(Some(&layer.fbo.texture));
-
-            // Delete all cached buffers and VAOs
-            for cache in layer.buffer_caches {
-                self.delete_buffer_cache(cache);
-            }
+            Self::delete_layer_gpu_resources(&self.gl, layer);
         }
         self.layer_count = 0;
     }
 
-    fn delete_buffer_cache(&self, cache: BufferCache) {
+    fn create_buffer_caches(count: usize) -> Vec<BufferCache> {
+        (0..count).map(|_| BufferCache::default()).collect()
+    }
+
+    fn delete_layer_gpu_resources(gl: &WebGl2RenderingContext, layer: LayerMetadata) {
+        Self::delete_fbo(gl, layer.fbo);
+
+        for cache in layer.buffer_caches {
+            Self::delete_buffer_cache(gl, cache);
+        }
+    }
+
+    fn delete_fbo(gl: &WebGl2RenderingContext, fbo: Fbo) {
+        gl.delete_framebuffer(Some(&fbo.framebuffer));
+        gl.delete_texture(Some(&fbo.texture));
+    }
+
+    fn delete_shader_programs(gl: &WebGl2RenderingContext, programs: &ShaderPrograms) {
+        gl.delete_program(Some(&programs.triangle.program));
+        gl.delete_program(Some(&programs.circle.program));
+        gl.delete_program(Some(&programs.arc.program));
+        gl.delete_program(Some(&programs.thermal.program));
+        gl.delete_program(Some(&programs.texture.program));
+    }
+
+    fn delete_buffer_cache(gl: &WebGl2RenderingContext, cache: BufferCache) {
         if let Some(vao) = cache.triangle_vao {
-            self.gl.delete_vertex_array(Some(&vao));
+            gl.delete_vertex_array(Some(&vao));
         }
         if let Some(buf) = cache.triangle_vertex_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.triangle_index_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.triangle_hole_center_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.triangle_hole_radius_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
 
         if let Some(vao) = cache.circle_vao {
-            self.gl.delete_vertex_array(Some(&vao));
+            gl.delete_vertex_array(Some(&vao));
         }
         if let Some(buf) = cache.circle_center_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.circle_radius_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.circle_hole_center_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.circle_hole_radius_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
 
         if let Some(vao) = cache.arc_vao {
-            self.gl.delete_vertex_array(Some(&vao));
+            gl.delete_vertex_array(Some(&vao));
         }
         if let Some(buf) = cache.arc_center_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.arc_radius_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.arc_start_angle_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.arc_sweep_angle_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.arc_thickness_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
 
         if let Some(vao) = cache.thermal_vao {
-            self.gl.delete_vertex_array(Some(&vao));
+            gl.delete_vertex_array(Some(&vao));
         }
         if let Some(buf) = cache.thermal_center_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.thermal_outer_diameter_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.thermal_inner_diameter_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.thermal_gap_thickness_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.thermal_rotation_buffer {
-            self.gl.delete_buffer(Some(&buf));
+            gl.delete_buffer(Some(&buf));
         }
     }
 
@@ -1424,9 +1409,58 @@ impl Renderer {
         for layer in self.layers.iter_mut().flatten() {
             let old_fbo =
                 std::mem::replace(&mut layer.fbo, Self::create_fbo(&self.gl, width, height)?);
-            self.gl.delete_framebuffer(Some(&old_fbo.framebuffer));
-            self.gl.delete_texture(Some(&old_fbo.texture));
+            Self::delete_fbo(&self.gl, old_fbo);
         }
+
+        Ok(())
+    }
+
+    /// Recreate WebGL-owned resources after the browser restores a lost context.
+    /// Parsed Gerber geometry and stable layer IDs are preserved.
+    pub fn restore_context(&mut self, gl: WebGl2RenderingContext) -> Result<(), JsValue> {
+        let programs = ShaderPrograms::new(&gl)?;
+        let quad_buffer = Self::create_quad_buffer(&gl)?;
+        let (width, height) = Self::get_canvas_size_from_gl(&gl)?;
+        let mut new_fbos = Vec::with_capacity(self.layers.len());
+
+        for layer in &self.layers {
+            if layer.is_some() {
+                let fbo = match Self::create_fbo(&gl, width, height) {
+                    Ok(fbo) => fbo,
+                    Err(error) => {
+                        for fbo in new_fbos.into_iter().flatten() {
+                            Self::delete_fbo(&gl, fbo);
+                        }
+                        gl.delete_buffer(Some(&quad_buffer));
+                        Self::delete_shader_programs(&gl, &programs);
+                        return Err(error);
+                    }
+                };
+                new_fbos.push(Some(fbo));
+            } else {
+                new_fbos.push(None);
+            }
+        }
+
+        let old_gl = self.gl.clone();
+        let old_programs = std::mem::replace(&mut self.programs, programs);
+        let old_quad_buffer = std::mem::replace(&mut self.quad_buffer, quad_buffer);
+
+        for (layer, new_fbo) in self.layers.iter_mut().zip(new_fbos) {
+            if let (Some(layer), Some(new_fbo)) = (layer, new_fbo) {
+                let old_fbo = std::mem::replace(&mut layer.fbo, new_fbo);
+                Self::delete_fbo(&old_gl, old_fbo);
+
+                for cache in std::mem::take(&mut layer.buffer_caches) {
+                    Self::delete_buffer_cache(&old_gl, cache);
+                }
+                layer.buffer_caches = Self::create_buffer_caches(layer.gerber_data.len());
+            }
+        }
+
+        old_gl.delete_buffer(Some(&old_quad_buffer));
+        Self::delete_shader_programs(&old_gl, &old_programs);
+        self.gl = gl;
 
         Ok(())
     }
@@ -1436,11 +1470,6 @@ impl Drop for Renderer {
     fn drop(&mut self) {
         self.clear_all();
         self.gl.delete_buffer(Some(&self.quad_buffer));
-        self.gl
-            .delete_program(Some(&self.programs.triangle.program));
-        self.gl.delete_program(Some(&self.programs.circle.program));
-        self.gl.delete_program(Some(&self.programs.arc.program));
-        self.gl.delete_program(Some(&self.programs.thermal.program));
-        self.gl.delete_program(Some(&self.programs.texture.program));
+        Self::delete_shader_programs(&self.gl, &self.programs);
     }
 }

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -10,7 +10,7 @@ use shader::{
     FLOAT, FUNC_ADD, ONE, ONE_MINUS_SRC_ALPHA, STATIC_DRAW, TRIANGLES, UNSIGNED_INT, ZERO,
 };
 
-use crate::shape::{Boundary, GerberData};
+use crate::shape::{Arcs, Boundary, Circles, GerberData, Thermals, Triangles};
 use js_sys::Float32Array;
 use wasm_bindgen::prelude::*;
 use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlTexture};
@@ -56,6 +56,7 @@ impl Renderer {
     /// Returns the layer index (layer_id)
     pub fn add_layer(&mut self, gerber_data: Vec<GerberData>) -> Result<usize, JsValue> {
         let (width, height) = self.get_canvas_size()?;
+        Self::validate_gerber_data_layers(&gerber_data)?;
 
         // Calculate combined boundary from all polarity sublayers
         let mut min_x = f32::INFINITY;
@@ -69,6 +70,10 @@ impl Renderer {
             max_x = max_x.max(b.max_x);
             min_y = min_y.min(b.min_y);
             max_y = max_y.max(b.max_y);
+        }
+
+        if !min_x.is_finite() || !max_x.is_finite() || !min_y.is_finite() || !max_y.is_finite() {
+            return Err(JsValue::from_str("Layer boundary is not finite"));
         }
 
         let boundary = Boundary::new(min_x, max_x, min_y, max_y);
@@ -122,6 +127,231 @@ impl Renderer {
             self.layer_count += 1;
             Ok(self.layers.len() - 1)
         }
+    }
+
+    fn validate_gerber_data_layers(gerber_data: &[GerberData]) -> Result<(), JsValue> {
+        if gerber_data.is_empty() {
+            return Err(JsValue::from_str("Layer does not contain any sublayers"));
+        }
+
+        for (sublayer_idx, data) in gerber_data.iter().enumerate() {
+            Self::validate_gerber_data(data, sublayer_idx)?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_gerber_data(data: &GerberData, sublayer_idx: usize) -> Result<(), JsValue> {
+        Self::validate_triangle_data(&data.triangles, sublayer_idx)?;
+        Self::validate_circle_data(&data.circles, sublayer_idx)?;
+        Self::validate_arc_data(&data.arcs, sublayer_idx)?;
+        Self::validate_thermal_data(&data.thermals, sublayer_idx)?;
+        Self::validate_finite_value("boundary.min_x", data.boundary.min_x)?;
+        Self::validate_finite_value("boundary.max_x", data.boundary.max_x)?;
+        Self::validate_finite_value("boundary.min_y", data.boundary.min_y)?;
+        Self::validate_finite_value("boundary.max_y", data.boundary.max_y)?;
+        Ok(())
+    }
+
+    fn validate_triangle_data(triangles: &Triangles, sublayer_idx: usize) -> Result<(), JsValue> {
+        if !triangles.vertices.len().is_multiple_of(2) {
+            return Err(JsValue::from_str(&format!(
+                "Sublayer {} triangle vertex buffer has an odd number of coordinates",
+                sublayer_idx
+            )));
+        }
+        if !triangles.indices.len().is_multiple_of(3) {
+            return Err(JsValue::from_str(&format!(
+                "Sublayer {} triangle index buffer is not divisible by 3",
+                sublayer_idx
+            )));
+        }
+
+        let vertex_count = triangles.vertices.len() / 2;
+        Self::validate_len(
+            "triangle hole_x",
+            sublayer_idx,
+            triangles.hole_x.len(),
+            vertex_count,
+        )?;
+        Self::validate_len(
+            "triangle hole_y",
+            sublayer_idx,
+            triangles.hole_y.len(),
+            vertex_count,
+        )?;
+        Self::validate_len(
+            "triangle hole_radius",
+            sublayer_idx,
+            triangles.hole_radius.len(),
+            vertex_count,
+        )?;
+        Self::validate_finite_slice("triangle vertices", &triangles.vertices)?;
+        Self::validate_finite_slice("triangle hole_x", &triangles.hole_x)?;
+        Self::validate_finite_slice("triangle hole_y", &triangles.hole_y)?;
+        Self::validate_non_negative_slice("triangle hole_radius", &triangles.hole_radius)?;
+
+        if triangles
+            .indices
+            .iter()
+            .any(|&index| index as usize >= vertex_count)
+        {
+            return Err(JsValue::from_str(&format!(
+                "Sublayer {} triangle index references a missing vertex",
+                sublayer_idx
+            )));
+        }
+
+        if triangles.indices.len() > i32::MAX as usize {
+            return Err(JsValue::from_str(&format!(
+                "Sublayer {} triangle index count exceeds WebGL draw limits",
+                sublayer_idx
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_circle_data(circles: &Circles, sublayer_idx: usize) -> Result<(), JsValue> {
+        let count = circles.x.len();
+        Self::validate_instance_count("circle", sublayer_idx, count)?;
+        Self::validate_len("circle y", sublayer_idx, circles.y.len(), count)?;
+        Self::validate_len("circle radius", sublayer_idx, circles.radius.len(), count)?;
+        Self::validate_len("circle hole_x", sublayer_idx, circles.hole_x.len(), count)?;
+        Self::validate_len("circle hole_y", sublayer_idx, circles.hole_y.len(), count)?;
+        Self::validate_len(
+            "circle hole_radius",
+            sublayer_idx,
+            circles.hole_radius.len(),
+            count,
+        )?;
+        Self::validate_finite_slice("circle x", &circles.x)?;
+        Self::validate_finite_slice("circle y", &circles.y)?;
+        Self::validate_non_negative_slice("circle radius", &circles.radius)?;
+        Self::validate_finite_slice("circle hole_x", &circles.hole_x)?;
+        Self::validate_finite_slice("circle hole_y", &circles.hole_y)?;
+        Self::validate_non_negative_slice("circle hole_radius", &circles.hole_radius)?;
+        Ok(())
+    }
+
+    fn validate_arc_data(arcs: &Arcs, sublayer_idx: usize) -> Result<(), JsValue> {
+        let count = arcs.x.len();
+        Self::validate_instance_count("arc", sublayer_idx, count)?;
+        Self::validate_len("arc y", sublayer_idx, arcs.y.len(), count)?;
+        Self::validate_len("arc radius", sublayer_idx, arcs.radius.len(), count)?;
+        Self::validate_len(
+            "arc start_angle",
+            sublayer_idx,
+            arcs.start_angle.len(),
+            count,
+        )?;
+        Self::validate_len(
+            "arc sweep_angle",
+            sublayer_idx,
+            arcs.sweep_angle.len(),
+            count,
+        )?;
+        Self::validate_len("arc thickness", sublayer_idx, arcs.thickness.len(), count)?;
+        Self::validate_finite_slice("arc x", &arcs.x)?;
+        Self::validate_finite_slice("arc y", &arcs.y)?;
+        Self::validate_non_negative_slice("arc radius", &arcs.radius)?;
+        Self::validate_finite_slice("arc start_angle", &arcs.start_angle)?;
+        Self::validate_finite_slice("arc sweep_angle", &arcs.sweep_angle)?;
+        Self::validate_non_negative_slice("arc thickness", &arcs.thickness)?;
+        Ok(())
+    }
+
+    fn validate_thermal_data(thermals: &Thermals, sublayer_idx: usize) -> Result<(), JsValue> {
+        let count = thermals.x.len();
+        Self::validate_instance_count("thermal", sublayer_idx, count)?;
+        Self::validate_len("thermal y", sublayer_idx, thermals.y.len(), count)?;
+        Self::validate_len(
+            "thermal outer_diameter",
+            sublayer_idx,
+            thermals.outer_diameter.len(),
+            count,
+        )?;
+        Self::validate_len(
+            "thermal inner_diameter",
+            sublayer_idx,
+            thermals.inner_diameter.len(),
+            count,
+        )?;
+        Self::validate_len(
+            "thermal gap_thickness",
+            sublayer_idx,
+            thermals.gap_thickness.len(),
+            count,
+        )?;
+        Self::validate_len(
+            "thermal rotation",
+            sublayer_idx,
+            thermals.rotation.len(),
+            count,
+        )?;
+        Self::validate_finite_slice("thermal x", &thermals.x)?;
+        Self::validate_finite_slice("thermal y", &thermals.y)?;
+        Self::validate_non_negative_slice("thermal outer_diameter", &thermals.outer_diameter)?;
+        Self::validate_non_negative_slice("thermal inner_diameter", &thermals.inner_diameter)?;
+        Self::validate_non_negative_slice("thermal gap_thickness", &thermals.gap_thickness)?;
+        Self::validate_finite_slice("thermal rotation", &thermals.rotation)?;
+        Ok(())
+    }
+
+    fn validate_len(
+        label: &str,
+        sublayer_idx: usize,
+        actual: usize,
+        expected: usize,
+    ) -> Result<(), JsValue> {
+        if actual != expected {
+            return Err(JsValue::from_str(&format!(
+                "Sublayer {} {} length mismatch: expected {}, got {}",
+                sublayer_idx, label, expected, actual
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_instance_count(
+        label: &str,
+        sublayer_idx: usize,
+        count: usize,
+    ) -> Result<(), JsValue> {
+        if count > i32::MAX as usize {
+            return Err(JsValue::from_str(&format!(
+                "Sublayer {} {} instance count exceeds WebGL draw limits",
+                sublayer_idx, label
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_finite_slice(label: &str, values: &[f32]) -> Result<(), JsValue> {
+        for &value in values {
+            Self::validate_finite_value(label, value)?;
+        }
+        Ok(())
+    }
+
+    fn validate_non_negative_slice(label: &str, values: &[f32]) -> Result<(), JsValue> {
+        for &value in values {
+            Self::validate_finite_value(label, value)?;
+            if value < 0.0 {
+                return Err(JsValue::from_str(&format!(
+                    "{} contains a negative value",
+                    label
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_finite_value(label: &str, value: f32) -> Result<(), JsValue> {
+        if !value.is_finite() {
+            return Err(JsValue::from_str(&format!("{} is not finite", label)));
+        }
+        Ok(())
     }
 
     /// Remove a layer by index
@@ -240,22 +470,48 @@ impl Renderer {
     }
 
     fn create_fbo(gl: &WebGl2RenderingContext, width: u32, height: u32) -> Result<Fbo, JsValue> {
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Cannot create an FBO with zero size"));
+        }
+
+        let max_texture_size = gl
+            .get_parameter(WebGl2RenderingContext::MAX_TEXTURE_SIZE)?
+            .as_f64()
+            .unwrap_or(0.0) as u32;
+        if max_texture_size > 0 && (width > max_texture_size || height > max_texture_size) {
+            return Err(JsValue::from_str(&format!(
+                "Canvas size {}x{} exceeds MAX_TEXTURE_SIZE {}",
+                width, height, max_texture_size
+            )));
+        }
+
         let texture = gl.create_texture().ok_or("Failed to create texture")?;
         gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&texture));
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-            WebGl2RenderingContext::TEXTURE_2D,
-            0,
-            WebGl2RenderingContext::RGBA as i32,
-            width as i32,
-            height as i32,
-            0,
-            WebGl2RenderingContext::RGBA,
-            WebGl2RenderingContext::UNSIGNED_BYTE,
-            None,
-        )?;
+        if let Err(error) = gl
+            .tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                WebGl2RenderingContext::TEXTURE_2D,
+                0,
+                WebGl2RenderingContext::RGBA as i32,
+                width as i32,
+                height as i32,
+                0,
+                WebGl2RenderingContext::RGBA,
+                WebGl2RenderingContext::UNSIGNED_BYTE,
+                None,
+            )
+        {
+            gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
+            gl.delete_texture(Some(&texture));
+            return Err(error);
+        }
         gl.tex_parameteri(
             WebGl2RenderingContext::TEXTURE_2D,
             WebGl2RenderingContext::TEXTURE_MIN_FILTER,
+            WebGl2RenderingContext::LINEAR as i32,
+        );
+        gl.tex_parameteri(
+            WebGl2RenderingContext::TEXTURE_2D,
+            WebGl2RenderingContext::TEXTURE_MAG_FILTER,
             WebGl2RenderingContext::LINEAR as i32,
         );
         gl.tex_parameteri(
@@ -278,6 +534,18 @@ impl Renderer {
             Some(&texture),
             0,
         );
+
+        let status = gl.check_framebuffer_status(WebGl2RenderingContext::FRAMEBUFFER);
+        if status != WebGl2RenderingContext::FRAMEBUFFER_COMPLETE {
+            gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
+            gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+            gl.delete_framebuffer(Some(&framebuffer));
+            gl.delete_texture(Some(&texture));
+            return Err(JsValue::from_str(&format!(
+                "Framebuffer is incomplete: 0x{:x}",
+                status
+            )));
+        }
 
         gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
         gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
@@ -405,6 +673,46 @@ impl Renderer {
         self.camera.zoom_y = zoom_y;
         self.camera.offset_x = offset_x;
         self.camera.offset_y = offset_y;
+    }
+
+    fn validate_render_inputs(
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+    ) -> Result<(), JsValue> {
+        let required_color_len = active_layer_ids
+            .len()
+            .checked_mul(3)
+            .ok_or_else(|| JsValue::from_str("Active layer count is too large"))?;
+        if color_data.len() < required_color_len {
+            return Err(JsValue::from_str(&format!(
+                "Color data is too short: expected at least {}, got {}",
+                required_color_len,
+                color_data.len()
+            )));
+        }
+
+        Self::validate_finite_value("zoom_x", zoom_x)?;
+        Self::validate_finite_value("zoom_y", zoom_y)?;
+        Self::validate_finite_value("offset_x", offset_x)?;
+        Self::validate_finite_value("offset_y", offset_y)?;
+        Self::validate_finite_value("alpha", alpha)?;
+
+        if zoom_x.abs() <= f32::EPSILON || zoom_y.abs() <= f32::EPSILON {
+            return Err(JsValue::from_str("Camera zoom must be non-zero"));
+        }
+
+        if !(0.0..=1.0).contains(&alpha) {
+            return Err(JsValue::from_str("Alpha must be between 0.0 and 1.0"));
+        }
+
+        Self::validate_finite_slice("color data", color_data)?;
+
+        Ok(())
     }
 
     /// Draw a specific FBO texture to the current framebuffer
@@ -978,11 +1286,24 @@ impl Renderer {
         offset_y: f32,
         alpha: f32,
     ) -> Result<(), JsValue> {
+        Self::validate_render_inputs(
+            active_layer_ids,
+            color_data,
+            zoom_x,
+            zoom_y,
+            offset_x,
+            offset_y,
+            alpha,
+        )?;
+
         // Update camera state
         self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
 
         // Get canvas dimensions
         let (width, height) = self.get_canvas_size()?;
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
+        }
 
         // Get transform matrix
         let transform = self.camera.get_transform_matrix(width, height);
@@ -1108,5 +1429,18 @@ impl Renderer {
         }
 
         Ok(())
+    }
+}
+
+impl Drop for Renderer {
+    fn drop(&mut self) {
+        self.clear_all();
+        self.gl.delete_buffer(Some(&self.quad_buffer));
+        self.gl
+            .delete_program(Some(&self.programs.triangle.program));
+        self.gl.delete_program(Some(&self.programs.circle.program));
+        self.gl.delete_program(Some(&self.programs.arc.program));
+        self.gl.delete_program(Some(&self.programs.thermal.program));
+        self.gl.delete_program(Some(&self.programs.texture.program));
     }
 }

--- a/wasm/src/renderer/camera.rs
+++ b/wasm/src/renderer/camera.rs
@@ -26,7 +26,9 @@ impl Camera {
     /// # Returns
     /// A 3x3 transformation matrix as [f32; 9]
     pub fn get_transform_matrix(&self, canvas_width: u32, canvas_height: u32) -> [f32; 9] {
-        let aspect = canvas_width as f32 / canvas_height as f32;
+        let width = canvas_width.max(1) as f32;
+        let height = canvas_height.max(1) as f32;
+        let aspect = width / height;
 
         let (scale_x, scale_y) = if aspect > 1.0 {
             (self.zoom_x / aspect, self.zoom_y)
@@ -71,5 +73,13 @@ mod tests {
         assert_eq!(transform[4], 3.0);
         assert_eq!(transform[6], 0.5);
         assert_eq!(transform[7], -2.0);
+    }
+
+    #[test]
+    fn transform_matrix_handles_zero_canvas_dimensions() {
+        let camera = Camera::default();
+        let transform = camera.get_transform_matrix(0, 0);
+
+        assert!(transform.iter().all(|value| value.is_finite()));
     }
 }

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -217,12 +217,12 @@ uniform lowp vec4 color;
 out lowp vec4 fragColor;
 
 void main() {
-    // Apply rotation to vPosition
+    // Inverse-rotate the fragment point into thermal-local space.
     float cosR = cos(vRotation);
     float sinR = sin(vRotation);
     vec2 rotated = vec2(
-        vPosition.x * cosR - vPosition.y * sinR,
-        vPosition.x * sinR + vPosition.y * cosR
+        vPosition.x * cosR + vPosition.y * sinR,
+        -vPosition.x * sinR + vPosition.y * cosR
     );
 
     float dist = length(rotated);

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -20,13 +20,14 @@ pub const ZERO: u32 = WebGl2RenderingContext::ZERO;
 
 // Shader sources
 pub const TRIANGLE_VERTEX_SHADER: &str = r#"#version 300 es
+precision highp float;
 in vec2 position;
 in vec2 hole_center_instance;
 in float hole_radius_instance;
 uniform mat3 transform;
-out lowp vec2 vPosition;
-out lowp vec2 vHoleCenter;
-out lowp float vHoleRadius;
+out highp vec2 vPosition;
+out highp vec2 vHoleCenter;
+out highp float vHoleRadius;
 void main() {
     vec3 transformed = transform * vec3(position, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
@@ -37,12 +38,12 @@ void main() {
 "#;
 
 pub const TRIANGLE_FRAGMENT_SHADER: &str = r#"#version 300 es
-precision lowp float;
-in lowp vec2 vPosition;
-in lowp vec2 vHoleCenter;
-in lowp float vHoleRadius;
-uniform vec4 color;
-out vec4 fragColor;
+precision highp float;
+in highp vec2 vPosition;
+in highp vec2 vHoleCenter;
+in highp float vHoleRadius;
+uniform lowp vec4 color;
+out lowp vec4 fragColor;
 void main() {
     if (vHoleRadius > 0.0) {
         vec2 diff = vPosition - vHoleCenter;
@@ -53,32 +54,34 @@ void main() {
 "#;
 
 pub const CIRCLE_VERTEX_SHADER: &str = r#"#version 300 es
+precision highp float;
 in vec2 position;
 in vec2 center_instance;
 in float radius_instance;
 in vec2 hole_center_instance;
 in float hole_radius_instance;
 uniform mat3 transform;
-out lowp vec2 vPosition;
-out lowp vec2 vHoleCenter;
-out lowp float vHoleRadius;
+out highp vec2 vPosition;
+out highp vec2 vHoleCenter;
+out highp float vHoleRadius;
 void main() {
     vec2 scaledPos = position * radius_instance + center_instance;
     vec3 transformed = transform * vec3(scaledPos, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
     vPosition = position;
-    vHoleCenter = (hole_center_instance - center_instance) / radius_instance;
-    vHoleRadius = hole_radius_instance / radius_instance;
+    float safeRadius = max(radius_instance, 0.000000001);
+    vHoleCenter = (hole_center_instance - center_instance) / safeRadius;
+    vHoleRadius = hole_radius_instance / safeRadius;
 }
 "#;
 
 pub const CIRCLE_FRAGMENT_SHADER: &str = r#"#version 300 es
-precision lowp float;
-in lowp vec2 vPosition;
-in lowp vec2 vHoleCenter;
-in lowp float vHoleRadius;
-uniform vec4 color;
-out vec4 fragColor;
+precision highp float;
+in highp vec2 vPosition;
+in highp vec2 vHoleCenter;
+in highp float vHoleRadius;
+uniform lowp vec4 color;
+out lowp vec4 fragColor;
 void main() {
     float dist = dot(vPosition, vPosition);
     if (dist > 1.0) discard;
@@ -91,6 +94,7 @@ void main() {
 "#;
 
 pub const ARC_VERTEX_SHADER: &str = r#"#version 300 es
+precision highp float;
 in vec2 position;
 in vec2 center_instance;
 in float radius_instance;
@@ -98,13 +102,13 @@ in float startAngle_instance;
 in float sweepAngle_instance;
 in float thickness_instance;
 uniform mat3 transform;
-out lowp vec2 vPosition;
-out lowp float vRadius;
-out lowp float vStartAngle;
-out lowp float vSweepAngle;
-out lowp float vThickness;
+out highp vec2 vPosition;
+out highp float vRadius;
+out highp float vStartAngle;
+out highp float vSweepAngle;
+out highp float vThickness;
 void main() {
-    float maxRadius = radius_instance + thickness_instance;
+    float maxRadius = max(radius_instance + thickness_instance * 0.5, 0.0);
     vec2 scaledPos = position * maxRadius + center_instance;
     vec3 transformed = transform * vec3(scaledPos, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
@@ -117,14 +121,14 @@ void main() {
 "#;
 
 pub const ARC_FRAGMENT_SHADER: &str = r#"#version 300 es
-precision lowp float;
-in lowp vec2 vPosition;
-in lowp float vRadius;
-in lowp float vStartAngle;
-in lowp float vSweepAngle;
-in lowp float vThickness;
-uniform vec4 color;
-out vec4 fragColor;
+precision highp float;
+in highp vec2 vPosition;
+in highp float vRadius;
+in highp float vStartAngle;
+in highp float vSweepAngle;
+in highp float vThickness;
+uniform lowp vec4 color;
+out lowp vec4 fragColor;
 
 const float PI = 3.14159265359;
 const float TWO_PI = 6.28318530718;
@@ -176,6 +180,7 @@ void main() {
 "#;
 
 pub const THERMAL_VERTEX_SHADER: &str = r#"#version 300 es
+precision highp float;
 in vec2 position;
 in vec2 center_instance;
 in float outer_diameter_instance;
@@ -183,13 +188,13 @@ in float inner_diameter_instance;
 in float gap_thickness_instance;
 in float rotation_instance;
 uniform mat3 transform;
-out lowp vec2 vPosition;
-out lowp float vInnerDiameter;
-out lowp float vOuterDiameter;
-out lowp float vGapThickness;
-out lowp float vRotation;
+out highp vec2 vPosition;
+out highp float vInnerDiameter;
+out highp float vOuterDiameter;
+out highp float vGapThickness;
+out highp float vRotation;
 void main() {
-    float outer_radius = outer_diameter_instance / 2.0;
+    float outer_radius = max(outer_diameter_instance, 0.0) * 0.5;
     vec2 scaledPos = position * outer_radius + center_instance;
     vec3 transformed = transform * vec3(scaledPos, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
@@ -202,14 +207,14 @@ void main() {
 "#;
 
 pub const THERMAL_FRAGMENT_SHADER: &str = r#"#version 300 es
-precision lowp float;
-in lowp vec2 vPosition;
-in lowp float vInnerDiameter;
-in lowp float vOuterDiameter;
-in lowp float vGapThickness;
-in lowp float vRotation;
-uniform vec4 color;
-out vec4 fragColor;
+precision highp float;
+in highp vec2 vPosition;
+in highp float vInnerDiameter;
+in highp float vOuterDiameter;
+in highp float vGapThickness;
+in highp float vRotation;
+uniform lowp vec4 color;
+out lowp vec4 fragColor;
 
 void main() {
     // Apply rotation to vPosition
@@ -221,8 +226,9 @@ void main() {
     );
 
     float dist = length(rotated);
-    float inner_radius = vInnerDiameter / (2.0 * vOuterDiameter);
-    float outer_radius = 0.5;
+    float safeOuterDiameter = max(vOuterDiameter, 0.000000001);
+    float inner_radius = clamp(vInnerDiameter / safeOuterDiameter, 0.0, 1.0);
+    float outer_radius = 1.0;
 
     // Discard if outside outer radius or inside inner radius
     if (dist > outer_radius || dist < inner_radius) {
@@ -230,7 +236,7 @@ void main() {
     }
 
     // Compute half gap thickness in normalized space
-    float half_gap = vGapThickness / (2.0 * vOuterDiameter);
+    float half_gap = max(vGapThickness / safeOuterDiameter, 0.0);
 
     // Discard if in cross-shaped gap region
     if (abs(rotated.x) < half_gap || abs(rotated.y) < half_gap) {
@@ -242,8 +248,9 @@ void main() {
 "#;
 
 pub const TEXTURE_VERTEX_SHADER: &str = r#"#version 300 es
+precision mediump float;
 in vec2 position;
-out vec2 v_uv;
+out mediump vec2 v_uv;
 void main() {
     v_uv = position * 0.5 + 0.5;
     gl_Position = vec4(position, 0.0, 1.0);
@@ -251,11 +258,11 @@ void main() {
 "#;
 
 pub const TEXTURE_FRAGMENT_SHADER: &str = r#"#version 300 es
-precision lowp float;
-in vec2 v_uv;
+precision mediump float;
+in mediump vec2 v_uv;
 uniform sampler2D u_texture;
-uniform vec4 u_color;
-out vec4 fragColor;
+uniform lowp vec4 u_color;
+out lowp vec4 fragColor;
 void main() {
     vec4 texColor = texture(u_texture, v_uv);
     // Pre-multiply alpha: color * alpha for additive blending
@@ -362,11 +369,22 @@ fn compile_program(
     uniforms: &[&str],
 ) -> Result<ShaderProgram, JsValue> {
     let vert_shader = compile_shader(gl, VERTEX_SHADER, vertex_src)?;
-    let frag_shader = compile_shader(gl, FRAGMENT_SHADER, fragment_src)?;
+    let frag_shader = match compile_shader(gl, FRAGMENT_SHADER, fragment_src) {
+        Ok(shader) => shader,
+        Err(error) => {
+            gl.delete_shader(Some(&vert_shader));
+            return Err(error);
+        }
+    };
 
-    let program = gl
-        .create_program()
-        .ok_or_else(|| JsValue::from_str("Unable to create shader program"))?;
+    let program = match gl.create_program() {
+        Some(program) => program,
+        None => {
+            gl.delete_shader(Some(&vert_shader));
+            gl.delete_shader(Some(&frag_shader));
+            return Err(JsValue::from_str("Unable to create shader program"));
+        }
+    };
 
     gl.attach_shader(&program, &vert_shader);
     gl.attach_shader(&program, &frag_shader);
@@ -385,6 +403,9 @@ fn compile_program(
         let error = gl
             .get_program_info_log(&program)
             .unwrap_or_else(|| "Unknown error".to_string());
+        gl.delete_shader(Some(&vert_shader));
+        gl.delete_shader(Some(&frag_shader));
+        gl.delete_program(Some(&program));
         return Err(JsValue::from_str(&format!("Shader link error: {}", error)));
     }
 
@@ -398,9 +419,14 @@ fn compile_program(
 
     let mut uniform_map = HashMap::new();
     for uniform_name in uniforms.iter() {
-        if let Some(loc) = gl.get_uniform_location(&program, uniform_name) {
-            uniform_map.insert(uniform_name.to_string(), loc);
-        }
+        let loc = gl
+            .get_uniform_location(&program, uniform_name)
+            .ok_or_else(|| {
+                let message = format!("Missing shader uniform: {}", uniform_name);
+                gl.delete_program(Some(&program));
+                JsValue::from_str(&message)
+            })?;
+        uniform_map.insert(uniform_name.to_string(), loc);
     }
 
     Ok(ShaderProgram {


### PR DESCRIPTION
## Summary
- validate renderer input geometry, render parameters, FBO completeness, and shader uniform presence
- adjust GLSL precision qualifiers and guard radius/thermal normalization math
- fix thermal shader rotation orientation using inverse local-space rotation
- preserve parsed Gerber geometry in WASM and rebuild only WebGL-owned resources after context restore
- keep JS and WASM layer state synchronized during context loss
- expand top/bottom layer filters for common EAGLE, OrCAD/PADS, KiCad, and generic side-specific Gerber naming conventions
- explicitly release renderer-owned WebGL resources on drop
- add a Ucamco sample-based thermal macro rotation regression test

## Verification
- node --check js/main.js
- glslangValidator on all 10 embedded GLSL shaders
- cargo fmt --manifest-path wasm/Cargo.toml
- cargo clippy --manifest-path wasm/Cargo.toml -- -D warnings
- cargo test --manifest-path wasm/Cargo.toml
- wasm-pack build wasm --target web --out-dir pkg --release
- git diff --check