### PR TITLE
Fix Gerber parser edge cases

### DIFF
--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -472,6 +472,7 @@ fn parse_aperture_block(
     let Some(block_code) = parse_aperture_block_code(line) else {
         return;
     };
+    let outer_state = state.clone();
 
     flush_primitives(current_primitives, polarity_layers, state.polarity);
 
@@ -523,11 +524,8 @@ fn parse_aperture_block(
 
     flush_primitives(&mut block_primitives, &mut block_layers, state.polarity);
 
-    state.x = 0.0;
-    state.y = 0.0;
-    state.pen_state = "up".to_string();
-
     apertures.insert(block_code, Aperture::new_block(block_layers));
+    *state = outer_state;
 }
 
 pub fn parse_gerber(data: &str) -> Result<Vec<GerberData>, JsValue> {

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -61,7 +61,9 @@ impl GerberParser {
                 continue;
             }
 
-            if line_ref.starts_with('%') {
+            if line_ref.starts_with("M02") {
+                break;
+            } else if line_ref.starts_with('%') {
                 parse_command(
                     line_ref,
                     &mut i,

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -472,7 +472,6 @@ fn parse_aperture_block(
     let Some(block_code) = parse_aperture_block_code(line) else {
         return;
     };
-    let outer_state = state.clone();
 
     flush_primitives(current_primitives, polarity_layers, state.polarity);
 
@@ -493,6 +492,7 @@ fn parse_aperture_block(
                 break;
             }
 
+            let nested_block_state = parse_aperture_block_code(block_line).map(|_| state.clone());
             parse_command(
                 block_line,
                 i,
@@ -504,6 +504,9 @@ fn parse_aperture_block(
                 &mut block_primitives,
                 &mut block_layers,
             );
+            if let Some(enclosing_state) = nested_block_state {
+                *state = enclosing_state;
+            }
         } else if block_line.starts_with('G')
             || block_line.starts_with('D')
             || block_line.starts_with('X')
@@ -524,8 +527,11 @@ fn parse_aperture_block(
 
     flush_primitives(&mut block_primitives, &mut block_layers, state.polarity);
 
+    state.x = 0.0;
+    state.y = 0.0;
+    state.pen_state = "up".to_string();
+
     apertures.insert(block_code, Aperture::new_block(block_layers));
-    *state = outer_state;
 }
 
 pub fn parse_gerber(data: &str) -> Result<Vec<GerberData>, JsValue> {

--- a/wasm/src/parser/aperture_macro.rs
+++ b/wasm/src/parser/aperture_macro.rs
@@ -271,11 +271,8 @@ fn is_operator_or_bracket(token: Option<&String>) -> bool {
 /// Convert token to value (number or $variable)
 fn token_to_value(token: &str, variables: &HashMap<String, f32>) -> Result<f32, String> {
     if token.starts_with('$') {
-        // Variable reference
-        variables
-            .get(token)
-            .copied()
-            .ok_or_else(|| format!("Undefined variable: {}", token))
+        // Undefined aperture macro variables evaluate to 0.
+        Ok(variables.get(token).copied().unwrap_or(0.0))
     } else {
         // Number
         token

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -980,24 +980,30 @@ pub fn execute_interpolation(
                             let sr_end_x = end_x + offset_x;
                             let sr_end_y = end_y + offset_y;
 
-                            // Flash aperture at start point (no SR since we're already in SR loop)
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_start_x,
-                                sr_start_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            );
-
                             if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
                                 calculate_arc_parameters(
                                     state, sr_start_x, sr_start_y, sr_end_x, sr_end_y, i, j,
                                 )
                             {
                                 let thickness = aperture.radius * 2.0 * state.layer_scale;
+                                let end_angle = start_angle + sweep_angle;
+
+                                let cap_start_x = center_x + radius * start_angle.cos();
+                                let cap_start_y = center_y + radius * start_angle.sin();
+                                let cap_end_x = center_x + radius * end_angle.cos();
+                                let cap_end_y = center_y + radius * end_angle.sin();
+
+                                // Flash aperture at rendered arc start point.
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    cap_start_x,
+                                    cap_start_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
 
                                 // Add Arc primitive
                                 primitives.push(Primitive::Arc {
@@ -1009,19 +1015,40 @@ pub fn execute_interpolation(
                                     thickness,
                                     exposure: 1.0,
                                 });
-                            }
 
-                            // Flash aperture at end point (no SR since we're already in SR loop)
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_end_x,
-                                sr_end_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            );
+                                // Flash aperture at rendered arc end point.
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    cap_end_x,
+                                    cap_end_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
+                            } else {
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    sr_start_x,
+                                    sr_start_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    sr_end_x,
+                                    sr_end_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
+                            }
                         }
                     }
                 }

--- a/wasm/src/parser/state.rs
+++ b/wasm/src/parser/state.rs
@@ -37,6 +37,7 @@ impl Default for FormatSpec {
     }
 }
 
+#[derive(Clone)]
 pub struct ParserState {
     pub x: f32,
     pub y: f32,

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -190,6 +190,25 @@ fn assert_gerber_snapshot(data: &str, expected: &str) {
 }
 
 #[test]
+fn m02_stops_parsing_following_commands() {
+    let layers = parse_gerber(
+        "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+X000000Y000000D03*
+M02*
+X010000Y000000D03*",
+    )
+    .expect("flash should parse");
+
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].circles.x.len(), 1);
+    assert_approx_eq(layers[0].circles.x[0], 0.0);
+}
+
+#[test]
 fn golden_region_d02_output_matches_current_parser() {
     assert_gerber_snapshot(
         "\

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -26,6 +26,24 @@ fn triangle_bounds(vertices: &[f32]) -> (f32, f32, f32, f32) {
     (min_x, max_x, min_y, max_y)
 }
 
+fn has_circle_at(
+    circles: &crate::shape::Circles,
+    expected_x: f32,
+    expected_y: f32,
+    expected_radius: f32,
+) -> bool {
+    circles
+        .x
+        .iter()
+        .zip(&circles.y)
+        .zip(&circles.radius)
+        .any(|((&x, &y), &radius)| {
+            (x - expected_x).abs() < 0.0001
+                && (y - expected_y).abs() < 0.0001
+                && (radius - expected_radius).abs() < 0.0001
+        })
+}
+
 fn test_circle() -> Primitive {
     Primitive::Circle {
         x: 0.0,
@@ -206,6 +224,63 @@ X010000Y000000D03*",
     assert_eq!(layers.len(), 1);
     assert_eq!(layers[0].circles.x.len(), 1);
     assert_approx_eq(layers[0].circles.x[0], 0.0);
+}
+
+#[test]
+fn aperture_macro_omitted_variables_default_to_zero() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%AMSTAR5*
+$3=$1x0.5*
+$4=$3x0.4*
+4,1,10,
+$3x0.0000,$3x1.0000,
+$4x-0.5878,$4x0.8090,
+$3x-0.9511,$3x0.3090,
+$4x-0.9511,$4x-0.3090,
+$3x-0.5878,$3x-0.8090,
+$4x0.0000,$4x-1.0000,
+$3x0.5878,$3x-0.8090,
+$4x0.9511,$4x-0.3090,
+$3x0.9511,$3x0.3090,
+$4x0.5878,$4x0.8090,
+$3x0.0000,$3x1.0000,
+$2*%
+%ADD23STAR5,5.000000*%
+%ADD24STAR5,5.000000X45*%
+%ADD25STAR5,5.000000X90*%
+%ADD26STAR5,5.000000X135*%
+D23*
+X025000000Y025000000D03*
+D24*
+X-025000000Y025000000D03*
+D25*
+X-025000000Y-025000000D03*
+D26*
+X025000000Y-025000000D03*
+M02*",
+    )
+    .expect("macro should parse omitted parameters");
+    let mut occupied_quadrants = [false; 4];
+
+    for triangle in layers[0].triangles.vertices.chunks_exact(6) {
+        let centroid_x = (triangle[0] + triangle[2] + triangle[4]) / 3.0;
+        let centroid_y = (triangle[1] + triangle[3] + triangle[5]) / 3.0;
+
+        if centroid_x > 10.0 && centroid_y > 10.0 {
+            occupied_quadrants[0] = true;
+        } else if centroid_x < -10.0 && centroid_y > 10.0 {
+            occupied_quadrants[1] = true;
+        } else if centroid_x < -10.0 && centroid_y < -10.0 {
+            occupied_quadrants[2] = true;
+        } else if centroid_x > 10.0 && centroid_y < -10.0 {
+            occupied_quadrants[3] = true;
+        }
+    }
+
+    assert_eq!(occupied_quadrants, [true, true, true, true]);
 }
 
 #[test]
@@ -767,6 +842,65 @@ M02*";
     assert_eq!(circles.x.len(), 1);
     assert_approx_eq(circles.x[0], 13.0);
     assert_approx_eq(circles.y[0], 0.0);
+}
+
+#[test]
+fn nested_aperture_block_restores_enclosing_graphic_state() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+%ADD11C,0.5*%
+%ABD20*%
+D11*
+G02*
+G75*
+X0000000Y2500000D02*
+%ABD21*%
+D10*
+G01*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+%AB*%
+X2500000Y0I0J-2500000D01*
+%AB*%
+D20*
+X0Y0D03*
+M02*",
+    )
+    .expect("nested aperture block should parse");
+    let arcs = &layers[0].arcs;
+    let circles = &layers[0].circles;
+
+    assert_eq!(arcs.x.len(), 1);
+    assert_approx_eq(arcs.x[0], 0.0);
+    assert_approx_eq(arcs.y[0], 0.0);
+    assert_approx_eq(arcs.radius[0], 2.5);
+    assert!(has_circle_at(circles, 0.0, 2.5, 0.25));
+    assert!(has_circle_at(circles, 2.5, 0.0, 0.25));
+}
+
+#[test]
+fn arc_caps_use_rendered_arc_endpoints() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+G03*
+G75*
+X0000000Y-2500000D02*
+X-5000000Y0I0J2500000D01*
+M02*",
+    )
+    .expect("arc should parse");
+    let circles = &layers[0].circles;
+
+    assert!(has_circle_at(circles, 0.0, -2.5, 0.5));
+    assert!(has_circle_at(circles, -2.5, 0.0, 0.5));
+    assert!(!has_circle_at(circles, -5.0, 0.0, 0.5));
 }
 
 #[test]

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -882,6 +882,28 @@ M02*",
 }
 
 #[test]
+fn aperture_block_definition_preserves_ending_graphic_state() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+%ADD11C,2.0*%
+%ABD20*%
+D10*
+X0000000Y0000000D03*
+D11*
+%AB*%
+X1000000Y0000000D03*
+M02*",
+    )
+    .expect("aperture block should parse");
+    let circles = &layers[0].circles;
+
+    assert!(has_circle_at(circles, 1.0, 0.0, 1.0));
+}
+
+#[test]
 fn arc_caps_use_rendered_arc_endpoints() {
     let layers = parse_gerber(
         "\


### PR DESCRIPTION
## Summary
- stop parsing at M02 end-of-file
- default omitted aperture macro variables to 0
- restore enclosing parser state after nested aperture block definitions
- place arc caps on the rendered arc endpoints

## Tests
- cargo test
- cargo check --target wasm32-unknown-unknown
- cargo clippy --all-targets -- -D warnings
- ./scripts/vercel-build.sh