### PR TITLE
Activate tiled/streamed screenshot export at 2x scale

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1046,8 +1046,9 @@ export class GerberViewer {
     const scale = this.getSelectedScreenshotScale();
     const { width, height } = this.getScreenshotDimensions(scale);
     const maxDimension = this.getMaxScreenshotDimension();
-    const isTiled = this.shouldTileScreenshot(scale);
-    const exceedsLimit = !isTiled && (width > maxDimension || height > maxDimension);
+    const shouldStream = this.shouldStreamScreenshot(scale);
+    const exceedsLimit =
+      !shouldStream && (width > maxDimension || height > maxDimension);
 
     this.screenshotResolution.textContent = exceedsLimit
       ? `Estimated ${width} x ${height} px · exceeds ${maxDimension}px GPU limit`
@@ -1060,7 +1061,11 @@ export class GerberViewer {
   }
 
   shouldStreamScreenshot(scale) {
-    return scale >= 2;
+    return scale >= 2 && this.supportsStreamingScreenshot();
+  }
+
+  supportsStreamingScreenshot() {
+    return typeof CompressionStream === "function";
   }
 
   async exportScreenshot({ includeBackground = false, scale = 1 } = {}) {
@@ -1087,7 +1092,10 @@ export class GerberViewer {
     const maxDimension = this.getMaxScreenshotDimension();
     const isTiled = this.shouldTileScreenshot(exportScale);
     const shouldStream = this.shouldStreamScreenshot(exportScale);
-    if (!isTiled && (exportWidth > maxDimension || exportHeight > maxDimension)) {
+    if (
+      !shouldStream &&
+      (exportWidth > maxDimension || exportHeight > maxDimension)
+    ) {
       this.showError(
         `Screenshot is too large for this GPU (${exportWidth} x ${exportHeight}px).`,
       );

--- a/js/main.js
+++ b/js/main.js
@@ -1056,11 +1056,11 @@ export class GerberViewer {
   }
 
   shouldTileScreenshot(scale) {
-    return scale >= 8;
+    return scale >= 2;
   }
 
   shouldStreamScreenshot(scale) {
-    return scale >= 8;
+    return scale >= 2;
   }
 
   async exportScreenshot({ includeBackground = false, scale = 1 } = {}) {
@@ -1336,7 +1336,7 @@ export class GerberViewer {
     return {
       width: Math.max(
         1,
-        Math.min(maxDimension, Math.round(rect.width * 8)),
+        Math.min(maxDimension, Math.round(rect.width * 2)),
       ),
       height: Math.max(
         1,


### PR DESCRIPTION
### Motivation
- 스크린샷 내보내기에서 타일링/스트리밍 경로가 기존의 `8x` 이상에서만 동작해 실제 사용에서 과도하게 높은 임계값으로 동작이 제한되어 이를 `2x` 이상으로 낮추려는 변경입니다.

### Description
- `js/main.js`에서 `shouldTileScreenshot`와 `shouldStreamScreenshot`이 `scale >= 2`를 반환하도록 변경했고 `getScreenshotStreamTileDimensions`의 타일 너비 계산에서 `rect.width * 8`을 `rect.width * 2`로 조정했습니다.

### Testing
- `node --check js/main.js` 문법 검사를 실행했고 검사를 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0594c6fcdc83288e478b5da3cfb90a)