### PR TITLE
[codex] Improve high-resolution screenshot export

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,6 +17,8 @@
   --panel-height: 420px;
   --panel-overlay-width: var(--panel-width);
   --panel-overlay-height: var(--panel-height);
+  --canvas-reserved-width: var(--panel-width);
+  --canvas-reserved-height: var(--panel-height);
   --panel-collapsed-width: 76px;
   --panel-collapsed-height: 102px;
   --panel-snap-threshold: 50px;
@@ -48,6 +50,7 @@ body {
 
 button,
 input,
+select,
 textarea {
   font: inherit;
 }
@@ -280,7 +283,7 @@ button {
 
 .viewer-surface canvas {
   display: block;
-  width: 100%;
+  width: calc(100% - var(--canvas-reserved-width));
   height: 100%;
   cursor: grab;
   touch-action: none;
@@ -297,8 +300,9 @@ button {
 
 .app-shell .measurement-overlay {
   position: absolute;
-  inset: 0;
-  width: 100%;
+  left: 0;
+  top: 0;
+  width: calc(100% - var(--canvas-reserved-width));
   height: 100%;
   pointer-events: none;
   z-index: 4;
@@ -824,6 +828,158 @@ button {
   background: var(--surface-2);
 }
 
+.screenshot-dialog {
+  width: min(380px, calc(100vw - 24px));
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-dialog::backdrop {
+  background: rgba(3, 7, 18, 0.62);
+  backdrop-filter: blur(4px);
+}
+
+.screenshot-form {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+}
+
+.screenshot-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.screenshot-dialog-header strong {
+  font-size: 14px;
+}
+
+.screenshot-option-row {
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface-2);
+}
+
+.screenshot-option-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.screenshot-option-row strong {
+  font-size: 13px;
+}
+
+.screenshot-option-row small,
+.screenshot-progress {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.screenshot-option-row input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+.screenshot-option-row select {
+  width: 86px;
+  flex: 0 0 86px;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #0f1724;
+  color: var(--text);
+  outline: none;
+}
+
+.screenshot-option-row select:focus {
+  border-color: rgba(94, 234, 212, 0.62);
+}
+
+.screenshot-progress {
+  display: none;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(94, 234, 212, 0.34);
+  border-radius: 7px;
+  background: rgba(20, 49, 58, 0.46);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.screenshot-form.is-exporting .screenshot-progress {
+  display: grid;
+}
+
+.screenshot-progress-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.screenshot-progress-header span {
+  min-width: 0;
+  color: var(--text);
+}
+
+.screenshot-progress-header strong {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.screenshot-progress-bar {
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+  appearance: none;
+  border: 1px solid rgba(94, 234, 212, 0.28);
+  border-radius: 999px;
+  background: rgba(15, 23, 36, 0.82);
+}
+
+.screenshot-progress-bar::-webkit-progress-bar {
+  border-radius: 999px;
+  background: rgba(15, 23, 36, 0.82);
+}
+
+.screenshot-progress-bar::-webkit-progress-value {
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.screenshot-progress-bar::-moz-progress-bar {
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.screenshot-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.screenshot-actions .chip-button,
+.screenshot-actions .tool-button {
+  flex: 0 0 auto;
+  min-width: 82px;
+}
+
 .filter-form {
   padding: 12px;
 }
@@ -983,6 +1139,12 @@ button {
 
   .workspace {
     overflow: hidden;
+  }
+
+  .viewer-surface canvas,
+  .app-shell .measurement-overlay {
+    width: 100%;
+    height: calc(100% - var(--canvas-reserved-height));
   }
 
   .workspace:has(.side-panel:not(.collapsed)) .empty-state {

--- a/index.html
+++ b/index.html
@@ -297,6 +297,68 @@
         </aside>
       </main>
 
+      <dialog id="screenshot-dialog" class="screenshot-dialog">
+        <form id="screenshot-form" class="screenshot-form">
+          <div class="screenshot-dialog-header">
+            <strong>Export PNG</strong>
+            <button
+              type="button"
+              class="icon-button"
+              id="screenshot-cancel-btn"
+              aria-label="Close screenshot options"
+            >
+              <i data-lucide="x"></i>
+            </button>
+          </div>
+
+          <label class="screenshot-option-row" for="screenshot-background-toggle">
+            <span class="screenshot-option-copy">
+              <strong>Background</strong>
+              <small>Include current canvas color</small>
+            </span>
+            <input type="checkbox" id="screenshot-background-toggle" />
+          </label>
+
+          <label class="screenshot-option-row" for="screenshot-scale-select">
+            <span class="screenshot-option-copy">
+              <strong>Resolution</strong>
+              <small id="screenshot-resolution">0 x 0 px</small>
+            </span>
+            <select id="screenshot-scale-select">
+              <option value="1">1x</option>
+              <option value="2">2x</option>
+              <option value="4">4x</option>
+              <option value="8">8x</option>
+              <option value="16">16x</option>
+              <option value="32">32x</option>
+              <option value="64">64x</option>
+            </select>
+          </label>
+
+          <div class="screenshot-progress" id="screenshot-progress" aria-live="polite">
+            <div class="screenshot-progress-header">
+              <span id="screenshot-progress-label">Exporting</span>
+              <strong id="screenshot-progress-value">0%</strong>
+            </div>
+            <progress
+              class="screenshot-progress-bar"
+              id="screenshot-progress-bar"
+              value="0"
+              max="100"
+            ></progress>
+          </div>
+
+          <div class="screenshot-actions">
+            <button type="button" class="chip-button" id="screenshot-dismiss-btn">
+              Cancel
+            </button>
+            <button type="submit" class="tool-button primary" id="screenshot-export-btn">
+              Export
+            </button>
+          </div>
+        </form>
+      </dialog>
+
       <div
         id="file-size-warning"
         class="notification"

--- a/js/main.js
+++ b/js/main.js
@@ -1047,14 +1047,17 @@ export class GerberViewer {
     const scale = this.getSelectedScreenshotScale();
     const { width, height } = this.getScreenshotDimensions(scale);
     const maxDimension = this.getMaxScreenshotDimension();
-    const shouldStream = this.shouldStreamScreenshot(scale);
-    const exceedsLimit =
-      !shouldStream && (width > maxDimension || height > maxDimension);
+    const limitMessage = this.getScreenshotExportLimitMessage(
+      width,
+      height,
+      maxDimension,
+      scale,
+    );
 
-    this.screenshotResolution.textContent = exceedsLimit
-      ? `Estimated ${width} x ${height} px · exceeds ${maxDimension}px GPU limit`
+    this.screenshotResolution.textContent = limitMessage
+      ? `Estimated ${width} x ${height} px · ${limitMessage}`
       : `Estimated ${width} x ${height} px`;
-    this.screenshotExportBtn.disabled = exceedsLimit;
+    this.screenshotExportBtn.disabled = Boolean(limitMessage);
   }
 
   shouldTileScreenshot(scale) {
@@ -1067,6 +1070,19 @@ export class GerberViewer {
 
   supportsStreamingScreenshot() {
     return typeof CompressionStream === "function";
+  }
+
+  getScreenshotExportLimitMessage(width, height, maxDimension, scale) {
+    const exceedsGpuLimit = width > maxDimension || height > maxDimension;
+    if (!exceedsGpuLimit || this.shouldStreamScreenshot(scale)) {
+      return "";
+    }
+
+    if (this.shouldTileScreenshot(scale) && !this.supportsStreamingScreenshot()) {
+      return "streamed PNG export is unavailable in this browser; try a lower resolution";
+    }
+
+    return `exceeds ${maxDimension}px GPU limit`;
   }
 
   captureScreenshotRenderState(rect = this.canvas.getBoundingClientRect()) {
@@ -1109,12 +1125,19 @@ export class GerberViewer {
     const isTiled = this.shouldTileScreenshot(exportScale);
     const shouldStream = this.shouldStreamScreenshot(exportScale);
     const renderState = this.captureScreenshotRenderState(rect);
-    if (
-      !shouldStream &&
-      (exportWidth > maxDimension || exportHeight > maxDimension)
-    ) {
+    const limitMessage = this.getScreenshotExportLimitMessage(
+      exportWidth,
+      exportHeight,
+      maxDimension,
+      exportScale,
+    );
+    if (limitMessage) {
+      const detail =
+        this.shouldTileScreenshot(exportScale) && !this.supportsStreamingScreenshot()
+          ? "This browser does not support streamed PNG export. Try a lower resolution or a browser with CompressionStream support."
+          : `The requested image exceeds this GPU's ${maxDimension}px render limit.`;
       this.showError(
-        `Screenshot is too large for this GPU (${exportWidth} x ${exportHeight}px).`,
+        `Screenshot is too large to export at ${exportWidth} x ${exportHeight}px. ${detail}`,
       );
       return false;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -340,6 +340,8 @@ export class GerberViewer {
     });
     this.screenshotForm.addEventListener("submit", (e) => {
       e.preventDefault();
+      if (this.isExportingScreenshot) return;
+
       const options = {
         includeBackground: this.screenshotBackgroundToggle.checked,
         scale: this.getSelectedScreenshotScale(),
@@ -1057,7 +1059,8 @@ export class GerberViewer {
     this.screenshotResolution.textContent = limitMessage
       ? `Estimated ${width} x ${height} px · ${limitMessage}`
       : `Estimated ${width} x ${height} px`;
-    this.screenshotExportBtn.disabled = Boolean(limitMessage);
+    this.screenshotExportBtn.disabled =
+      this.isExportingScreenshot || Boolean(limitMessage);
   }
 
   shouldTileScreenshot(scale) {

--- a/js/main.js
+++ b/js/main.js
@@ -64,6 +64,24 @@ export class GerberViewer {
     this.flipVerticalBtn = document.getElementById("flip-vertical-btn");
     this.canvasThemeToggle = document.getElementById("canvas-theme-toggle");
     this.screenshotBtn = document.getElementById("screenshot-btn");
+    this.screenshotDialog = document.getElementById("screenshot-dialog");
+    this.screenshotForm = document.getElementById("screenshot-form");
+    this.screenshotBackgroundToggle = document.getElementById(
+      "screenshot-background-toggle",
+    );
+    this.screenshotScaleSelect = document.getElementById("screenshot-scale-select");
+    this.screenshotResolution = document.getElementById("screenshot-resolution");
+    this.screenshotProgress = document.getElementById("screenshot-progress");
+    this.screenshotProgressLabel = document.getElementById(
+      "screenshot-progress-label",
+    );
+    this.screenshotProgressValue = document.getElementById(
+      "screenshot-progress-value",
+    );
+    this.screenshotProgressBar = document.getElementById("screenshot-progress-bar");
+    this.screenshotCancelBtn = document.getElementById("screenshot-cancel-btn");
+    this.screenshotDismissBtn = document.getElementById("screenshot-dismiss-btn");
+    this.screenshotExportBtn = document.getElementById("screenshot-export-btn");
     this.rulerToggleBtn = document.getElementById("ruler-toggle-btn");
     this.rulerClearBtn = document.getElementById("ruler-clear-btn");
     this.measurementUnitToggle = document.getElementById("measurement-unit-toggle");
@@ -154,6 +172,7 @@ export class GerberViewer {
     this.drawerCurrentHeight = 420;
     this.drawerPendingWidth = null;
     this.drawerPendingHeight = null;
+    this.drawerResizeViewState = null;
     this.drawerMinWidth = 200;
     this.drawerMaxWidth = 600;
     this.drawerMinHeight = 300;
@@ -185,6 +204,9 @@ export class GerberViewer {
     this.rulerStartPoint = null;
     this.rulerHoverPoint = null;
     this.measurements = [];
+    this.measurementOverlayNodes = [];
+    this.measurementOverlayCursor = 0;
+    this.isExportingScreenshot = false;
     this.measurementUnit = "mm";
     this.layerFilterStorageKey = "wasm-gerber-viewer.layerFilters";
     this.layerFilters = this.loadLayerFilters();
@@ -203,6 +225,9 @@ export class GerberViewer {
     window.addEventListener("resize", () => {
       this.resizeCanvas();
       this.updateDrawerToggleState();
+      if (this.screenshotDialog.open) {
+        this.updateScreenshotResolutionPreview();
+      }
     });
 
     this.setupEventListeners();
@@ -233,9 +258,11 @@ export class GerberViewer {
     this.wasmProcessor.init(this.gl);
   }
 
-  resizeCanvas({ allowProcessorResize = false } = {}) {
-    if (this.drawer && !this.drawer.classList.contains("collapsed")) {
-      if (this.isMobileDrawerLayout()) {
+  resizeCanvas({ allowProcessorResize = false, preserveViewState = null } = {}) {
+    if (this.drawer) {
+      if (this.drawer.classList.contains("collapsed")) {
+        this.updateCanvasReservationForDrawerState();
+      } else if (this.isMobileDrawerLayout()) {
         this.setDrawerHeight(this.drawerCurrentHeight);
       } else {
         this.setDrawerWidth(this.drawerCurrentWidth);
@@ -246,6 +273,7 @@ export class GerberViewer {
     const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
     this.canvas.width = Math.max(1, Math.round(rect.width * pixelRatio));
     this.canvas.height = Math.max(1, Math.round(rect.height * pixelRatio));
+    this.restoreCanvasViewState(preserveViewState);
 
     const canResizeProcessor =
       this.wasmProcessor &&
@@ -307,7 +335,39 @@ export class GerberViewer {
     });
 
     this.screenshotBtn.addEventListener("click", () => {
-      this.exportScreenshot();
+      this.openScreenshotDialog();
+    });
+    this.screenshotForm.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const options = {
+        includeBackground: this.screenshotBackgroundToggle.checked,
+        scale: this.getSelectedScreenshotScale(),
+      };
+      const isTiled = this.shouldTileScreenshot(options.scale);
+      if (!isTiled) {
+        this.closeScreenshotDialog();
+      }
+      void this.exportScreenshot(options).finally(() => {
+        if (isTiled) {
+          this.closeScreenshotDialog();
+        }
+      });
+    });
+    this.screenshotScaleSelect.addEventListener("change", () => {
+      this.updateScreenshotResolutionPreview();
+    });
+    this.screenshotCancelBtn.addEventListener("click", () => {
+      if (this.isExportingScreenshot) return;
+      this.closeScreenshotDialog();
+    });
+    this.screenshotDismissBtn.addEventListener("click", () => {
+      if (this.isExportingScreenshot) return;
+      this.closeScreenshotDialog();
+    });
+    this.screenshotDialog.addEventListener("click", (e) => {
+      if (e.target === this.screenshotDialog && !this.isExportingScreenshot) {
+        this.closeScreenshotDialog();
+      }
     });
 
     this.rulerToggleBtn.addEventListener("click", () => {
@@ -432,7 +492,9 @@ export class GerberViewer {
     if (this.isMobileDrawerLayout()) {
       this.drawer.classList.add("collapsed");
     }
+    this.updateCanvasReservationForDrawerState();
     this.updateDrawerToggleState();
+    this.resizeCanvas();
     this.drawerToggleBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       e.preventDefault();
@@ -484,6 +546,7 @@ export class GerberViewer {
       bounds: layer.bounds ? { ...layer.bounds } : null,
       visible: layer.visible,
       color: [...layer.color],
+      sourceContent: layer.sourceContent,
     }));
 
     this.isRestoringWebGlContext = true;
@@ -688,13 +751,28 @@ export class GerberViewer {
       return "100%";
     }
 
-    const fitZoom = this.getFitViewZoom() ?? this.fitViewZoom;
+    const fitZoom = this.getZoomReadoutBaseZoom();
     if (!Number.isFinite(fitZoom) || fitZoom <= 0) {
       return "100%";
     }
 
     const zoomPercent = (this.camera.zoom / fitZoom) * 100;
     return `${Math.trunc(zoomPercent)}%`;
+  }
+
+  getZoomReadoutBaseZoom() {
+    return Number.isFinite(this.fitViewZoom) && this.fitViewZoom > 0
+      ? this.fitViewZoom
+      : this.getFitViewZoom();
+  }
+
+  getZoomReadoutRatio() {
+    const fitZoom = this.getZoomReadoutBaseZoom();
+    if (!Number.isFinite(fitZoom) || fitZoom <= 0) {
+      return null;
+    }
+
+    return this.camera.zoom / fitZoom;
   }
 
   formatCombinedBounds() {
@@ -821,6 +899,47 @@ export class GerberViewer {
     };
   }
 
+  captureCanvasViewState() {
+    const rect = this.canvas.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0 || this.camera.zoom === 0) {
+      return null;
+    }
+
+    const anchorWorld = this.canvasPointToWorld(rect.left, rect.top);
+    if (!anchorWorld) return null;
+
+    return {
+      anchorWorld,
+      pixelsPerWorld: (Math.min(rect.width, rect.height) * this.camera.zoom) / 2,
+      zoomReadoutRatio: this.getZoomReadoutRatio(),
+    };
+  }
+
+  restoreCanvasViewState(viewState) {
+    if (!viewState || !Number.isFinite(viewState.pixelsPerWorld)) return;
+
+    const rect = this.canvas.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+
+    const nextZoom = this.clampZoom(
+      (viewState.pixelsPerWorld * 2) / Math.min(rect.width, rect.height),
+    );
+    this.camera.zoom = nextZoom;
+
+    const anchorCorrected = this.canvasLocalPointToCorrected(0, 0, rect);
+    this.camera.offsetX =
+      anchorCorrected.x - viewState.anchorWorld.x * this.getViewScaleX();
+    this.camera.offsetY =
+      anchorCorrected.y - viewState.anchorWorld.y * this.getViewScaleY();
+
+    if (
+      Number.isFinite(viewState.zoomReadoutRatio) &&
+      viewState.zoomReadoutRatio > 0
+    ) {
+      this.fitViewZoom = this.camera.zoom / viewState.zoomReadoutRatio;
+    }
+  }
+
   updateViewFlipControls() {
     this.flipHorizontalBtn.setAttribute(
       "aria-pressed",
@@ -854,41 +973,555 @@ export class GerberViewer {
     this.refreshIcons();
   }
 
-  async exportScreenshot() {
-    this.render();
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-
+  openScreenshotDialog() {
     const rect = this.canvas.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) {
       this.showError("Cannot export screenshot because the canvas has no size.");
       return;
     }
 
-    const scale = Math.min(window.devicePixelRatio || 1, 2);
-    const output = document.createElement("canvas");
-    output.width = Math.max(1, Math.round(rect.width * scale));
-    output.height = Math.max(1, Math.round(rect.height * scale));
+    this.updateScreenshotResolutionPreview();
+    if (!this.screenshotDialog.open) {
+      this.screenshotDialog.showModal();
+    }
+  }
 
-    const context = output.getContext("2d");
-    context.scale(scale, scale);
-    context.fillStyle = this.isCanvasLight ? "#f8fafc" : "#020617";
-    context.fillRect(0, 0, rect.width, rect.height);
-    context.drawImage(this.canvas, 0, 0, rect.width, rect.height);
-    this.drawMeasurementsOnContext(context);
+  closeScreenshotDialog() {
+    if (this.screenshotDialog.open) {
+      this.screenshotDialog.close();
+    }
+  }
 
-    output.toBlob((blob) => {
-      if (!blob) {
-        this.showError("Failed to export screenshot.");
-        return;
+  setScreenshotExportBusy(isBusy) {
+    this.screenshotForm.classList.toggle("is-exporting", isBusy);
+    this.screenshotBackgroundToggle.disabled = isBusy;
+    this.screenshotScaleSelect.disabled = isBusy;
+    this.screenshotCancelBtn.disabled = isBusy;
+    this.screenshotDismissBtn.disabled = isBusy;
+    this.screenshotExportBtn.disabled = isBusy;
+    this.screenshotExportBtn.textContent = isBusy ? "Exporting" : "Export";
+
+    if (isBusy) {
+      this.setScreenshotProgress(0, "Rendering");
+    } else {
+      this.setScreenshotProgress(0, "Exporting");
+    }
+  }
+
+  setScreenshotProgress(progress, label = null) {
+    const clampedProgress = Math.min(1, Math.max(0, progress));
+    const percent = Math.trunc(clampedProgress * 100);
+
+    if (label !== null) {
+      this.screenshotProgressLabel.textContent = label;
+    }
+    this.screenshotProgressValue.textContent = `${percent}%`;
+    this.screenshotProgressBar.value = percent;
+  }
+
+  getSelectedScreenshotScale() {
+    const scale = Number.parseFloat(this.screenshotScaleSelect.value);
+    return Number.isFinite(scale) && scale > 0 ? scale : 1;
+  }
+
+  getScreenshotDimensions(scale = this.getSelectedScreenshotScale()) {
+    const rect = this.canvas.getBoundingClientRect();
+    return {
+      width: Math.max(1, Math.round(rect.width * scale)),
+      height: Math.max(1, Math.round(rect.height * scale)),
+    };
+  }
+
+  getMaxScreenshotDimension() {
+    if (!this.gl) return Number.POSITIVE_INFINITY;
+
+    const maxTextureSize = this.gl.getParameter(this.gl.MAX_TEXTURE_SIZE);
+    const maxRenderbufferSize = this.gl.getParameter(
+      this.gl.MAX_RENDERBUFFER_SIZE,
+    );
+    return Math.min(maxTextureSize, maxRenderbufferSize);
+  }
+
+  updateScreenshotResolutionPreview() {
+    const scale = this.getSelectedScreenshotScale();
+    const { width, height } = this.getScreenshotDimensions(scale);
+    const maxDimension = this.getMaxScreenshotDimension();
+    const isTiled = this.shouldTileScreenshot(scale);
+    const exceedsLimit = !isTiled && (width > maxDimension || height > maxDimension);
+
+    this.screenshotResolution.textContent = exceedsLimit
+      ? `Estimated ${width} x ${height} px · exceeds ${maxDimension}px GPU limit`
+      : `Estimated ${width} x ${height} px`;
+    this.screenshotExportBtn.disabled = exceedsLimit;
+  }
+
+  shouldTileScreenshot(scale) {
+    return scale >= 8;
+  }
+
+  shouldStreamScreenshot(scale) {
+    return scale >= 8;
+  }
+
+  async exportScreenshot({ includeBackground = false, scale = 1 } = {}) {
+    if (this.isExportingScreenshot) return false;
+
+    if (
+      !this.wasmProcessor ||
+      this.isWebGlContextLost ||
+      this.isRestoringWebGlContext
+    ) {
+      this.showError("Cannot export screenshot while WebGL is unavailable.");
+      return false;
+    }
+
+    const rect = this.canvas.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) {
+      this.showError("Cannot export screenshot because the canvas has no size.");
+      return false;
+    }
+
+    const exportScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+    const exportWidth = Math.max(1, Math.round(rect.width * exportScale));
+    const exportHeight = Math.max(1, Math.round(rect.height * exportScale));
+    const maxDimension = this.getMaxScreenshotDimension();
+    const isTiled = this.shouldTileScreenshot(exportScale);
+    const shouldStream = this.shouldStreamScreenshot(exportScale);
+    if (!isTiled && (exportWidth > maxDimension || exportHeight > maxDimension)) {
+      this.showError(
+        `Screenshot is too large for this GPU (${exportWidth} x ${exportHeight}px).`,
+      );
+      return false;
+    }
+
+    this.isExportingScreenshot = true;
+    this.screenshotBtn.disabled = true;
+    this.setScreenshotExportBusy(isTiled);
+    let screenshotRenderer = null;
+
+    try {
+      screenshotRenderer = this.createScreenshotRenderer();
+      let blob = null;
+
+      if (shouldStream) {
+        blob = await this.renderStreamingScreenshot(
+          screenshotRenderer,
+          exportWidth,
+          exportHeight,
+          exportScale,
+          includeBackground,
+        );
+      } else {
+        const output = document.createElement("canvas");
+        output.width = exportWidth;
+        output.height = exportHeight;
+
+        const context = output.getContext("2d");
+        if (!context) {
+          throw new Error(
+            `Cannot create ${exportWidth} x ${exportHeight}px screenshot canvas. Try a lower resolution.`,
+          );
+        }
+
+        if (includeBackground) {
+          context.fillStyle = this.isCanvasLight ? "#f8fafc" : "#020617";
+          context.fillRect(0, 0, exportWidth, exportHeight);
+        } else {
+          context.clearRect(0, 0, exportWidth, exportHeight);
+        }
+
+        this.renderSingleScreenshotTile(
+          screenshotRenderer,
+          exportWidth,
+          exportHeight,
+          0,
+          0,
+          exportWidth,
+          exportHeight,
+        );
+        context.drawImage(
+          screenshotRenderer.canvas,
+          0,
+          0,
+          exportWidth,
+          exportHeight,
+        );
+
+        context.save();
+        context.scale(exportScale, exportScale);
+        this.drawMeasurementsOnContext(context);
+        context.restore();
+
+        blob = await new Promise((resolve) => {
+          output.toBlob(resolve, "image/png");
+        });
       }
 
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `gerber-viewer-${this.getTimestampForFileName()}.png`;
-      link.click();
-      URL.revokeObjectURL(url);
-    }, "image/png");
+      if (!blob) {
+        throw new Error(
+          `Failed to encode ${exportWidth} x ${exportHeight}px PNG. The requested image may exceed this browser's canvas limit.`,
+        );
+      }
+
+      this.downloadScreenshotBlob(blob);
+      return true;
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      console.error("[Export] Failed to export screenshot:", error);
+      this.showError(`Failed to export screenshot: ${message}`);
+      return false;
+    } finally {
+      this.disposeScreenshotRenderer(screenshotRenderer);
+      this.isExportingScreenshot = false;
+      this.screenshotBtn.disabled = false;
+      this.setScreenshotExportBusy(false);
+      this.updateScreenshotResolutionPreview();
+    }
+  }
+
+  createScreenshotRenderer() {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+    if (!gl) {
+      throw new Error("WebGL2 is unavailable for screenshot export.");
+    }
+
+    const processor = new this.wasmModule.GerberProcessor();
+    processor.init(gl);
+
+    const activeLayerIds = [];
+    const colorData = [];
+    for (const layer of this.layers) {
+      if (typeof layer.sourceContent !== "string") {
+        throw new Error("Reload files before using high-resolution screenshot export.");
+      }
+
+      const layerId = processor.add_layer(layer.sourceContent);
+      if (layer.visible) {
+        activeLayerIds.push(layerId);
+        colorData.push(layer.color[0], layer.color[1], layer.color[2]);
+      }
+    }
+
+    return {
+      canvas,
+      gl,
+      processor,
+      activeLayerIds: new Uint32Array(activeLayerIds),
+      colorData: new Float32Array(colorData),
+    };
+  }
+
+  disposeScreenshotRenderer(screenshotRenderer) {
+    if (!screenshotRenderer) return;
+
+    try {
+      screenshotRenderer.processor.clear();
+    } catch (error) {
+      console.warn("[Export] Failed to dispose screenshot renderer:", error);
+    }
+
+    screenshotRenderer.canvas.width = 0;
+    screenshotRenderer.canvas.height = 0;
+    if (screenshotRenderer.tileCanvas) {
+      screenshotRenderer.tileCanvas.width = 0;
+      screenshotRenderer.tileCanvas.height = 0;
+    }
+  }
+
+  async renderStreamingScreenshot(
+    screenshotRenderer,
+    exportWidth,
+    exportHeight,
+    exportScale,
+    includeBackground,
+  ) {
+    if (typeof CompressionStream !== "function") {
+      throw new Error(
+        "This browser does not support streamed PNG export. Try a lower resolution.",
+      );
+    }
+
+    const tileSize = this.getScreenshotStreamTileDimensions();
+    const totalTiles =
+      Math.ceil(exportWidth / tileSize.width) *
+      Math.ceil(exportHeight / tileSize.height);
+    const rowStride = 1 + exportWidth * 4;
+    const pngParts = [
+      this.createPngSignature(),
+      this.createPngHeaderChunk(exportWidth, exportHeight),
+    ];
+    const compressionStream = new CompressionStream("deflate");
+    const reader = compressionStream.readable.getReader();
+    const writer = compressionStream.writable.getWriter();
+    const readCompressed = (async () => {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        pngParts.push(this.createPngChunk("IDAT", value));
+      }
+    })();
+    let tileCount = 0;
+    let writeError = null;
+
+    try {
+      for (let tileY = 0; tileY < exportHeight; tileY += tileSize.height) {
+        const tileHeight = Math.min(tileSize.height, exportHeight - tileY);
+        const bandBuffer = new Uint8Array(rowStride * tileHeight);
+
+        for (let tileX = 0; tileX < exportWidth; tileX += tileSize.width) {
+          const tileWidth = Math.min(tileSize.width, exportWidth - tileX);
+          this.setScreenshotProgress(tileCount / totalTiles);
+          const tileData = this.renderScreenshotTileToImageData(
+            screenshotRenderer,
+            exportWidth,
+            exportHeight,
+            exportScale,
+            tileX,
+            tileY,
+            tileWidth,
+            tileHeight,
+            includeBackground,
+          );
+
+          for (let row = 0; row < tileHeight; row += 1) {
+            const sourceStart = row * tileWidth * 4;
+            const sourceEnd = sourceStart + tileWidth * 4;
+            const destStart = row * rowStride + 1 + tileX * 4;
+            bandBuffer.set(tileData.subarray(sourceStart, sourceEnd), destStart);
+          }
+
+          tileCount += 1;
+          this.setScreenshotProgress(tileCount / totalTiles);
+        }
+
+        for (let row = 0; row < tileHeight; row += 1) {
+          const rowStart = row * rowStride;
+          await writer.write(bandBuffer.subarray(rowStart, rowStart + rowStride));
+        }
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      }
+
+      this.setScreenshotProgress(1);
+      await writer.close();
+    } catch (error) {
+      writeError = error;
+      try {
+        await writer.abort(error);
+      } catch {
+        // The stream may already be closed or errored.
+      }
+    }
+
+    try {
+      await readCompressed;
+    } catch (error) {
+      if (!writeError) {
+        writeError = error;
+      }
+    }
+
+    if (writeError) {
+      throw writeError;
+    }
+
+    pngParts.push(this.createPngChunk("IEND", new Uint8Array()));
+    return new Blob(pngParts, { type: "image/png" });
+  }
+
+  getScreenshotStreamTileDimensions() {
+    const rect = this.canvas.getBoundingClientRect();
+    const maxDimension = this.getMaxScreenshotDimension();
+
+    return {
+      width: Math.max(
+        1,
+        Math.min(maxDimension, Math.round(rect.width * 8)),
+      ),
+      height: Math.max(
+        1,
+        Math.min(maxDimension, Math.round(rect.height)),
+      ),
+    };
+  }
+
+  renderScreenshotTileToImageData(
+    screenshotRenderer,
+    exportWidth,
+    exportHeight,
+    exportScale,
+    tileX,
+    tileY,
+    tileWidth,
+    tileHeight,
+    includeBackground,
+  ) {
+    this.renderSingleScreenshotTile(
+      screenshotRenderer,
+      exportWidth,
+      exportHeight,
+      tileX,
+      tileY,
+      tileWidth,
+      tileHeight,
+    );
+
+    const context = this.getScreenshotTileContext(
+      screenshotRenderer,
+      tileWidth,
+      tileHeight,
+    );
+
+    if (includeBackground) {
+      context.fillStyle = this.isCanvasLight ? "#f8fafc" : "#020617";
+      context.fillRect(0, 0, tileWidth, tileHeight);
+    } else {
+      context.clearRect(0, 0, tileWidth, tileHeight);
+    }
+
+    context.drawImage(
+      screenshotRenderer.canvas,
+      0,
+      0,
+      tileWidth,
+      tileHeight,
+    );
+    context.save();
+    context.scale(exportScale, exportScale);
+    context.translate(-tileX / exportScale, -tileY / exportScale);
+    this.drawMeasurementsOnContext(context);
+    context.restore();
+
+    return context.getImageData(0, 0, tileWidth, tileHeight).data;
+  }
+
+  getScreenshotTileContext(screenshotRenderer, tileWidth, tileHeight) {
+    if (!screenshotRenderer.tileCanvas) {
+      screenshotRenderer.tileCanvas = document.createElement("canvas");
+    }
+
+    const tileCanvas = screenshotRenderer.tileCanvas;
+    if (tileCanvas.width !== tileWidth) {
+      tileCanvas.width = tileWidth;
+    }
+    if (tileCanvas.height !== tileHeight) {
+      tileCanvas.height = tileHeight;
+    }
+
+    if (!screenshotRenderer.tileContext) {
+      screenshotRenderer.tileContext = tileCanvas.getContext("2d", {
+        willReadFrequently: true,
+      });
+    }
+    if (!screenshotRenderer.tileContext) {
+      throw new Error("Cannot create screenshot tile canvas.");
+    }
+
+    return screenshotRenderer.tileContext;
+  }
+
+  downloadScreenshotBlob(blob) {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `gerber-viewer-${this.getTimestampForFileName()}.png`;
+    link.click();
+    window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+
+  createPngSignature() {
+    return new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+  }
+
+  createPngHeaderChunk(width, height) {
+    const data = new Uint8Array(13);
+    const view = new DataView(data.buffer);
+    view.setUint32(0, width, false);
+    view.setUint32(4, height, false);
+    data[8] = 8;
+    data[9] = 6;
+    data[10] = 0;
+    data[11] = 0;
+    data[12] = 0;
+    return this.createPngChunk("IHDR", data);
+  }
+
+  createPngChunk(type, data) {
+    const payload = data instanceof Uint8Array ? data : new Uint8Array(data);
+    const chunk = new Uint8Array(12 + payload.length);
+    const view = new DataView(chunk.buffer);
+    view.setUint32(0, payload.length, false);
+
+    for (let index = 0; index < 4; index += 1) {
+      chunk[4 + index] = type.charCodeAt(index);
+    }
+
+    chunk.set(payload, 8);
+    view.setUint32(
+      8 + payload.length,
+      this.pngCrc32(chunk.subarray(4, 8 + payload.length)),
+      false,
+    );
+    return chunk;
+  }
+
+  pngCrc32(bytes) {
+    const table = this.getPngCrcTable();
+    let crc = 0xffffffff;
+
+    for (const byte of bytes) {
+      crc = table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+    }
+
+    return (crc ^ 0xffffffff) >>> 0;
+  }
+
+  getPngCrcTable() {
+    if (this.pngCrcTable) {
+      return this.pngCrcTable;
+    }
+
+    const table = new Uint32Array(256);
+    for (let index = 0; index < 256; index += 1) {
+      let value = index;
+      for (let bit = 0; bit < 8; bit += 1) {
+        value = (value & 1) ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+      }
+      table[index] = value >>> 0;
+    }
+
+    this.pngCrcTable = table;
+    return table;
+  }
+
+  renderSingleScreenshotTile(
+    screenshotRenderer,
+    exportWidth,
+    exportHeight,
+    tileX,
+    tileY,
+    tileWidth,
+    tileHeight,
+  ) {
+    screenshotRenderer.canvas.width = tileWidth;
+    screenshotRenderer.canvas.height = tileHeight;
+    screenshotRenderer.processor.resize();
+    screenshotRenderer.processor.render_tile(
+      screenshotRenderer.activeLayerIds,
+      screenshotRenderer.colorData,
+      exportWidth,
+      exportHeight,
+      tileX,
+      tileY,
+      tileWidth,
+      tileHeight,
+      this.getViewScaleX(),
+      this.getViewScaleY(),
+      this.camera.offsetX,
+      this.camera.offsetY,
+      this.globalAlpha,
+    );
+    screenshotRenderer.gl.finish();
   }
 
   drawMeasurementsOnContext(context) {
@@ -1380,6 +2013,7 @@ export class GerberViewer {
         name: name,
         visible: options.visible ?? true,
         color: color,
+        sourceContent: options.sourceContent ?? content,
         bounds: {
           minX: bounds.min_x,
           maxX: bounds.max_x,
@@ -1412,27 +2046,12 @@ export class GerberViewer {
     }
 
     try {
-      // Get selected layers
-      const selectedLayerIds = this.getSelectedLayerIds();
-
-      const activeLayerIds = [];
-      const colorData = [];
-
-      this.layers.forEach((layer) => {
-        if (selectedLayerIds.has(layer.id)) {
-          activeLayerIds.push(layer.layerId);
-
-          // Add RGB color (no alpha)
-          colorData.push(layer.color[0]);
-          colorData.push(layer.color[1]);
-          colorData.push(layer.color[2]);
-        }
-      });
+      const { activeLayerIds, colorData } = this.getRenderLayerPayload();
 
       // Render with active layers
       this.wasmProcessor.render(
-        new Uint32Array(activeLayerIds),
-        new Float32Array(colorData),
+        activeLayerIds,
+        colorData,
         this.getViewScaleX(),
         this.getViewScaleY(),
         this.camera.offsetX,
@@ -1449,11 +2068,30 @@ export class GerberViewer {
     this.renderMeasurements();
   }
 
+  getRenderLayerPayload() {
+    const selectedLayerIds = this.getSelectedLayerIds();
+    const activeLayerIds = [];
+    const colorData = [];
+
+    this.layers.forEach((layer) => {
+      if (selectedLayerIds.has(layer.id)) {
+        activeLayerIds.push(layer.layerId);
+        colorData.push(layer.color[0], layer.color[1], layer.color[2]);
+      }
+    });
+
+    return {
+      activeLayerIds: new Uint32Array(activeLayerIds),
+      colorData: new Float32Array(colorData),
+    };
+  }
+
   renderMeasurements() {
     const rect = this.canvas.getBoundingClientRect();
-    this.measurementOverlay.replaceChildren();
+    this.measurementOverlayCursor = 0;
 
     if (rect.width === 0 || rect.height === 0) {
+      this.pruneMeasurementOverlayNodes();
       return;
     }
 
@@ -1469,6 +2107,8 @@ export class GerberViewer {
         this.drawMeasurement(this.rulerStartPoint, this.rulerHoverPoint, true);
       }
     }
+
+    this.pruneMeasurementOverlayNodes();
   }
 
   drawMeasurement(start, end, isPreview) {
@@ -1482,28 +2122,26 @@ export class GerberViewer {
       outline.setAttribute("opacity", "0.7");
       line.setAttribute("opacity", "0.7");
     }
-    this.measurementOverlay.appendChild(outline);
-    this.measurementOverlay.appendChild(line);
 
     this.drawMeasurementPoint(start);
     this.drawMeasurementPoint(end);
 
     const distance = Math.hypot(end.x - start.x, end.y - start.y);
-    const label = this.createSvgElement("text");
+    const label = this.getMeasurementSvgElement("text");
     label.textContent = this.formatMeasurementLength(distance);
     label.setAttribute("x", (startPoint.x + endPoint.x) / 2);
     label.setAttribute("y", (startPoint.y + endPoint.y) / 2 - 8);
     label.setAttribute("text-anchor", "middle");
-    this.measurementOverlay.appendChild(label);
   }
 
   createMeasurementLine(startPoint, endPoint, className) {
-    const line = this.createSvgElement("line");
+    const line = this.getMeasurementSvgElement("line");
     line.setAttribute("class", className);
     line.setAttribute("x1", startPoint.x);
     line.setAttribute("y1", startPoint.y);
     line.setAttribute("x2", endPoint.x);
     line.setAttribute("y2", endPoint.y);
+    line.removeAttribute("opacity");
     return line;
   }
 
@@ -1511,11 +2149,41 @@ export class GerberViewer {
     const canvasPoint = this.worldToCanvasPoint(point);
     if (!canvasPoint) return;
 
-    const circle = this.createSvgElement("circle");
+    const circle = this.getMeasurementSvgElement("circle");
     circle.setAttribute("cx", canvasPoint.x);
     circle.setAttribute("cy", canvasPoint.y);
     circle.setAttribute("r", "4");
-    this.measurementOverlay.appendChild(circle);
+  }
+
+  getMeasurementSvgElement(tagName) {
+    const index = this.measurementOverlayCursor++;
+    let node = this.measurementOverlayNodes[index];
+
+    if (!node || node.localName !== tagName) {
+      if (node) {
+        node.remove();
+      }
+      node = this.createSvgElement(tagName);
+      this.measurementOverlayNodes[index] = node;
+    }
+
+    const currentNode = this.measurementOverlay.childNodes[index];
+    if (currentNode !== node) {
+      this.measurementOverlay.insertBefore(node, currentNode || null);
+    }
+
+    return node;
+  }
+
+  pruneMeasurementOverlayNodes() {
+    for (
+      let i = this.measurementOverlayCursor;
+      i < this.measurementOverlayNodes.length;
+      i++
+    ) {
+      this.measurementOverlayNodes[i].remove();
+    }
+    this.measurementOverlayNodes.length = this.measurementOverlayCursor;
   }
 
   createSvgElement(tagName) {
@@ -1645,41 +2313,14 @@ export class GerberViewer {
       return null;
     }
 
-    const visibleRect = {
-      left: 0,
-      top: 0,
-      right: rect.width,
-      bottom: rect.height,
-    };
-    const drawerRect = this.drawer.getBoundingClientRect();
-    const intersectsCanvas =
-      drawerRect.right > rect.left &&
-      drawerRect.left < rect.right &&
-      drawerRect.bottom > rect.top &&
-      drawerRect.top < rect.bottom;
-
-    if (intersectsCanvas) {
-      if (this.isMobileDrawerLayout()) {
-        visibleRect.bottom = Math.max(
-          visibleRect.top + 1,
-          Math.min(visibleRect.bottom, drawerRect.top - rect.top),
-        );
-      } else {
-        visibleRect.right = Math.max(
-          visibleRect.left + 1,
-          Math.min(visibleRect.right, drawerRect.left - rect.left),
-        );
-      }
-    }
-
     const topLeft = this.canvasLocalPointToCorrected(
-      visibleRect.left,
-      visibleRect.top,
+      0,
+      0,
       rect,
     );
     const bottomRight = this.canvasLocalPointToCorrected(
-      visibleRect.right,
-      visibleRect.bottom,
+      rect.width,
+      rect.height,
       rect,
     );
 
@@ -2494,6 +3135,29 @@ export class GerberViewer {
     );
   }
 
+  updateCanvasReservationForDrawerState() {
+    const isCollapsed = this.drawer.classList.contains("collapsed");
+
+    if (this.isMobileDrawerLayout()) {
+      const reservedHeight = isCollapsed
+        ? this.getDrawerCollapsedHeight()
+        : this.drawerCurrentHeight;
+      this.dropZone.style.setProperty(
+        "--canvas-reserved-height",
+        `${reservedHeight}px`,
+      );
+      return;
+    }
+
+    const reservedWidth = isCollapsed
+      ? this.getDrawerCollapsedWidth()
+      : this.drawerCurrentWidth;
+    this.dropZone.style.setProperty(
+      "--canvas-reserved-width",
+      `${reservedWidth}px`,
+    );
+  }
+
   getDrawerMaxWidth() {
     const viewportLimit = Math.max(this.drawerMinWidth, window.innerWidth - 48);
     return Math.min(this.drawerMaxWidth, viewportLimit);
@@ -2517,6 +3181,10 @@ export class GerberViewer {
       this.drawerCurrentWidth = clampedWidth;
       this.drawerPendingWidth = null;
       this.dropZone.style.setProperty("--panel-width", `${clampedWidth}px`);
+      this.dropZone.style.setProperty(
+        "--canvas-reserved-width",
+        `${clampedWidth}px`,
+      );
     } else {
       this.drawerPendingWidth = clampedWidth;
     }
@@ -2550,6 +3218,10 @@ export class GerberViewer {
       this.drawerCurrentHeight = clampedHeight;
       this.drawerPendingHeight = null;
       this.dropZone.style.setProperty("--panel-height", `${clampedHeight}px`);
+      this.dropZone.style.setProperty(
+        "--canvas-reserved-height",
+        `${clampedHeight}px`,
+      );
     } else {
       this.drawerPendingHeight = clampedHeight;
     }
@@ -2560,6 +3232,7 @@ export class GerberViewer {
   startDrawerResize(e) {
     e.preventDefault();
     this.isResizingDrawer = true;
+    this.drawerResizeViewState = this.captureCanvasViewState();
     this.drawer.classList.add("resizing");
     document.body.style.userSelect = "none";
     document.body.style.cursor = this.isMobileDrawerLayout()
@@ -2630,6 +3303,9 @@ export class GerberViewer {
   stopDrawerResize(e) {
     if (!this.isResizingDrawer) return;
 
+    const viewState =
+      this.drawerResizeViewState ?? this.captureCanvasViewState();
+
     if (this.drawer.classList.contains("collapsed")) {
       this.drawerPendingHeight = null;
       this.drawerPendingWidth = null;
@@ -2642,12 +3318,14 @@ export class GerberViewer {
     }
 
     this.isResizingDrawer = false;
+    this.drawerResizeViewState = null;
     document.body.style.userSelect = "";
     document.body.style.cursor = "";
     requestAnimationFrame(() => {
       this.drawer.classList.remove("resizing");
     });
-    this.render();
+    this.updateCanvasReservationForDrawerState();
+    this.resizeCanvas({ preserveViewState: viewState });
   }
 
   triggerCanvasResize() {
@@ -2656,6 +3334,7 @@ export class GerberViewer {
   }
 
   toggleDrawer(forceOpen = null) {
+    const viewState = this.captureCanvasViewState();
     const isCollapsed = this.drawer.classList.contains("collapsed");
     const shouldOpen = forceOpen === null ? isCollapsed : forceOpen;
 
@@ -2682,7 +3361,11 @@ export class GerberViewer {
       this.drawer.classList.add("collapsed");
     }
 
+    this.updateCanvasReservationForDrawerState();
     this.updateDrawerToggleState();
+    requestAnimationFrame(() => {
+      this.resizeCanvas({ preserveViewState: viewState });
+    });
   }
 
   updateDrawerToggleState() {

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 const NOTIFICATION_DURATION_MS = 2000;
 const MAX_FILE_SIZE_BYTES = 300 * 1024 * 1024;
+const MAX_SCREENSHOT_STREAM_BAND_BYTES = 1024 * 1024 * 1024;
 const ZIP_MIME_TYPES = new Set([
   "application/zip",
   "application/x-zip-compressed",
@@ -1270,10 +1271,11 @@ export class GerberViewer {
     }
 
     const tileSize = this.getScreenshotStreamTileDimensions();
+    this.validateScreenshotStreamMemory(exportWidth, exportHeight, tileSize);
     const totalTiles =
       Math.ceil(exportWidth / tileSize.width) *
       Math.ceil(exportHeight / tileSize.height);
-    const rowStride = 1 + exportWidth * 4;
+    const rowStride = this.getScreenshotPngRowStride(exportWidth);
     const pngParts = [
       this.createPngSignature(),
       this.createPngHeaderChunk(exportWidth, exportHeight),
@@ -1294,7 +1296,11 @@ export class GerberViewer {
     try {
       for (let tileY = 0; tileY < exportHeight; tileY += tileSize.height) {
         const tileHeight = Math.min(tileSize.height, exportHeight - tileY);
-        const bandBuffer = new Uint8Array(rowStride * tileHeight);
+        const bandBuffer = this.createScreenshotBandBuffer(
+          exportWidth,
+          exportHeight,
+          tileHeight,
+        );
 
         for (let tileX = 0; tileX < exportWidth; tileX += tileSize.width) {
           const tileWidth = Math.min(tileSize.width, exportWidth - tileX);
@@ -1355,6 +1361,53 @@ export class GerberViewer {
 
     pngParts.push(this.createPngChunk("IEND", new Uint8Array()));
     return new Blob(pngParts, { type: "image/png" });
+  }
+
+  validateScreenshotStreamMemory(exportWidth, exportHeight, tileSize) {
+    const bandHeight = Math.min(tileSize.height, exportHeight);
+    const bandBytes = this.getScreenshotBandByteLength(exportWidth, bandHeight);
+
+    if (
+      !Number.isSafeInteger(bandBytes) ||
+      bandBytes > MAX_SCREENSHOT_STREAM_BAND_BYTES
+    ) {
+      throw new Error(
+        this.getScreenshotMemoryLimitMessage(exportWidth, exportHeight, bandBytes),
+      );
+    }
+  }
+
+  createScreenshotBandBuffer(exportWidth, exportHeight, bandHeight) {
+    const bandBytes = this.getScreenshotBandByteLength(exportWidth, bandHeight);
+
+    try {
+      return new Uint8Array(bandBytes);
+    } catch (error) {
+      throw new Error(
+        this.getScreenshotMemoryLimitMessage(exportWidth, exportHeight, bandBytes),
+        { cause: error },
+      );
+    }
+  }
+
+  getScreenshotBandByteLength(exportWidth, bandHeight) {
+    return this.getScreenshotPngRowStride(exportWidth) * bandHeight;
+  }
+
+  getScreenshotPngRowStride(width) {
+    return 1 + width * 4;
+  }
+
+  getScreenshotMemoryLimitMessage(exportWidth, exportHeight, bandBytes) {
+    const memoryText = Number.isFinite(bandBytes)
+      ? this.formatFileSize(bandBytes)
+      : "more than this browser can address";
+
+    return [
+      `Screenshot is too large to export at ${exportWidth} x ${exportHeight}px.`,
+      `It needs about ${memoryText} of temporary browser memory.`,
+      "Try a lower resolution.",
+    ].join(" ");
   }
 
   getScreenshotStreamTileDimensions() {

--- a/js/main.js
+++ b/js/main.js
@@ -1068,6 +1068,21 @@ export class GerberViewer {
     return typeof CompressionStream === "function";
   }
 
+  captureScreenshotRenderState(rect = this.canvas.getBoundingClientRect()) {
+    return {
+      viewScaleX: this.getViewScaleX(),
+      viewScaleY: this.getViewScaleY(),
+      offsetX: this.camera.offsetX,
+      offsetY: this.camera.offsetY,
+      canvasWidth: this.canvas.width,
+      canvasHeight: this.canvas.height,
+      rectWidth: rect.width,
+      rectHeight: rect.height,
+      globalAlpha: this.globalAlpha,
+      backgroundColor: this.isCanvasLight ? "#f8fafc" : "#020617",
+    };
+  }
+
   async exportScreenshot({ includeBackground = false, scale = 1 } = {}) {
     if (this.isExportingScreenshot) return false;
 
@@ -1092,6 +1107,7 @@ export class GerberViewer {
     const maxDimension = this.getMaxScreenshotDimension();
     const isTiled = this.shouldTileScreenshot(exportScale);
     const shouldStream = this.shouldStreamScreenshot(exportScale);
+    const renderState = this.captureScreenshotRenderState(rect);
     if (
       !shouldStream &&
       (exportWidth > maxDimension || exportHeight > maxDimension)
@@ -1118,6 +1134,7 @@ export class GerberViewer {
           exportHeight,
           exportScale,
           includeBackground,
+          renderState,
         );
       } else {
         const output = document.createElement("canvas");
@@ -1132,7 +1149,7 @@ export class GerberViewer {
         }
 
         if (includeBackground) {
-          context.fillStyle = this.isCanvasLight ? "#f8fafc" : "#020617";
+          context.fillStyle = renderState.backgroundColor;
           context.fillRect(0, 0, exportWidth, exportHeight);
         } else {
           context.clearRect(0, 0, exportWidth, exportHeight);
@@ -1146,6 +1163,7 @@ export class GerberViewer {
           0,
           exportWidth,
           exportHeight,
+          renderState,
         );
         context.drawImage(
           screenshotRenderer.canvas,
@@ -1157,7 +1175,7 @@ export class GerberViewer {
 
         context.save();
         context.scale(exportScale, exportScale);
-        this.drawMeasurementsOnContext(context);
+        this.drawMeasurementsOnContext(context, renderState);
         context.restore();
 
         blob = await new Promise((resolve) => {
@@ -1243,6 +1261,7 @@ export class GerberViewer {
     exportHeight,
     exportScale,
     includeBackground,
+    renderState,
   ) {
     if (typeof CompressionStream !== "function") {
       throw new Error(
@@ -1290,6 +1309,7 @@ export class GerberViewer {
             tileWidth,
             tileHeight,
             includeBackground,
+            renderState,
           );
 
           for (let row = 0; row < tileHeight; row += 1) {
@@ -1363,6 +1383,7 @@ export class GerberViewer {
     tileWidth,
     tileHeight,
     includeBackground,
+    renderState,
   ) {
     this.renderSingleScreenshotTile(
       screenshotRenderer,
@@ -1372,6 +1393,7 @@ export class GerberViewer {
       tileY,
       tileWidth,
       tileHeight,
+      renderState,
     );
 
     const context = this.getScreenshotTileContext(
@@ -1381,7 +1403,7 @@ export class GerberViewer {
     );
 
     if (includeBackground) {
-      context.fillStyle = this.isCanvasLight ? "#f8fafc" : "#020617";
+      context.fillStyle = renderState.backgroundColor;
       context.fillRect(0, 0, tileWidth, tileHeight);
     } else {
       context.clearRect(0, 0, tileWidth, tileHeight);
@@ -1397,7 +1419,7 @@ export class GerberViewer {
     context.save();
     context.scale(exportScale, exportScale);
     context.translate(-tileX / exportScale, -tileY / exportScale);
-    this.drawMeasurementsOnContext(context);
+    this.drawMeasurementsOnContext(context, renderState);
     context.restore();
 
     return context.getImageData(0, 0, tileWidth, tileHeight).data;
@@ -1510,6 +1532,7 @@ export class GerberViewer {
     tileY,
     tileWidth,
     tileHeight,
+    renderState,
   ) {
     screenshotRenderer.canvas.width = tileWidth;
     screenshotRenderer.canvas.height = tileHeight;
@@ -1523,18 +1546,24 @@ export class GerberViewer {
       tileY,
       tileWidth,
       tileHeight,
-      this.getViewScaleX(),
-      this.getViewScaleY(),
-      this.camera.offsetX,
-      this.camera.offsetY,
-      this.globalAlpha,
+      renderState.viewScaleX,
+      renderState.viewScaleY,
+      renderState.offsetX,
+      renderState.offsetY,
+      renderState.globalAlpha,
     );
     screenshotRenderer.gl.finish();
   }
 
-  drawMeasurementsOnContext(context) {
+  drawMeasurementsOnContext(context, renderState = null) {
     for (const measurement of this.measurements) {
-      this.drawMeasurementOnContext(context, measurement.start, measurement.end, false);
+      this.drawMeasurementOnContext(
+        context,
+        measurement.start,
+        measurement.end,
+        false,
+        renderState,
+      );
     }
 
     if (this.rulerStartPoint && this.rulerHoverPoint) {
@@ -1543,15 +1572,16 @@ export class GerberViewer {
         this.rulerStartPoint,
         this.rulerHoverPoint,
         true,
+        renderState,
       );
     } else if (this.rulerStartPoint) {
-      this.drawMeasurementPointOnContext(context, this.rulerStartPoint);
+      this.drawMeasurementPointOnContext(context, this.rulerStartPoint, renderState);
     }
   }
 
-  drawMeasurementOnContext(context, start, end, isPreview) {
-    const startPoint = this.worldToCanvasPoint(start);
-    const endPoint = this.worldToCanvasPoint(end);
+  drawMeasurementOnContext(context, start, end, isPreview, renderState = null) {
+    const startPoint = this.worldToCanvasPoint(start, renderState);
+    const endPoint = this.worldToCanvasPoint(end, renderState);
     if (!startPoint || !endPoint) return;
 
     context.save();
@@ -1572,8 +1602,8 @@ export class GerberViewer {
     context.stroke();
     context.restore();
 
-    this.drawMeasurementPointOnContext(context, start);
-    this.drawMeasurementPointOnContext(context, end);
+    this.drawMeasurementPointOnContext(context, start, renderState);
+    this.drawMeasurementPointOnContext(context, end, renderState);
 
     const distance = Math.hypot(end.x - start.x, end.y - start.y);
     const x = (startPoint.x + endPoint.x) / 2;
@@ -1590,8 +1620,8 @@ export class GerberViewer {
     context.restore();
   }
 
-  drawMeasurementPointOnContext(context, point) {
-    const canvasPoint = this.worldToCanvasPoint(point);
+  drawMeasurementPointOnContext(context, point, renderState = null) {
+    const canvasPoint = this.worldToCanvasPoint(point, renderState);
     if (!canvasPoint) return;
 
     context.save();
@@ -2505,15 +2535,23 @@ export class GerberViewer {
     return { x: worldX, y: worldY };
   }
 
-  worldToCanvasPoint(point) {
-    const rect = this.canvas.getBoundingClientRect();
+  worldToCanvasPoint(point, renderState = null) {
+    const rect = renderState
+      ? { width: renderState.rectWidth, height: renderState.rectHeight }
+      : this.canvas.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) {
       return null;
     }
 
-    const aspect = this.canvas.width / this.canvas.height;
-    const correctedX = point.x * this.getViewScaleX() + this.camera.offsetX;
-    const correctedY = point.y * this.getViewScaleY() + this.camera.offsetY;
+    const canvasWidth = renderState?.canvasWidth ?? this.canvas.width;
+    const canvasHeight = renderState?.canvasHeight ?? this.canvas.height;
+    const viewScaleX = renderState?.viewScaleX ?? this.getViewScaleX();
+    const viewScaleY = renderState?.viewScaleY ?? this.getViewScaleY();
+    const offsetX = renderState?.offsetX ?? this.camera.offsetX;
+    const offsetY = renderState?.offsetY ?? this.camera.offsetY;
+    const aspect = canvasWidth / canvasHeight;
+    const correctedX = point.x * viewScaleX + offsetX;
+    const correctedY = point.y * viewScaleY + offsetY;
     const ndcX = aspect > 1.0 ? correctedX / aspect : correctedX;
     const ndcY = aspect > 1.0 ? correctedY : correctedY * aspect;
     return {

--- a/js/main.js
+++ b/js/main.js
@@ -1046,8 +1046,9 @@ export class GerberViewer {
     const scale = this.getSelectedScreenshotScale();
     const { width, height } = this.getScreenshotDimensions(scale);
     const maxDimension = this.getMaxScreenshotDimension();
-    const isTiled = this.shouldTileScreenshot(scale);
-    const exceedsLimit = !isTiled && (width > maxDimension || height > maxDimension);
+    const shouldStream = this.shouldStreamScreenshot(scale);
+    const exceedsLimit =
+      !shouldStream && (width > maxDimension || height > maxDimension);
 
     this.screenshotResolution.textContent = exceedsLimit
       ? `Estimated ${width} x ${height} px · exceeds ${maxDimension}px GPU limit`
@@ -1056,11 +1057,15 @@ export class GerberViewer {
   }
 
   shouldTileScreenshot(scale) {
-    return scale >= 8;
+    return scale >= 2;
   }
 
   shouldStreamScreenshot(scale) {
-    return scale >= 8;
+    return scale >= 2 && this.supportsStreamingScreenshot();
+  }
+
+  supportsStreamingScreenshot() {
+    return typeof CompressionStream === "function";
   }
 
   async exportScreenshot({ includeBackground = false, scale = 1 } = {}) {
@@ -1087,7 +1092,10 @@ export class GerberViewer {
     const maxDimension = this.getMaxScreenshotDimension();
     const isTiled = this.shouldTileScreenshot(exportScale);
     const shouldStream = this.shouldStreamScreenshot(exportScale);
-    if (!isTiled && (exportWidth > maxDimension || exportHeight > maxDimension)) {
+    if (
+      !shouldStream &&
+      (exportWidth > maxDimension || exportHeight > maxDimension)
+    ) {
       this.showError(
         `Screenshot is too large for this GPU (${exportWidth} x ${exportHeight}px).`,
       );
@@ -1336,7 +1344,7 @@ export class GerberViewer {
     return {
       width: Math.max(
         1,
-        Math.min(maxDimension, Math.round(rect.width * 8)),
+        Math.min(maxDimension, Math.round(rect.width * 2)),
       ),
       height: Math.max(
         1,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -187,6 +187,52 @@ impl GerberProcessor {
         }
     }
 
+    /// Render one tile of a larger virtual canvas to the current WebGL canvas.
+    ///
+    /// The caller is expected to resize the WebGL canvas to `tile_width` x
+    /// `tile_height` before calling this method, then copy the result into the
+    /// final image at `tile_x`, `tile_y`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_tile(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        export_width: u32,
+        export_height: u32,
+        tile_x: u32,
+        tile_y: u32,
+        tile_width: u32,
+        tile_height: u32,
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+    ) -> Result<String, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.render_tile(
+                active_layer_ids,
+                color_data,
+                export_width,
+                export_height,
+                tile_x,
+                tile_y,
+                tile_width,
+                tile_height,
+                zoom_x,
+                zoom_y,
+                offset_x,
+                offset_y,
+                alpha,
+            )?;
+            Ok("render_tile_done".to_string())
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
     /// Get the boundary of the parsed Gerber data for fitToView
     ///
     /// # Returns

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -472,6 +472,7 @@ fn parse_aperture_block(
     let Some(block_code) = parse_aperture_block_code(line) else {
         return;
     };
+    let outer_state = state.clone();
 
     flush_primitives(current_primitives, polarity_layers, state.polarity);
 
@@ -523,11 +524,8 @@ fn parse_aperture_block(
 
     flush_primitives(&mut block_primitives, &mut block_layers, state.polarity);
 
-    state.x = 0.0;
-    state.y = 0.0;
-    state.pen_state = "up".to_string();
-
     apertures.insert(block_code, Aperture::new_block(block_layers));
+    *state = outer_state;
 }
 
 pub fn parse_gerber(data: &str) -> Result<Vec<GerberData>, JsValue> {

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -61,7 +61,9 @@ impl GerberParser {
                 continue;
             }
 
-            if line_ref.starts_with('%') {
+            if line_ref.starts_with("M02") {
+                break;
+            } else if line_ref.starts_with('%') {
                 parse_command(
                     line_ref,
                     &mut i,

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -472,7 +472,6 @@ fn parse_aperture_block(
     let Some(block_code) = parse_aperture_block_code(line) else {
         return;
     };
-    let outer_state = state.clone();
 
     flush_primitives(current_primitives, polarity_layers, state.polarity);
 
@@ -493,6 +492,7 @@ fn parse_aperture_block(
                 break;
             }
 
+            let nested_block_state = parse_aperture_block_code(block_line).map(|_| state.clone());
             parse_command(
                 block_line,
                 i,
@@ -504,6 +504,9 @@ fn parse_aperture_block(
                 &mut block_primitives,
                 &mut block_layers,
             );
+            if let Some(enclosing_state) = nested_block_state {
+                *state = enclosing_state;
+            }
         } else if block_line.starts_with('G')
             || block_line.starts_with('D')
             || block_line.starts_with('X')
@@ -524,8 +527,11 @@ fn parse_aperture_block(
 
     flush_primitives(&mut block_primitives, &mut block_layers, state.polarity);
 
+    state.x = 0.0;
+    state.y = 0.0;
+    state.pen_state = "up".to_string();
+
     apertures.insert(block_code, Aperture::new_block(block_layers));
-    *state = outer_state;
 }
 
 pub fn parse_gerber(data: &str) -> Result<Vec<GerberData>, JsValue> {

--- a/wasm/src/parser/aperture_macro.rs
+++ b/wasm/src/parser/aperture_macro.rs
@@ -271,11 +271,8 @@ fn is_operator_or_bracket(token: Option<&String>) -> bool {
 /// Convert token to value (number or $variable)
 fn token_to_value(token: &str, variables: &HashMap<String, f32>) -> Result<f32, String> {
     if token.starts_with('$') {
-        // Variable reference
-        variables
-            .get(token)
-            .copied()
-            .ok_or_else(|| format!("Undefined variable: {}", token))
+        // Undefined aperture macro variables evaluate to 0.
+        Ok(variables.get(token).copied().unwrap_or(0.0))
     } else {
         // Number
         token

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -980,24 +980,30 @@ pub fn execute_interpolation(
                             let sr_end_x = end_x + offset_x;
                             let sr_end_y = end_y + offset_y;
 
-                            // Flash aperture at start point (no SR since we're already in SR loop)
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_start_x,
-                                sr_start_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            );
-
                             if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
                                 calculate_arc_parameters(
                                     state, sr_start_x, sr_start_y, sr_end_x, sr_end_y, i, j,
                                 )
                             {
                                 let thickness = aperture.radius * 2.0 * state.layer_scale;
+                                let end_angle = start_angle + sweep_angle;
+
+                                let cap_start_x = center_x + radius * start_angle.cos();
+                                let cap_start_y = center_y + radius * start_angle.sin();
+                                let cap_end_x = center_x + radius * end_angle.cos();
+                                let cap_end_y = center_y + radius * end_angle.sin();
+
+                                // Flash aperture at rendered arc start point.
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    cap_start_x,
+                                    cap_start_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
 
                                 // Add Arc primitive
                                 primitives.push(Primitive::Arc {
@@ -1009,19 +1015,40 @@ pub fn execute_interpolation(
                                     thickness,
                                     exposure: 1.0,
                                 });
-                            }
 
-                            // Flash aperture at end point (no SR since we're already in SR loop)
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_end_x,
-                                sr_end_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            );
+                                // Flash aperture at rendered arc end point.
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    cap_end_x,
+                                    cap_end_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
+                            } else {
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    sr_start_x,
+                                    sr_start_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
+                                flash_aperture_no_sr(
+                                    aperture,
+                                    primitives,
+                                    sr_end_x,
+                                    sr_end_y,
+                                    state.layer_scale,
+                                    state.mirror_x,
+                                    state.mirror_y,
+                                    state.layer_rotation,
+                                );
+                            }
                         }
                     }
                 }

--- a/wasm/src/parser/state.rs
+++ b/wasm/src/parser/state.rs
@@ -37,6 +37,7 @@ impl Default for FormatSpec {
     }
 }
 
+#[derive(Clone)]
 pub struct ParserState {
     pub x: f32,
     pub y: f32,

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -190,6 +190,25 @@ fn assert_gerber_snapshot(data: &str, expected: &str) {
 }
 
 #[test]
+fn m02_stops_parsing_following_commands() {
+    let layers = parse_gerber(
+        "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+X000000Y000000D03*
+M02*
+X010000Y000000D03*",
+    )
+    .expect("flash should parse");
+
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].circles.x.len(), 1);
+    assert_approx_eq(layers[0].circles.x[0], 0.0);
+}
+
+#[test]
 fn golden_region_d02_output_matches_current_parser() {
     assert_gerber_snapshot(
         "\

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -26,6 +26,24 @@ fn triangle_bounds(vertices: &[f32]) -> (f32, f32, f32, f32) {
     (min_x, max_x, min_y, max_y)
 }
 
+fn has_circle_at(
+    circles: &crate::shape::Circles,
+    expected_x: f32,
+    expected_y: f32,
+    expected_radius: f32,
+) -> bool {
+    circles
+        .x
+        .iter()
+        .zip(&circles.y)
+        .zip(&circles.radius)
+        .any(|((&x, &y), &radius)| {
+            (x - expected_x).abs() < 0.0001
+                && (y - expected_y).abs() < 0.0001
+                && (radius - expected_radius).abs() < 0.0001
+        })
+}
+
 fn test_circle() -> Primitive {
     Primitive::Circle {
         x: 0.0,
@@ -206,6 +224,63 @@ X010000Y000000D03*",
     assert_eq!(layers.len(), 1);
     assert_eq!(layers[0].circles.x.len(), 1);
     assert_approx_eq(layers[0].circles.x[0], 0.0);
+}
+
+#[test]
+fn aperture_macro_omitted_variables_default_to_zero() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%AMSTAR5*
+$3=$1x0.5*
+$4=$3x0.4*
+4,1,10,
+$3x0.0000,$3x1.0000,
+$4x-0.5878,$4x0.8090,
+$3x-0.9511,$3x0.3090,
+$4x-0.9511,$4x-0.3090,
+$3x-0.5878,$3x-0.8090,
+$4x0.0000,$4x-1.0000,
+$3x0.5878,$3x-0.8090,
+$4x0.9511,$4x-0.3090,
+$3x0.9511,$3x0.3090,
+$4x0.5878,$4x0.8090,
+$3x0.0000,$3x1.0000,
+$2*%
+%ADD23STAR5,5.000000*%
+%ADD24STAR5,5.000000X45*%
+%ADD25STAR5,5.000000X90*%
+%ADD26STAR5,5.000000X135*%
+D23*
+X025000000Y025000000D03*
+D24*
+X-025000000Y025000000D03*
+D25*
+X-025000000Y-025000000D03*
+D26*
+X025000000Y-025000000D03*
+M02*",
+    )
+    .expect("macro should parse omitted parameters");
+    let mut occupied_quadrants = [false; 4];
+
+    for triangle in layers[0].triangles.vertices.chunks_exact(6) {
+        let centroid_x = (triangle[0] + triangle[2] + triangle[4]) / 3.0;
+        let centroid_y = (triangle[1] + triangle[3] + triangle[5]) / 3.0;
+
+        if centroid_x > 10.0 && centroid_y > 10.0 {
+            occupied_quadrants[0] = true;
+        } else if centroid_x < -10.0 && centroid_y > 10.0 {
+            occupied_quadrants[1] = true;
+        } else if centroid_x < -10.0 && centroid_y < -10.0 {
+            occupied_quadrants[2] = true;
+        } else if centroid_x > 10.0 && centroid_y < -10.0 {
+            occupied_quadrants[3] = true;
+        }
+    }
+
+    assert_eq!(occupied_quadrants, [true, true, true, true]);
 }
 
 #[test]
@@ -767,6 +842,65 @@ M02*";
     assert_eq!(circles.x.len(), 1);
     assert_approx_eq(circles.x[0], 13.0);
     assert_approx_eq(circles.y[0], 0.0);
+}
+
+#[test]
+fn nested_aperture_block_restores_enclosing_graphic_state() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+%ADD11C,0.5*%
+%ABD20*%
+D11*
+G02*
+G75*
+X0000000Y2500000D02*
+%ABD21*%
+D10*
+G01*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+%AB*%
+X2500000Y0I0J-2500000D01*
+%AB*%
+D20*
+X0Y0D03*
+M02*",
+    )
+    .expect("nested aperture block should parse");
+    let arcs = &layers[0].arcs;
+    let circles = &layers[0].circles;
+
+    assert_eq!(arcs.x.len(), 1);
+    assert_approx_eq(arcs.x[0], 0.0);
+    assert_approx_eq(arcs.y[0], 0.0);
+    assert_approx_eq(arcs.radius[0], 2.5);
+    assert!(has_circle_at(circles, 0.0, 2.5, 0.25));
+    assert!(has_circle_at(circles, 2.5, 0.0, 0.25));
+}
+
+#[test]
+fn arc_caps_use_rendered_arc_endpoints() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+G03*
+G75*
+X0000000Y-2500000D02*
+X-5000000Y0I0J2500000D01*
+M02*",
+    )
+    .expect("arc should parse");
+    let circles = &layers[0].circles;
+
+    assert!(has_circle_at(circles, 0.0, -2.5, 0.5));
+    assert!(has_circle_at(circles, -2.5, 0.0, 0.5));
+    assert!(!has_circle_at(circles, -5.0, 0.0, 0.5));
 }
 
 #[test]

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -882,6 +882,28 @@ M02*",
 }
 
 #[test]
+fn aperture_block_definition_preserves_ending_graphic_state() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+%ADD11C,2.0*%
+%ABD20*%
+D10*
+X0000000Y0000000D03*
+D11*
+%AB*%
+X1000000Y0000000D03*
+M02*",
+    )
+    .expect("aperture block should parse");
+    let circles = &layers[0].circles;
+
+    assert!(has_circle_at(circles, 1.0, 0.0, 1.0));
+}
+
+#[test]
 fn arc_caps_use_rendered_arc_endpoints() {
     let layers = parse_gerber(
         "\

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -21,6 +21,8 @@ pub struct LayerMetadata {
     fbo: Fbo,                        // FBO for rendering this layer
     buffer_caches: Vec<BufferCache>, // Buffer cache per polarity sublayer
     boundary: Boundary,              // Combined boundary
+    fbo_dirty: bool,
+    fbo_transform: Option<[f32; 9]>,
 }
 
 /// WebGL renderer for Gerber graphics with multi-layer support
@@ -89,6 +91,8 @@ impl Renderer {
             fbo,
             buffer_caches,
             boundary,
+            fbo_dirty: true,
+            fbo_transform: None,
         };
 
         // Find next free slot or extend vec
@@ -1293,31 +1297,163 @@ impl Renderer {
         // Get transform matrix
         let transform = self.camera.get_transform_matrix(width, height);
 
-        // STEP 1: Render each active layer's geometry to its FBO (white)
+        self.render_with_transform(active_layer_ids, color_data, alpha, transform)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_tile(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        export_width: u32,
+        export_height: u32,
+        tile_x: u32,
+        tile_y: u32,
+        tile_width: u32,
+        tile_height: u32,
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+    ) -> Result<(), JsValue> {
+        Self::validate_render_inputs(
+            active_layer_ids,
+            color_data,
+            zoom_x,
+            zoom_y,
+            offset_x,
+            offset_y,
+            alpha,
+        )?;
+        Self::validate_tile_inputs(
+            export_width,
+            export_height,
+            tile_x,
+            tile_y,
+            tile_width,
+            tile_height,
+        )?;
+
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
+        let transform = Self::tile_transform_matrix(
+            self.camera
+                .get_transform_matrix(export_width, export_height),
+            export_width,
+            export_height,
+            tile_x,
+            tile_y,
+            tile_width,
+            tile_height,
+        );
+
+        self.render_with_transform(active_layer_ids, color_data, alpha, transform)
+    }
+
+    fn render_with_transform(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        alpha: f32,
+        transform: [f32; 9],
+    ) -> Result<(), JsValue> {
+        let (width, height) = self.get_canvas_size()?;
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
+        }
+
+        // STEP 1: Render active layer geometry to FBOs only when geometry/camera state changed.
         for &layer_id in active_layer_ids {
             let layer_idx = layer_id as usize;
+            let should_redraw = {
+                let layer = self.get_layer(layer_idx)?;
+                layer.fbo_dirty || layer.fbo_transform.as_ref() != Some(&transform)
+            };
 
-            // Validate layer exists and get FBO
-            let layer = self.get_layer(layer_idx)?;
-            let fbo = &layer.fbo;
+            if should_redraw {
+                // Validate layer exists and get FBO
+                let layer = self.get_layer(layer_idx)?;
+                let fbo = &layer.fbo;
 
-            // Bind layer FBO
-            self.gl
-                .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&fbo.framebuffer));
-            self.gl.viewport(0, 0, width as i32, height as i32);
+                // Bind layer FBO
+                self.gl
+                    .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&fbo.framebuffer));
+                self.gl.viewport(0, 0, width as i32, height as i32);
 
-            // Clear layer FBO
-            self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
-            self.gl.clear(COLOR_BUFFER_BIT);
+                // Clear layer FBO
+                self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
+                self.gl.clear(COLOR_BUFFER_BIT);
 
-            // Render layer geometry (with polarity blending handled internally)
-            self.render_layer_geometry(layer_idx, &transform)?;
+                // Render layer geometry (with polarity blending handled internally)
+                self.render_layer_geometry(layer_idx, &transform)?;
+
+                if let Some(layer) = &mut self.layers[layer_idx] {
+                    layer.fbo_dirty = false;
+                    layer.fbo_transform = Some(transform);
+                }
+            }
         }
 
         // STEP 2: Composite FBOs to canvas
         self.composite_layers(active_layer_ids, color_data, alpha)?;
 
         Ok(())
+    }
+
+    fn validate_tile_inputs(
+        export_width: u32,
+        export_height: u32,
+        tile_x: u32,
+        tile_y: u32,
+        tile_width: u32,
+        tile_height: u32,
+    ) -> Result<(), JsValue> {
+        if export_width == 0 || export_height == 0 || tile_width == 0 || tile_height == 0 {
+            return Err(JsValue::from_str("Tile dimensions must be non-zero"));
+        }
+
+        let tile_right = tile_x
+            .checked_add(tile_width)
+            .ok_or_else(|| JsValue::from_str("Tile width overflows export bounds"))?;
+        let tile_bottom = tile_y
+            .checked_add(tile_height)
+            .ok_or_else(|| JsValue::from_str("Tile height overflows export bounds"))?;
+
+        if tile_right > export_width || tile_bottom > export_height {
+            return Err(JsValue::from_str("Tile is outside export bounds"));
+        }
+
+        Ok(())
+    }
+
+    fn tile_transform_matrix(
+        mut transform: [f32; 9],
+        export_width: u32,
+        export_height: u32,
+        tile_x: u32,
+        tile_y: u32,
+        tile_width: u32,
+        tile_height: u32,
+    ) -> [f32; 9] {
+        let export_width = export_width as f32;
+        let export_height = export_height as f32;
+        let tile_x = tile_x as f32;
+        let tile_y = tile_y as f32;
+        let tile_width = tile_width as f32;
+        let tile_height = tile_height as f32;
+
+        let scale_x = export_width / tile_width;
+        let offset_x = (export_width - 2.0 * tile_x) / tile_width - 1.0;
+        let scale_y = export_height / tile_height;
+        let offset_y = 1.0 - export_height / tile_height + 2.0 * tile_y / tile_height;
+
+        transform[0] *= scale_x;
+        transform[3] *= scale_x;
+        transform[6] = transform[6] * scale_x + offset_x;
+        transform[1] *= scale_y;
+        transform[4] *= scale_y;
+        transform[7] = transform[7] * scale_y + offset_y;
+        transform
     }
 
     fn composite_layers(
@@ -1410,6 +1546,8 @@ impl Renderer {
             let old_fbo =
                 std::mem::replace(&mut layer.fbo, Self::create_fbo(&self.gl, width, height)?);
             Self::delete_fbo(&self.gl, old_fbo);
+            layer.fbo_dirty = true;
+            layer.fbo_transform = None;
         }
 
         Ok(())
@@ -1455,6 +1593,8 @@ impl Renderer {
                     Self::delete_buffer_cache(&old_gl, cache);
                 }
                 layer.buffer_caches = Self::create_buffer_caches(layer.gerber_data.len());
+                layer.fbo_dirty = true;
+                layer.fbo_transform = None;
             }
         }
 


### PR DESCRIPTION
## Summary
- Add screenshot export options for background inclusion and resolution scale.
- Render high-resolution exports through a hidden WebGL renderer and stream PNG rows for 8x and higher scales to avoid allocating one huge output canvas.
- Preserve ruler overlays in exported screenshots and avoid changing the live viewer canvas during export.

## Validation
- `node --check js/main.js`
- `cargo test --manifest-path wasm/Cargo.toml`