### PR TITLE
[codex] Set collapsed bottom drawer button height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,7 +20,7 @@
   --canvas-reserved-width: var(--panel-width);
   --canvas-reserved-height: var(--panel-height);
   --panel-collapsed-width: 76px;
-  --panel-collapsed-height: 102px;
+  --panel-collapsed-height: 122px;
   --panel-snap-threshold: 50px;
   --panel-bottom-collapse-threshold: 200px;
   --toolbar-height: 58px;

--- a/css/style.css
+++ b/css/style.css
@@ -1252,7 +1252,7 @@ button {
   .side-panel.collapsed .section-toolbar .chip-button {
     flex: 1;
     width: auto;
-    height: auto;
+    height: 42px;
     padding: 0 6px;
   }
 

--- a/js/drawer-controller.js
+++ b/js/drawer-controller.js
@@ -75,6 +75,7 @@ export class DrawerController {
 
   syncLayout() {
     if (this.drawer.classList.contains("collapsed")) {
+      this.syncCollapsedLayout();
       this.updateCanvasReservationForState();
       return;
     }
@@ -84,6 +85,17 @@ export class DrawerController {
     } else {
       this.setWidth(this.currentWidth);
     }
+  }
+
+  syncCollapsedLayout() {
+    if (this.isMobileLayout()) {
+      this.drawer.style.width = "";
+      this.drawer.style.height = `${this.currentHeight}px`;
+      return;
+    }
+
+    this.drawer.style.height = "";
+    this.drawer.style.width = `${this.currentWidth}px`;
   }
 
   isMobileLayout() {

--- a/js/drawer-controller.js
+++ b/js/drawer-controller.js
@@ -32,7 +32,7 @@ export class DrawerController {
     this.maxHeight = 560;
     this.mobileMaxHeightRatio = 0.72;
     this.collapsedWidth = 156;
-    this.collapsedHeight = 95;
+    this.collapsedHeight = 122;
     this.snapThreshold = 50;
     this.bottomCollapseThreshold = 200;
   }


### PR DESCRIPTION
## Summary
- Set collapsed bottom drawer toolbar chip buttons to a fixed 42px height in mobile layout.
- Increase the bottom drawer collapsed height by 20px to leave more touch space below the alpha control.
- Sync collapsed drawer inline dimensions when switching between bottom and right drawer breakpoints, so a mobile collapsed height does not constrain the desktop right drawer.

## Validation
- `for file in js/*.js; do node --check "$file" || exit 1; done`
- `git diff --check`