### PR TITLE
[codex] Simplify memory allocation errors

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1034,9 +1034,7 @@ export class GerberViewer {
     try {
       this.wasmModule.reserve_input_capacity(reserveBytes);
     } catch (error) {
-      throw new Error(
-        `Not enough WebAssembly memory to load ${formatFileSize(byteLength)} input: ${getErrorMessage(error)}`,
-      );
+      throw new Error(getErrorMessage(error));
     }
   }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -15,14 +15,31 @@ pub fn init_panic_hook() {
     console_error_panic_hook::set_once();
 }
 
+fn format_bytes(bytes: usize) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let bytes = bytes as f64;
+
+    if bytes >= GIB {
+        format!("{:.1} GB", bytes / GIB)
+    } else if bytes >= MIB {
+        format!("{:.1} MB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{:.1} KB", bytes / KIB)
+    } else {
+        format!("{} B", bytes as usize)
+    }
+}
+
 /// Preflight a large JS-to-WASM input copy with catchable allocation failure.
 #[wasm_bindgen]
 pub fn reserve_input_capacity(byte_count: usize) -> Result<(), JsValue> {
     let mut buffer = Vec::<u8>::new();
-    buffer.try_reserve_exact(byte_count).map_err(|error| {
+    buffer.try_reserve_exact(byte_count).map_err(|_| {
         JsValue::from_str(&format!(
-            "Not enough WebAssembly memory to load file input ({} bytes): {:?}",
-            byte_count, error
+            "Not enough WebAssembly memory to load file input ({})",
+            format_bytes(byte_count)
         ))
     })?;
     Ok(())

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -17,6 +17,7 @@ use state::{
 use self::geometry::{parse_graphic_command, Primitive};
 use crate::shape::{Arcs, Boundary, Circles, GerberData, Thermals, Triangles};
 use std::collections::HashMap;
+use std::mem::size_of;
 use std::mem::take;
 use wasm_bindgen::prelude::*;
 
@@ -229,15 +230,56 @@ fn checked_capacity(
     })
 }
 
+fn format_count(value: usize) -> String {
+    let digits = value.to_string();
+    let mut formatted = String::with_capacity(digits.len() + digits.len() / 3);
+    let first_group_len = digits.len() % 3;
+
+    for (index, ch) in digits.chars().enumerate() {
+        if index > 0 && (index - first_group_len) % 3 == 0 {
+            formatted.push(',');
+        }
+        formatted.push(ch);
+    }
+
+    formatted
+}
+
+fn format_bytes(bytes: usize) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let bytes = bytes as f64;
+
+    if bytes >= GIB {
+        format!("{:.1} GB", bytes / GIB)
+    } else if bytes >= MIB {
+        format!("{:.1} MB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{:.1} KB", bytes / KIB)
+    } else {
+        format!("{} B", bytes as usize)
+    }
+}
+
+fn format_value_allocation<T>(additional: usize) -> String {
+    let values = format_count(additional);
+    match additional.checked_mul(size_of::<T>()) {
+        Some(bytes) => format!("{} values, {}", values, format_bytes(bytes)),
+        None => format!("{} values", values),
+    }
+}
+
 fn try_reserve_exact<T>(
     values: &mut Vec<T>,
     additional: usize,
     buffer_name: &str,
 ) -> Result<(), JsValue> {
-    values.try_reserve_exact(additional).map_err(|error| {
+    values.try_reserve_exact(additional).map_err(|_| {
         JsValue::from_str(&format!(
-            "Gerber layer is too large to render: unable to allocate {} ({} values): {:?}",
-            buffer_name, additional, error
+            "Gerber layer is too large to render: not enough memory for {} ({})",
+            buffer_name,
+            format_value_allocation::<T>(additional)
         ))
     })
 }

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -236,7 +236,7 @@ fn format_count(value: usize) -> String {
     let first_group_len = digits.len() % 3;
 
     for (index, ch) in digits.chars().enumerate() {
-        if index > 0 && (index - first_group_len) % 3 == 0 {
+        if index > 0 && index >= first_group_len && (index - first_group_len) % 3 == 0 {
             formatted.push(',');
         }
         formatted.push(ch);

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -4,17 +4,47 @@ use i_overlay::core::overlay_rule::OverlayRule;
 use i_overlay::float::single::SingleFloatOverlay;
 use i_triangle::float::triangulatable::Triangulatable;
 use std::collections::HashMap;
+use std::mem::size_of;
 use std::mem::take;
 
-fn primitive_allocation_error(
-    context: &str,
-    additional: usize,
-    error: impl std::fmt::Debug,
-) -> String {
-    format!(
-        "Gerber layer is too large to parse: unable to allocate {} ({} primitives): {:?}",
-        context, additional, error
-    )
+fn format_count(value: usize) -> String {
+    let digits = value.to_string();
+    let mut formatted = String::with_capacity(digits.len() + digits.len() / 3);
+    let first_group_len = digits.len() % 3;
+
+    for (index, ch) in digits.chars().enumerate() {
+        if index > 0 && (index - first_group_len) % 3 == 0 {
+            formatted.push(',');
+        }
+        formatted.push(ch);
+    }
+
+    formatted
+}
+
+fn format_bytes(bytes: usize) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let bytes = bytes as f64;
+
+    if bytes >= GIB {
+        format!("{:.1} GB", bytes / GIB)
+    } else if bytes >= MIB {
+        format!("{:.1} MB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{:.1} KB", bytes / KIB)
+    } else {
+        format!("{} B", bytes as usize)
+    }
+}
+
+fn format_primitive_allocation(additional: usize) -> String {
+    let primitives = format_count(additional);
+    match additional.checked_mul(size_of::<Primitive>()) {
+        Some(bytes) => format!("{} primitives, {}", primitives, format_bytes(bytes)),
+        None => format!("{} primitives", primitives),
+    }
 }
 
 fn checked_primitive_count(
@@ -35,9 +65,13 @@ fn try_reserve_primitives(
     additional: usize,
     context: &str,
 ) -> Result<(), String> {
-    primitives
-        .try_reserve(additional)
-        .map_err(|error| primitive_allocation_error(context, additional, error))
+    primitives.try_reserve(additional).map_err(|_| {
+        format!(
+            "Gerber layer is too large to parse: not enough memory for {} ({})",
+            context,
+            format_primitive_allocation(additional)
+        )
+    })
 }
 
 fn try_reserve_layers(
@@ -45,10 +79,11 @@ fn try_reserve_layers(
     additional: usize,
     context: &str,
 ) -> Result<(), String> {
-    polarity_layers.try_reserve(additional).map_err(|error| {
+    polarity_layers.try_reserve(additional).map_err(|_| {
         format!(
-            "Gerber layer is too large to parse: unable to allocate {} ({} polarity layers): {:?}",
-            context, additional, error
+            "Gerber layer is too large to parse: not enough memory for {} ({} polarity layers)",
+            context,
+            format_count(additional)
         )
     })
 }

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -13,7 +13,7 @@ fn format_count(value: usize) -> String {
     let first_group_len = digits.len() % 3;
 
     for (index, ch) in digits.chars().enumerate() {
-        if index > 0 && (index - first_group_len) % 3 == 0 {
+        if index > 0 && index >= first_group_len && (index - first_group_len) % 3 == 0 {
             formatted.push(',');
         }
         formatted.push(ch);

--- a/wasm/src/parser/state.rs
+++ b/wasm/src/parser/state.rs
@@ -275,11 +275,9 @@ pub fn parse_lp(
 
     // Check if polarity has changed
     if state.polarity != new_polarity && !current_primitives.is_empty() {
-        polarity_layers.try_reserve(1).map_err(|error| {
-            format!(
-                "Gerber layer is too large to parse: unable to allocate polarity layer list: {:?}",
-                error
-            )
+        polarity_layers.try_reserve(1).map_err(|_| {
+            "Gerber layer is too large to parse: not enough memory for polarity layer list"
+                .to_string()
         })?;
         polarity_layers.push((state.polarity, take(current_primitives)));
     }

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1,6 +1,6 @@
 use super::aperture_macro::{evaluate_expression, parse_macro};
 use super::geometry::Primitive;
-use super::{parse_gerber, GerberParser, Polarity};
+use super::{format_count, parse_gerber, GerberParser, Polarity};
 use std::collections::HashMap;
 
 fn assert_approx_eq(actual: f32, expected: f32) {
@@ -54,6 +54,17 @@ fn test_circle() -> Primitive {
         hole_y: 0.0,
         hole_radius: 0.0,
     }
+}
+
+#[test]
+fn allocation_count_formatting_groups_digits_without_underflow() {
+    assert_eq!(format_count(0), "0");
+    assert_eq!(format_count(12), "12");
+    assert_eq!(format_count(123), "123");
+    assert_eq!(format_count(1_234), "1,234");
+    assert_eq!(format_count(12_345), "12,345");
+    assert_eq!(format_count(123_456), "123,456");
+    assert_eq!(format_count(24_000_000), "24,000,000");
 }
 
 fn scaled(value: f32) -> i32 {


### PR DESCRIPTION
## Summary
- Remove raw Rust allocation debug output from user-facing memory errors.
- Show only the failed allocation context and approximate size/count needed.
- Avoid duplicating the WASM input memory error prefix in JS.

## Validation
- `node --check js/main.js`
- `cargo test --manifest-path wasm/Cargo.toml`
- `wasm-pack build wasm --target web --out-dir pkg --release`