### PR TITLE
Expand layer side filters

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,7 +47,8 @@ body {
 }
 
 button,
-input {
+input,
+textarea {
   font: inherit;
 }
 
@@ -844,6 +845,15 @@ button {
   gap: 12px;
 }
 
+.filter-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.filter-actions .chip-button {
+  flex: 1;
+}
+
 .filter-field {
   display: grid;
   gap: 6px;
@@ -856,18 +866,22 @@ button {
   line-height: 1.35;
 }
 
-.filter-field input {
+.filter-field textarea {
   width: 100%;
-  min-height: 36px;
-  padding: 0 10px;
+  min-height: 148px;
+  padding: 9px 10px;
   border: 1px solid var(--line);
   border-radius: 7px;
   background: #0f1724;
   color: var(--text);
   outline: none;
+  resize: vertical;
+  line-height: 1.45;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
 }
 
-.filter-field input:focus {
+.filter-field textarea:focus {
   border-color: rgba(94, 234, 212, 0.62);
 }
 

--- a/index.html
+++ b/index.html
@@ -231,26 +231,53 @@
 
             <section class="panel-section" data-panel="filter">
               <div class="filter-form">
+                <div class="filter-actions">
+                  <button class="chip-button" id="filter-save-btn" type="button" title="Save">
+                    <i data-lucide="save"></i>
+                    <span>Save</span>
+                  </button>
+                  <button
+                    class="chip-button"
+                    id="filter-default-btn"
+                    type="button"
+                    title="Default"
+                  >
+                    <i data-lucide="rotate-ccw"></i>
+                    <span>Default</span>
+                  </button>
+                  <button
+                    class="chip-button"
+                    id="filter-restore-btn"
+                    type="button"
+                    title="Restore"
+                  >
+                    <i data-lucide="history"></i>
+                    <span>Restore</span>
+                  </button>
+                </div>
                 <label class="filter-field" for="top-filter-input">
                   <span>Top</span>
-                  <input
-                    type="text"
+                  <textarea
                     id="top-filter-input"
+                    rows="7"
                     autocomplete="off"
                     spellcheck="false"
-                  />
+                    wrap="soft"
+                  ></textarea>
                 </label>
                 <label class="filter-field" for="bottom-filter-input">
                   <span>Bottom</span>
-                  <input
-                    type="text"
+                  <textarea
                     id="bottom-filter-input"
+                    rows="7"
                     autocomplete="off"
                     spellcheck="false"
-                  />
+                    wrap="soft"
+                  ></textarea>
                 </label>
                 <p class="filter-note">
-                  <span>Use comma or space separated text. Prefix with # for case-sensitive matching.</span>
+                  <span>Use spaces, commas, or new lines.</span>
+                  <span>Prefix with # for case-sensitive matching.</span>
                   <span>Example: top #BOT</span>
                 </p>
               </div>

--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,12 @@ const ZIP_MIME_TYPES = new Set([
 ]);
 const GERBER_FILE_EXTENSIONS = new Set([
   ".art",
+  ".bot",
+  ".bsk",
+  ".bsm",
   ".cmp",
+  ".crc",
+  ".crs",
   ".drd",
   ".gbl",
   ".gbo",
@@ -16,14 +21,31 @@ const GERBER_FILE_EXTENSIONS = new Set([
   ".gdo",
   ".ger",
   ".gko",
+  ".gpb",
+  ".gpt",
   ".gtl",
   ".gto",
   ".gtp",
   ".gts",
+  ".pastebot",
+  ".pastetop",
+  ".pho",
+  ".plb",
   ".plc",
+  ".pls",
+  ".plt",
+  ".smb",
+  ".smt",
   ".sol",
+  ".spb",
+  ".spt",
+  ".ssb",
+  ".sst",
   ".stc",
   ".sts",
+  ".top",
+  ".tsk",
+  ".tsm",
 ]);
 
 export class GerberViewer {
@@ -484,22 +506,30 @@ export class GerberViewer {
 
   loadLayerFilters() {
     const defaults = {
-      top: "top -f .gtl .gto .gts .gtp #TOP",
-      bottom: "bottom -b .gbl .gbo .gbs .gbp #BOT",
+      top:
+        "top front -f .gtl .gto .gts .gtp .gpt .cmp .plc .stc .crc .top .smt .sst .spt .tsm .tsk .plt .pastetop f.cu f_cu f.mask f_mask f.silks f_silks f.paste f_paste mt.pho st.pho pt.pho #TOP",
+      bottom:
+        "bottom back -b .gbl .gbo .gbs .gbp .gpb .sol .pls .sts .crs .bot .smb .ssb .spb .bsm .bsk .plb .pastebot b.cu b_cu b.mask b_mask b.silks b_silks b.paste b_paste mb.pho sb.pho pb.pho #BOT",
     };
     const previousDefaults = {
-      top: "top .gtl .gto .gts .gtp #TOP",
-      bottom: "bottom .gbl .gbo .gbs .gbp #BOT",
-      front: "front .gtl .gto .gts .gtp #TOP",
-      back: "back .gbl .gbo .gbs .gbp #BOT",
+      top: [
+        "top -f .gtl .gto .gts .gtp #TOP",
+        "top .gtl .gto .gts .gtp #TOP",
+      ],
+      bottom: [
+        "bottom -b .gbl .gbo .gbs .gbp #BOT",
+        "bottom .gbl .gbo .gbs .gbp #BOT",
+      ],
+      front: ["front .gtl .gto .gts .gtp #TOP"],
+      back: ["back .gbl .gbo .gbs .gbp #BOT"],
     };
 
     try {
       const stored = JSON.parse(
         window.localStorage.getItem(this.layerFilterStorageKey) || "{}",
       );
-      const normalizeFilter = (value, previousDefault, currentDefault) =>
-        value === previousDefault ? currentDefault : value;
+      const normalizeFilter = (value, previousDefaultValues, currentDefault) =>
+        previousDefaultValues.includes(value) ? currentDefault : value;
 
       return {
         top:

--- a/js/main.js
+++ b/js/main.js
@@ -96,6 +96,9 @@ export class GerberViewer {
     this.diagnosticsCount = document.getElementById("diagnostics-count");
     this.topFilterInput = document.getElementById("top-filter-input");
     this.bottomFilterInput = document.getElementById("bottom-filter-input");
+    this.filterSaveBtn = document.getElementById("filter-save-btn");
+    this.filterDefaultBtn = document.getElementById("filter-default-btn");
+    this.filterRestoreBtn = document.getElementById("filter-restore-btn");
     this.panelTabs = Array.from(document.querySelectorAll("[data-panel-tab]"));
     this.panelSections = Array.from(document.querySelectorAll("[data-panel]"));
 
@@ -368,6 +371,18 @@ export class GerberViewer {
       this.updateLayerFilter("bottom", this.bottomFilterInput.value);
     });
 
+    this.filterSaveBtn.addEventListener("click", () => {
+      this.saveLayerFiltersFromInputs();
+    });
+
+    this.filterDefaultBtn.addEventListener("click", () => {
+      this.setLayerFilters(this.getDefaultLayerFilters());
+    });
+
+    this.filterRestoreBtn.addEventListener("click", () => {
+      this.setLayerFilters(this.loadLayerFilters());
+    });
+
     this.notificationCloseBtn.addEventListener("click", () => {
       this.hideNotification();
     });
@@ -504,25 +519,47 @@ export class GerberViewer {
     }
   }
 
-  loadLayerFilters() {
-    const defaults = {
-      top:
-        "top front -f .gtl .gto .gts .gtp .gpt .cmp .plc .stc .crc .top .smt .sst .spt .tsm .tsk .plt .pastetop f.cu f_cu f.mask f_mask f.silks f_silks f.paste f_paste mt.pho st.pho pt.pho #TOP",
-      bottom:
-        "bottom back -b .gbl .gbo .gbs .gbp .gpb .sol .pls .sts .crs .bot .smb .ssb .spb .bsm .bsk .plb .pastebot b.cu b_cu b.mask b_mask b.silks b_silks b.paste b_paste mb.pho sb.pho pb.pho #BOT",
-    };
-    const previousDefaults = {
+  getDefaultLayerFilters() {
+    return {
       top: [
+        "top front -f #TOP",
+        ".gtl .gto .gts .gtp .gpt",
+        ".cmp .plc .stc .crc",
+        ".top .smt .sst .spt .tsm .tsk .plt .pastetop",
+        "f.cu f_cu f.mask f_mask f.silks f_silks f.paste f_paste",
+        "mt.pho st.pho pt.pho",
+      ].join("\n"),
+      bottom: [
+        "bottom back -b #BOT",
+        ".gbl .gbo .gbs .gbp .gpb",
+        ".sol .pls .sts .crs",
+        ".bot .smb .ssb .spb .bsm .bsk .plb .pastebot",
+        "b.cu b_cu b.mask b_mask b.silks b_silks b.paste b_paste",
+        "mb.pho sb.pho pb.pho",
+      ].join("\n"),
+    };
+  }
+
+  getPreviousLayerFilterDefaults() {
+    return {
+      top: [
+        "top front -f .gtl .gto .gts .gtp .gpt .cmp .plc .stc .crc .top .smt .sst .spt .tsm .tsk .plt .pastetop f.cu f_cu f.mask f_mask f.silks f_silks f.paste f_paste mt.pho st.pho pt.pho #TOP",
         "top -f .gtl .gto .gts .gtp #TOP",
         "top .gtl .gto .gts .gtp #TOP",
       ],
       bottom: [
+        "bottom back -b .gbl .gbo .gbs .gbp .gpb .sol .pls .sts .crs .bot .smb .ssb .spb .bsm .bsk .plb .pastebot b.cu b_cu b.mask b_mask b.silks b_silks b.paste b_paste mb.pho sb.pho pb.pho #BOT",
         "bottom -b .gbl .gbo .gbs .gbp #BOT",
         "bottom .gbl .gbo .gbs .gbp #BOT",
       ],
       front: ["front .gtl .gto .gts .gtp #TOP"],
       back: ["back .gbl .gbo .gbs .gbp #BOT"],
     };
+  }
+
+  loadLayerFilters() {
+    const defaults = this.getDefaultLayerFilters();
+    const previousDefaults = this.getPreviousLayerFilterDefaults();
 
     try {
       const stored = JSON.parse(
@@ -558,6 +595,14 @@ export class GerberViewer {
     }
   }
 
+  setLayerFilters(filters) {
+    this.layerFilters = {
+      top: filters.top,
+      bottom: filters.bottom,
+    };
+    this.syncFilterInputs();
+  }
+
   saveLayerFilters() {
     window.localStorage.setItem(
       this.layerFilterStorageKey,
@@ -572,7 +617,20 @@ export class GerberViewer {
 
   updateLayerFilter(kind, value) {
     this.layerFilters[kind] = value;
+  }
+
+  saveLayerFiltersFromInputs() {
+    this.updateLayerFilter("top", this.topFilterInput.value);
+    this.updateLayerFilter("bottom", this.bottomFilterInput.value);
     this.saveLayerFilters();
+    this.showNotification(
+      "Filters saved",
+      "info",
+      NOTIFICATION_DURATION_MS,
+      (messageElement) => {
+        messageElement.textContent = "Layer filter settings were saved.";
+      },
+    );
   }
 
   getFilterTokens(kind) {


### PR DESCRIPTION
## Summary
- expand ZIP Gerber candidate extensions for common EAGLE, OrCAD/PADS, KiCad, and generic side-specific naming conventions
- expand default top/bottom layer filters for copper, solder mask, silkscreen, paste, and pad-master side markers
- keep outline/mechanical extensions out of top/bottom filters
- change filter inputs to multi-line text areas with Save, Default, and Restore controls

## Verification
- node --check js/main.js
- git diff --check