### PR TITLE
[codex] Optimize Gerber render memory usage

### DIFF
--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -21,9 +21,6 @@ use std::mem::size_of;
 use std::mem::take;
 use wasm_bindgen::prelude::*;
 
-// Security limits for resource consumption
-const MAX_TOTAL_PRIMITIVES: usize = 70_000_000; // 70 million total primitives max
-
 fn collect_lines(data: &str) -> Result<Vec<&str>, JsValue> {
     let line_count = data.bytes().filter(|byte| *byte == b'\n').count() + 1;
     let mut lines = Vec::new();
@@ -35,7 +32,9 @@ fn collect_lines(data: &str) -> Result<Vec<&str>, JsValue> {
 #[derive(Default)]
 struct PrimitiveBufferCounts {
     triangles: usize,
+    has_triangle_holes: bool,
     circles: usize,
+    has_circle_holes: bool,
     arcs: usize,
     thermals: usize,
 }
@@ -46,8 +45,14 @@ impl PrimitiveBufferCounts {
 
         for primitive in primitives {
             match primitive {
-                Primitive::Triangle { .. } => counts.triangles += 1,
-                Primitive::Circle { .. } => counts.circles += 1,
+                Primitive::Triangle { hole_radius, .. } => {
+                    counts.triangles += 1;
+                    counts.has_triangle_holes |= *hole_radius != 0.0;
+                }
+                Primitive::Circle { hole_radius, .. } => {
+                    counts.circles += 1;
+                    counts.has_circle_holes |= *hole_radius != 0.0;
+                }
                 Primitive::Arc { .. } => counts.arcs += 1,
                 Primitive::Thermal { .. } => counts.thermals += 1,
             }
@@ -58,11 +63,12 @@ impl PrimitiveBufferCounts {
 }
 
 struct PrimitiveOutputBuffers {
+    has_triangle_holes: bool,
     triangle_vertices: Vec<f32>,
-    triangle_indices: Vec<u32>,
     triangle_hole_x: Vec<f32>,
     triangle_hole_y: Vec<f32>,
     triangle_hole_radius: Vec<f32>,
+    has_circle_holes: bool,
     circles_x: Vec<f32>,
     circles_y: Vec<f32>,
     circles_radius: Vec<f32>,
@@ -88,20 +94,14 @@ impl PrimitiveOutputBuffers {
         let counts = PrimitiveBufferCounts::from_primitives(primitives);
         let triangle_vertex_values =
             checked_capacity(counts.triangles, 6, "triangle vertex buffer")?;
-        let triangle_index_values = checked_capacity(counts.triangles, 3, "triangle index buffer")?;
-
-        if triangle_index_values > u32::MAX as usize {
-            return Err(JsValue::from_str(
-                "Gerber layer is too large to render: triangle index buffer exceeds WebGL index range",
-            ));
-        }
 
         let mut buffers = Self {
+            has_triangle_holes: counts.has_triangle_holes,
             triangle_vertices: Vec::new(),
-            triangle_indices: Vec::new(),
             triangle_hole_x: Vec::new(),
             triangle_hole_y: Vec::new(),
             triangle_hole_radius: Vec::new(),
+            has_circle_holes: counts.has_circle_holes,
             circles_x: Vec::new(),
             circles_y: Vec::new(),
             circles_radius: Vec::new(),
@@ -127,26 +127,25 @@ impl PrimitiveOutputBuffers {
             triangle_vertex_values,
             "triangle vertex buffer",
         )?;
-        try_reserve_exact(
-            &mut buffers.triangle_indices,
-            triangle_index_values,
-            "triangle index buffer",
-        )?;
-        try_reserve_exact(
-            &mut buffers.triangle_hole_x,
-            triangle_index_values,
-            "triangle hole X buffer",
-        )?;
-        try_reserve_exact(
-            &mut buffers.triangle_hole_y,
-            triangle_index_values,
-            "triangle hole Y buffer",
-        )?;
-        try_reserve_exact(
-            &mut buffers.triangle_hole_radius,
-            triangle_index_values,
-            "triangle hole radius buffer",
-        )?;
+        if counts.has_triangle_holes {
+            let triangle_vertex_count =
+                checked_capacity(counts.triangles, 3, "triangle hole buffer")?;
+            try_reserve_exact(
+                &mut buffers.triangle_hole_x,
+                triangle_vertex_count,
+                "triangle hole X buffer",
+            )?;
+            try_reserve_exact(
+                &mut buffers.triangle_hole_y,
+                triangle_vertex_count,
+                "triangle hole Y buffer",
+            )?;
+            try_reserve_exact(
+                &mut buffers.triangle_hole_radius,
+                triangle_vertex_count,
+                "triangle hole radius buffer",
+            )?;
+        }
 
         try_reserve_exact(&mut buffers.circles_x, counts.circles, "circle X buffer")?;
         try_reserve_exact(&mut buffers.circles_y, counts.circles, "circle Y buffer")?;
@@ -155,21 +154,23 @@ impl PrimitiveOutputBuffers {
             counts.circles,
             "circle radius buffer",
         )?;
-        try_reserve_exact(
-            &mut buffers.circles_hole_x,
-            counts.circles,
-            "circle hole X buffer",
-        )?;
-        try_reserve_exact(
-            &mut buffers.circles_hole_y,
-            counts.circles,
-            "circle hole Y buffer",
-        )?;
-        try_reserve_exact(
-            &mut buffers.circles_hole_radius,
-            counts.circles,
-            "circle hole radius buffer",
-        )?;
+        if counts.has_circle_holes {
+            try_reserve_exact(
+                &mut buffers.circles_hole_x,
+                counts.circles,
+                "circle hole X buffer",
+            )?;
+            try_reserve_exact(
+                &mut buffers.circles_hole_y,
+                counts.circles,
+                "circle hole Y buffer",
+            )?;
+            try_reserve_exact(
+                &mut buffers.circles_hole_radius,
+                counts.circles,
+                "circle hole radius buffer",
+            )?;
+        }
 
         try_reserve_exact(&mut buffers.arcs_x, counts.arcs, "arc X buffer")?;
         try_reserve_exact(&mut buffers.arcs_y, counts.arcs, "arc Y buffer")?;
@@ -284,6 +285,20 @@ fn try_reserve_exact<T>(
     })
 }
 
+fn try_reserve_string(
+    value: &mut String,
+    additional: usize,
+    buffer_name: &str,
+) -> Result<(), JsValue> {
+    value.try_reserve(additional).map_err(|_| {
+        JsValue::from_str(&format!(
+            "Gerber layer is too large to render: not enough memory for {} ({})",
+            buffer_name,
+            format_value_allocation::<u8>(additional)
+        ))
+    })
+}
+
 /// Gerber parser with stateful aperture and macro storage
 pub struct GerberParser {
     pub apertures: HashMap<String, Aperture>,
@@ -356,8 +371,6 @@ impl GerberParser {
                 .map_err(|message| JsValue::from_str(&message))?;
             }
 
-            self.enforce_primitive_limit(MAX_TOTAL_PRIMITIVES)
-                .map_err(|message| JsValue::from_str(&message))?;
             i += 1;
         }
 
@@ -368,8 +381,6 @@ impl GerberParser {
                 self.current_state.polarity,
                 take(&mut self.current_primitives),
             ));
-            self.enforce_primitive_limit(MAX_TOTAL_PRIMITIVES)
-                .map_err(|message| JsValue::from_str(&message))?;
         }
 
         // Convert each layer to individual GerberData
@@ -389,32 +400,12 @@ impl GerberParser {
         Ok(gerber_data_layers)
     }
 
-    fn enforce_primitive_limit(&self, max_total_primitives: usize) -> Result<(), String> {
-        let flushed_primitives = self
-            .polarity_layers
-            .iter()
-            .map(|(_, primitives)| primitives.len())
-            .sum::<usize>();
-        let total_primitives = flushed_primitives + self.current_primitives.len();
-
-        if total_primitives > max_total_primitives {
-            return Err(format!(
-                "Too many total primitives: {} (max: {})",
-                total_primitives, max_total_primitives
-            ));
-        }
-
-        Ok(())
-    }
-
     /// Convert a vector of primitives to GerberData
     fn primitives_to_gerber_data(
         primitives: &[Primitive],
         is_negative: bool,
     ) -> Result<GerberData, JsValue> {
         let mut buffers = PrimitiveOutputBuffers::reserved_for(primitives)?;
-
-        let mut vertex_offset: u32 = 0;
 
         // Unit conversion: aperture.rs already converts to mm using unit_multiplier
         // No additional conversion needed
@@ -434,17 +425,14 @@ impl GerberParser {
                         buffers.triangle_vertices.push(vertex[0] * TO_MM);
                         buffers.triangle_vertices.push(vertex[1] * TO_MM);
                     }
-                    // Add index for every 3 vertices (one triangle)
-                    buffers.triangle_indices.push(vertex_offset);
-                    buffers.triangle_indices.push(vertex_offset + 1);
-                    buffers.triangle_indices.push(vertex_offset + 2);
-                    vertex_offset += 3;
 
-                    // Add hole data for each vertex (3 times per triangle)
-                    for _ in 0..3 {
-                        buffers.triangle_hole_x.push(*hole_x * TO_MM);
-                        buffers.triangle_hole_y.push(*hole_y * TO_MM);
-                        buffers.triangle_hole_radius.push(*hole_radius * TO_MM);
+                    if buffers.has_triangle_holes {
+                        // Add hole data for each vertex (3 times per triangle)
+                        for _ in 0..3 {
+                            buffers.triangle_hole_x.push(*hole_x * TO_MM);
+                            buffers.triangle_hole_y.push(*hole_y * TO_MM);
+                            buffers.triangle_hole_radius.push(*hole_radius * TO_MM);
+                        }
                     }
                 }
                 Primitive::Circle {
@@ -459,9 +447,11 @@ impl GerberParser {
                     buffers.circles_x.push(*x * TO_MM);
                     buffers.circles_y.push(*y * TO_MM);
                     buffers.circles_radius.push(*radius * TO_MM);
-                    buffers.circles_hole_x.push(*hole_x * TO_MM);
-                    buffers.circles_hole_y.push(*hole_y * TO_MM);
-                    buffers.circles_hole_radius.push(*hole_radius * TO_MM);
+                    if buffers.has_circle_holes {
+                        buffers.circles_hole_x.push(*hole_x * TO_MM);
+                        buffers.circles_hole_y.push(*hole_y * TO_MM);
+                        buffers.circles_hole_radius.push(*hole_radius * TO_MM);
+                    }
                 }
                 Primitive::Arc {
                     x,
@@ -565,7 +555,6 @@ impl GerberParser {
         Ok(GerberData::new(
             Triangles::new(
                 buffers.triangle_vertices,
-                buffers.triangle_indices,
                 buffers.triangle_hole_x,
                 buffers.triangle_hole_y,
                 buffers.triangle_hole_radius,
@@ -612,14 +601,15 @@ fn parse_command(
     polarity_layers: &mut Vec<(Polarity, Vec<Primitive>)>,
 ) -> Result<(), JsValue> {
     let line = if !line_ref.ends_with('%') {
-        let mut buffer = Vec::new();
-        try_reserve_exact(&mut buffer, 1, "extended command line buffer")?;
-        buffer.push(line_ref.to_string());
+        let mut buffer = String::new();
+        try_reserve_string(&mut buffer, line_ref.len(), "extended command buffer")?;
+        buffer.push_str(line_ref);
         *i += 1;
 
         while *i < length {
             let next_line = lines[*i].trim();
-            buffer.push(next_line.to_string());
+            try_reserve_string(&mut buffer, next_line.len(), "extended command buffer")?;
+            buffer.push_str(next_line);
 
             if next_line.ends_with('%') {
                 break;
@@ -627,7 +617,7 @@ fn parse_command(
             *i += 1;
         }
 
-        buffer.join("")
+        buffer
     } else {
         line_ref.to_string()
     };

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1,6 +1,5 @@
 use super::aperture_macro::{evaluate_expression, parse_macro};
-use super::geometry::Primitive;
-use super::{format_count, parse_gerber, GerberParser, Polarity};
+use super::{format_count, parse_gerber};
 use std::collections::HashMap;
 
 fn assert_approx_eq(actual: f32, expected: f32) {
@@ -44,18 +43,6 @@ fn has_circle_at(
         })
 }
 
-fn test_circle() -> Primitive {
-    Primitive::Circle {
-        x: 0.0,
-        y: 0.0,
-        radius: 0.5,
-        exposure: 1.0,
-        hole_x: 0.0,
-        hole_y: 0.0,
-        hole_radius: 0.0,
-    }
-}
-
 #[test]
 fn allocation_count_formatting_groups_digits_without_underflow() {
     assert_eq!(format_count(0), "0");
@@ -81,12 +68,6 @@ fn push_scaled_vec(output: &mut String, label: &str, values: &[f32]) {
     }
 }
 
-fn push_indices(output: &mut String, label: &str, values: &[u32]) {
-    if !values.is_empty() {
-        output.push_str(&format!("{label}={values:?}\n"));
-    }
-}
-
 fn gerber_snapshot(data: &str) -> String {
     let layers = parse_gerber(data).expect("snapshot input should parse");
     let mut output = String::new();
@@ -106,11 +87,6 @@ fn gerber_snapshot(data: &str) -> String {
             &mut output,
             &format!("layer[{idx}].triangles.vertices"),
             &layer.triangles.vertices,
-        );
-        push_indices(
-            &mut output,
-            &format!("layer[{idx}].triangles.indices"),
-            &layer.triangles.indices,
         );
         push_scaled_vec(
             &mut output,
@@ -313,11 +289,7 @@ M02*",
 layers=1
 layer[0].negative=false
 layer[0].boundary=[0,10000,0,10000]
-layer[0].triangles.vertices=[10000, 0, 0, 10000, 0, 0, 10000, 10000, 0, 10000, 10000, 0]
-layer[0].triangles.indices=[0, 1, 2, 3, 4, 5]
-layer[0].triangles.hole_x=[0, 0, 0, 0, 0, 0]
-layer[0].triangles.hole_y=[0, 0, 0, 0, 0, 0]
-layer[0].triangles.hole_radius=[0, 0, 0, 0, 0, 0]",
+layer[0].triangles.vertices=[10000, 0, 0, 10000, 0, 0, 10000, 10000, 0, 10000, 10000, 0]",
     );
 }
 
@@ -339,11 +311,68 @@ layer[0].negative=false
 layer[0].boundary=[-12700,266700,-12700,12700]
 layer[0].circles.x=[0, 254000]
 layer[0].circles.y=[0, 0]
-layer[0].circles.radius=[12700, 12700]
-layer[0].circles.hole_x=[0, 254000]
-layer[0].circles.hole_y=[0, 0]
-layer[0].circles.hole_radius=[0, 0]",
+layer[0].circles.radius=[12700, 12700]",
     );
+}
+
+#[test]
+fn no_hole_apertures_omit_hole_buffers() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X1.0*%
+%ADD11C,1.0*%
+D10*
+X000000Y000000D03*
+D11*
+X2000000Y000000D03*
+M02*",
+    )
+    .expect("apertures should parse");
+
+    let triangles = &layers[0].triangles;
+    assert!(!triangles.vertices.is_empty());
+    assert!(triangles.hole_x.is_empty());
+    assert!(triangles.hole_y.is_empty());
+    assert!(triangles.hole_radius.is_empty());
+
+    let circles = &layers[0].circles;
+    assert_eq!(circles.x.len(), 1);
+    assert!(circles.hole_x.is_empty());
+    assert!(circles.hole_y.is_empty());
+    assert!(circles.hole_radius.is_empty());
+}
+
+#[test]
+fn apertures_with_holes_keep_hole_buffers() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X1.0X0.2*%
+%ADD11C,1.0X0.2*%
+D10*
+X000000Y000000D03*
+D11*
+X2000000Y000000D03*
+M02*",
+    )
+    .expect("apertures should parse");
+
+    let triangles = &layers[0].triangles;
+    assert!(!triangles.vertices.is_empty());
+    assert_eq!(triangles.hole_x.len(), triangles.vertices.len() / 2);
+    assert_eq!(triangles.hole_y.len(), triangles.vertices.len() / 2);
+    assert_eq!(triangles.hole_radius.len(), triangles.vertices.len() / 2);
+    assert!(triangles.hole_radius.iter().all(|radius| *radius > 0.0));
+
+    let circles = &layers[0].circles;
+    assert_eq!(circles.x.len(), 1);
+    assert_eq!(circles.hole_x.len(), circles.x.len());
+    assert_eq!(circles.hole_y.len(), circles.x.len());
+    assert_eq!(circles.hole_radius.len(), circles.x.len());
+    assert!(circles.hole_radius.iter().all(|radius| *radius > 0.0));
 }
 
 #[test]
@@ -361,11 +390,7 @@ M02*",
 layers=1
 layer[0].negative=false
 layer[0].boundary=[-5000,5000,0,20000]
-layer[0].triangles.vertices=[5000, 0, 5000, 20000, -5000, 20000, 5000, 0, -5000, 20000, -5000, 0]
-layer[0].triangles.indices=[0, 1, 2, 3, 4, 5]
-layer[0].triangles.hole_x=[0, 0, 0, 0, 0, 0]
-layer[0].triangles.hole_y=[0, 0, 0, 0, 0, 0]
-layer[0].triangles.hole_radius=[0, 0, 0, 0, 0, 0]",
+layer[0].triangles.vertices=[5000, 0, 5000, 20000, -5000, 20000, 5000, 0, -5000, 20000, -5000, 0]",
     );
 }
 
@@ -396,17 +421,11 @@ layer[0].boundary=[80000,120000,-20000,20000]
 layer[0].circles.x=[100000]
 layer[0].circles.y=[0]
 layer[0].circles.radius=[20000]
-layer[0].circles.hole_x=[100000]
-layer[0].circles.hole_y=[0]
-layer[0].circles.hole_radius=[0]
 layer[1].negative=true
 layer[1].boundary=[90000,110000,-10000,10000]
 layer[1].circles.x=[100000]
 layer[1].circles.y=[0]
-layer[1].circles.radius=[10000]
-layer[1].circles.hole_x=[100000]
-layer[1].circles.hole_y=[0]
-layer[1].circles.hole_radius=[0]",
+layer[1].circles.radius=[10000]",
     );
 }
 
@@ -431,10 +450,7 @@ layer[0].negative=false
 layer[0].boundary=[95000,105000,5000,15000]
 layer[0].circles.x=[100000]
 layer[0].circles.y=[10000]
-layer[0].circles.radius=[5000]
-layer[0].circles.hole_x=[100000]
-layer[0].circles.hole_y=[10000]
-layer[0].circles.hole_radius=[0]",
+layer[0].circles.radius=[5000]",
     );
 }
 
@@ -460,23 +476,8 @@ M02*",
 layers=1
 layer[0].negative=false
 layer[0].boundary=[-2000,0,-9000,11000]
-layer[0].triangles.vertices=[-2000, 8000, -2000, -6000, 0, -9000, 0, 11000, -2000, 8000, 0, -9000]
-layer[0].triangles.indices=[0, 1, 2, 3, 4, 5]
-layer[0].triangles.hole_x=[0, 0, 0, 0, 0, 0]
-layer[0].triangles.hole_y=[0, 0, 0, 0, 0, 0]
-layer[0].triangles.hole_radius=[0, 0, 0, 0, 0, 0]",
+layer[0].triangles.vertices=[-2000, 8000, -2000, -6000, 0, -9000, 0, 11000, -2000, 8000, 0, -9000]",
     );
-}
-
-#[test]
-fn primitive_limit_counts_flushed_polarity_layers() {
-    let mut parser = GerberParser::new();
-    parser
-        .polarity_layers
-        .push((Polarity::Positive, vec![test_circle()]));
-    parser.current_primitives.push(test_circle());
-
-    assert!(parser.enforce_primitive_limit(1).is_err());
 }
 
 #[test]
@@ -498,7 +499,6 @@ M02*";
     let triangles = &layers[0].triangles;
 
     assert_eq!(triangles.vertices.len() / 2, 6);
-    assert_eq!(triangles.indices.len(), 6);
 }
 
 #[test]
@@ -719,7 +719,7 @@ M02*";
     let layers = parse_gerber(data).expect("macro expression should parse");
 
     assert_eq!(layers.len(), 1);
-    assert!(!layers[0].triangles.indices.is_empty());
+    assert!(!layers[0].triangles.vertices.is_empty());
 }
 
 #[test]

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -6,8 +6,8 @@ mod shader;
 use buffer::{BufferCache, Fbo};
 use camera::Camera;
 use shader::{
-    ShaderProgram, ShaderPrograms, ARRAY_BUFFER, BLEND, COLOR_BUFFER_BIT, ELEMENT_ARRAY_BUFFER,
-    FLOAT, FUNC_ADD, ONE, ONE_MINUS_SRC_ALPHA, STATIC_DRAW, TRIANGLES, UNSIGNED_INT, ZERO,
+    ShaderProgram, ShaderPrograms, ARRAY_BUFFER, BLEND, COLOR_BUFFER_BIT, FLOAT, FUNC_ADD, ONE,
+    ONE_MINUS_SRC_ALPHA, STATIC_DRAW, TRIANGLES, ZERO,
 };
 
 use crate::shape::{Arcs, Boundary, Circles, GerberData, Thermals, Triangles};
@@ -138,51 +138,45 @@ impl Renderer {
                 sublayer_idx
             )));
         }
-        if !triangles.indices.len().is_multiple_of(3) {
-            return Err(JsValue::from_str(&format!(
-                "Sublayer {} triangle index buffer is not divisible by 3",
-                sublayer_idx
-            )));
-        }
-
         let vertex_count = triangles.vertices.len() / 2;
-        Self::validate_len(
-            "triangle hole_x",
-            sublayer_idx,
-            triangles.hole_x.len(),
-            vertex_count,
-        )?;
-        Self::validate_len(
-            "triangle hole_y",
-            sublayer_idx,
-            triangles.hole_y.len(),
-            vertex_count,
-        )?;
-        Self::validate_len(
-            "triangle hole_radius",
-            sublayer_idx,
-            triangles.hole_radius.len(),
-            vertex_count,
-        )?;
-        Self::validate_finite_slice("triangle vertices", &triangles.vertices)?;
-        Self::validate_finite_slice("triangle hole_x", &triangles.hole_x)?;
-        Self::validate_finite_slice("triangle hole_y", &triangles.hole_y)?;
-        Self::validate_non_negative_slice("triangle hole_radius", &triangles.hole_radius)?;
-
-        if triangles
-            .indices
-            .iter()
-            .any(|&index| index as usize >= vertex_count)
-        {
+        if !vertex_count.is_multiple_of(3) {
             return Err(JsValue::from_str(&format!(
-                "Sublayer {} triangle index references a missing vertex",
+                "Sublayer {} triangle vertex count is not divisible by 3",
                 sublayer_idx
             )));
         }
 
-        if triangles.indices.len() > i32::MAX as usize {
+        Self::validate_finite_slice("triangle vertices", &triangles.vertices)?;
+        if !triangles.hole_x.is_empty()
+            || !triangles.hole_y.is_empty()
+            || !triangles.hole_radius.is_empty()
+        {
+            Self::validate_len(
+                "triangle hole_x",
+                sublayer_idx,
+                triangles.hole_x.len(),
+                vertex_count,
+            )?;
+            Self::validate_len(
+                "triangle hole_y",
+                sublayer_idx,
+                triangles.hole_y.len(),
+                vertex_count,
+            )?;
+            Self::validate_len(
+                "triangle hole_radius",
+                sublayer_idx,
+                triangles.hole_radius.len(),
+                vertex_count,
+            )?;
+            Self::validate_finite_slice("triangle hole_x", &triangles.hole_x)?;
+            Self::validate_finite_slice("triangle hole_y", &triangles.hole_y)?;
+            Self::validate_non_negative_slice("triangle hole_radius", &triangles.hole_radius)?;
+        }
+
+        if vertex_count > i32::MAX as usize {
             return Err(JsValue::from_str(&format!(
-                "Sublayer {} triangle index count exceeds WebGL draw limits",
+                "Sublayer {} triangle vertex count exceeds WebGL draw limits",
                 sublayer_idx
             )));
         }
@@ -195,20 +189,25 @@ impl Renderer {
         Self::validate_instance_count("circle", sublayer_idx, count)?;
         Self::validate_len("circle y", sublayer_idx, circles.y.len(), count)?;
         Self::validate_len("circle radius", sublayer_idx, circles.radius.len(), count)?;
-        Self::validate_len("circle hole_x", sublayer_idx, circles.hole_x.len(), count)?;
-        Self::validate_len("circle hole_y", sublayer_idx, circles.hole_y.len(), count)?;
-        Self::validate_len(
-            "circle hole_radius",
-            sublayer_idx,
-            circles.hole_radius.len(),
-            count,
-        )?;
         Self::validate_finite_slice("circle x", &circles.x)?;
         Self::validate_finite_slice("circle y", &circles.y)?;
         Self::validate_non_negative_slice("circle radius", &circles.radius)?;
-        Self::validate_finite_slice("circle hole_x", &circles.hole_x)?;
-        Self::validate_finite_slice("circle hole_y", &circles.hole_y)?;
-        Self::validate_non_negative_slice("circle hole_radius", &circles.hole_radius)?;
+        if !circles.hole_x.is_empty()
+            || !circles.hole_y.is_empty()
+            || !circles.hole_radius.is_empty()
+        {
+            Self::validate_len("circle hole_x", sublayer_idx, circles.hole_x.len(), count)?;
+            Self::validate_len("circle hole_y", sublayer_idx, circles.hole_y.len(), count)?;
+            Self::validate_len(
+                "circle hole_radius",
+                sublayer_idx,
+                circles.hole_radius.len(),
+                count,
+            )?;
+            Self::validate_finite_slice("circle hole_x", &circles.hole_x)?;
+            Self::validate_finite_slice("circle hole_y", &circles.hole_y)?;
+            Self::validate_non_negative_slice("circle hole_radius", &circles.hole_radius)?;
+        }
         Ok(())
     }
 
@@ -391,9 +390,6 @@ impl Renderer {
             gl.delete_vertex_array(Some(&vao));
         }
         if let Some(buf) = cache.triangle_vertex_buffer {
-            gl.delete_buffer(Some(&buf));
-        }
-        if let Some(buf) = cache.triangle_index_buffer {
             gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.triangle_hole_center_buffer {
@@ -595,14 +591,51 @@ impl Renderer {
         Ok(buffer)
     }
 
+    fn use_constant_vertex_attrib_1f(
+        gl: &WebGl2RenderingContext,
+        program: &ShaderProgram,
+        attr_name: &str,
+        x: f32,
+    ) -> Result<(), JsValue> {
+        let loc = Self::shader_attribute(program, attr_name)?;
+        gl.disable_vertex_attrib_array(loc);
+        gl.vertex_attrib1f(loc, x);
+        Ok(())
+    }
+
+    fn use_constant_vertex_attrib_2f(
+        gl: &WebGl2RenderingContext,
+        program: &ShaderProgram,
+        attr_name: &str,
+        x: f32,
+        y: f32,
+    ) -> Result<(), JsValue> {
+        let loc = Self::shader_attribute(program, attr_name)?;
+        gl.disable_vertex_attrib_array(loc);
+        gl.vertex_attrib2f(loc, x, y);
+        Ok(())
+    }
+
     /// Interleave x,y arrays into a single flat array
-    fn interleave_xy(x: &[f32], y: &[f32]) -> Vec<f32> {
-        let mut result = Vec::with_capacity(x.len() * 2);
+    fn interleave_xy(x: &[f32], y: &[f32], label: &str) -> Result<Vec<f32>, JsValue> {
+        let capacity = x.len().checked_mul(2).ok_or_else(|| {
+            JsValue::from_str(&format!(
+                "Renderer temporary buffer is too large: {} size overflow",
+                label
+            ))
+        })?;
+        let mut result = Vec::new();
+        result.try_reserve_exact(capacity).map_err(|_| {
+            JsValue::from_str(&format!(
+                "Not enough memory for renderer temporary buffer: {} ({} values)",
+                label, capacity
+            ))
+        })?;
         for i in 0..x.len() {
             result.push(x[i]);
             result.push(y[i]);
         }
-        result
+        Ok(result)
     }
 
     /// Create quad buffer for instanced rendering
@@ -748,7 +781,11 @@ impl Renderer {
             } else {
                 return Err(JsValue::from_str("Layer deallocated"));
             };
-            if layer.gerber_data[sublayer_idx].triangles.indices.is_empty() {
+            if layer.gerber_data[sublayer_idx]
+                .triangles
+                .vertices
+                .is_empty()
+            {
                 return Ok(());
             }
         }
@@ -757,7 +794,7 @@ impl Renderer {
         self.gl.use_program(Some(&program.program));
 
         // Buffer creation/update phase (scoped to end borrow early)
-        let index_count = {
+        let vertex_count = {
             let layer = if let Some(l) = &mut self.layers[layer_id] {
                 l
             } else {
@@ -787,59 +824,72 @@ impl Renderer {
                         .buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
                 }
 
-                // Create and bind index buffer
-                let index_buffer = self
-                    .gl
-                    .create_buffer()
-                    .ok_or_else(|| JsValue::from_str("Failed to create index buffer"))?;
-                self.gl
-                    .bind_buffer(ELEMENT_ARRAY_BUFFER, Some(&index_buffer));
-                unsafe {
-                    let array = js_sys::Uint32Array::view(&triangles.indices);
-                    self.gl.buffer_data_with_array_buffer_view(
-                        ELEMENT_ARRAY_BUFFER,
-                        &array,
-                        STATIC_DRAW,
-                    );
-                }
-
                 // Set up attributes
                 let position_loc = Self::shader_attribute(program, "position")?;
                 self.gl.enable_vertex_attrib_array(position_loc);
                 self.gl
                     .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
-                // Create regular attribute buffers for hole data (per-vertex)
-                let hole_centers = Self::interleave_xy(&triangles.hole_x, &triangles.hole_y);
-                let hole_center_buffer = self
-                    .gl
-                    .create_buffer()
-                    .ok_or_else(|| JsValue::from_str("Failed to create hole center buffer"))?;
-                self.gl.bind_buffer(ARRAY_BUFFER, Some(&hole_center_buffer));
-                unsafe {
-                    let array = Float32Array::view(&hole_centers);
+                if triangles.hole_radius.is_empty() {
+                    Self::use_constant_vertex_attrib_2f(
+                        &self.gl,
+                        program,
+                        "hole_center_instance",
+                        0.0,
+                        0.0,
+                    )?;
+                    Self::use_constant_vertex_attrib_1f(
+                        &self.gl,
+                        program,
+                        "hole_radius_instance",
+                        0.0,
+                    )?;
+                } else {
+                    // Create regular attribute buffers for hole data (per-vertex)
+                    let hole_centers = Self::interleave_xy(
+                        &triangles.hole_x,
+                        &triangles.hole_y,
+                        "triangle holes",
+                    )?;
+                    let hole_center_buffer = self
+                        .gl
+                        .create_buffer()
+                        .ok_or_else(|| JsValue::from_str("Failed to create hole center buffer"))?;
+                    self.gl.bind_buffer(ARRAY_BUFFER, Some(&hole_center_buffer));
+                    unsafe {
+                        let array = Float32Array::view(&hole_centers);
+                        self.gl.buffer_data_with_array_buffer_view(
+                            ARRAY_BUFFER,
+                            &array,
+                            STATIC_DRAW,
+                        );
+                    }
+                    let hole_center_loc = Self::shader_attribute(program, "hole_center_instance")?;
+                    self.gl.enable_vertex_attrib_array(hole_center_loc);
                     self.gl
-                        .buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
-                }
-                let hole_center_loc = Self::shader_attribute(program, "hole_center_instance")?;
-                self.gl.enable_vertex_attrib_array(hole_center_loc);
-                self.gl
-                    .vertex_attrib_pointer_with_i32(hole_center_loc, 2, FLOAT, false, 0, 0);
+                        .vertex_attrib_pointer_with_i32(hole_center_loc, 2, FLOAT, false, 0, 0);
 
-                let hole_radius_buffer = self
-                    .gl
-                    .create_buffer()
-                    .ok_or_else(|| JsValue::from_str("Failed to create hole radius buffer"))?;
-                self.gl.bind_buffer(ARRAY_BUFFER, Some(&hole_radius_buffer));
-                unsafe {
-                    let array = Float32Array::view(&triangles.hole_radius);
+                    let hole_radius_buffer = self
+                        .gl
+                        .create_buffer()
+                        .ok_or_else(|| JsValue::from_str("Failed to create hole radius buffer"))?;
+                    self.gl.bind_buffer(ARRAY_BUFFER, Some(&hole_radius_buffer));
+                    unsafe {
+                        let array = Float32Array::view(&triangles.hole_radius);
+                        self.gl.buffer_data_with_array_buffer_view(
+                            ARRAY_BUFFER,
+                            &array,
+                            STATIC_DRAW,
+                        );
+                    }
+                    let hole_radius_loc = Self::shader_attribute(program, "hole_radius_instance")?;
+                    self.gl.enable_vertex_attrib_array(hole_radius_loc);
                     self.gl
-                        .buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
+                        .vertex_attrib_pointer_with_i32(hole_radius_loc, 1, FLOAT, false, 0, 0);
+
+                    buffer_cache.triangle_hole_center_buffer = Some(hole_center_buffer);
+                    buffer_cache.triangle_hole_radius_buffer = Some(hole_radius_buffer);
                 }
-                let hole_radius_loc = Self::shader_attribute(program, "hole_radius_instance")?;
-                self.gl.enable_vertex_attrib_array(hole_radius_loc);
-                self.gl
-                    .vertex_attrib_pointer_with_i32(hole_radius_loc, 1, FLOAT, false, 0, 0);
 
                 // Unbind VAO
                 self.gl.bind_vertex_array(None);
@@ -847,12 +897,9 @@ impl Renderer {
                 // Cache VAO and buffers for this sublayer
                 buffer_cache.triangle_vao = Some(vao);
                 buffer_cache.triangle_vertex_buffer = Some(vertex_buffer);
-                buffer_cache.triangle_index_buffer = Some(index_buffer);
-                buffer_cache.triangle_hole_center_buffer = Some(hole_center_buffer);
-                buffer_cache.triangle_hole_radius_buffer = Some(hole_radius_buffer);
             }
 
-            triangles.indices.len()
+            triangles.vertices.len() / 2
         }; // Borrow ends here
 
         // Rendering phase (new borrow)
@@ -862,6 +909,16 @@ impl Renderer {
         // Bind cached VAO for this sublayer
         self.gl
             .bind_vertex_array(buffer_cache.triangle_vao.as_ref());
+        if buffer_cache.triangle_hole_radius_buffer.is_none() {
+            Self::use_constant_vertex_attrib_2f(
+                &self.gl,
+                program,
+                "hole_center_instance",
+                0.0,
+                0.0,
+            )?;
+            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_radius_instance", 0.0)?;
+        }
 
         // Set uniforms (only these change per frame)
         if let Some(loc) = program.uniforms.get("transform") {
@@ -873,8 +930,7 @@ impl Renderer {
         }
 
         // Draw
-        self.gl
-            .draw_elements_with_i32(TRIANGLES, index_count as i32, UNSIGNED_INT, 0);
+        self.gl.draw_arrays(TRIANGLES, 0, vertex_count as i32);
 
         // Unbind VAO to prevent state leakage
         self.gl.bind_vertex_array(None);
@@ -927,7 +983,7 @@ impl Renderer {
                 .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
             // Create instance buffers
-            let centers = Self::interleave_xy(&circles.x, &circles.y);
+            let centers = Self::interleave_xy(&circles.x, &circles.y, "circle centers")?;
             let center_buffer =
                 Self::create_instance_buffer_2d(&self.gl, &centers, program, "center_instance", 1)?;
             let radius_buffer = Self::create_instance_buffer(
@@ -937,21 +993,41 @@ impl Renderer {
                 "radius_instance",
                 1,
             )?;
-            let hole_centers = Self::interleave_xy(&circles.hole_x, &circles.hole_y);
-            let hole_center_buffer = Self::create_instance_buffer_2d(
-                &self.gl,
-                &hole_centers,
-                program,
-                "hole_center_instance",
-                1,
-            )?;
-            let hole_radius_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &circles.hole_radius,
-                program,
-                "hole_radius_instance",
-                1,
-            )?;
+            if circles.hole_radius.is_empty() {
+                Self::use_constant_vertex_attrib_2f(
+                    &self.gl,
+                    program,
+                    "hole_center_instance",
+                    0.0,
+                    0.0,
+                )?;
+                Self::use_constant_vertex_attrib_1f(
+                    &self.gl,
+                    program,
+                    "hole_radius_instance",
+                    0.0,
+                )?;
+            } else {
+                let hole_centers =
+                    Self::interleave_xy(&circles.hole_x, &circles.hole_y, "circle holes")?;
+                let hole_center_buffer = Self::create_instance_buffer_2d(
+                    &self.gl,
+                    &hole_centers,
+                    program,
+                    "hole_center_instance",
+                    1,
+                )?;
+                let hole_radius_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &circles.hole_radius,
+                    program,
+                    "hole_radius_instance",
+                    1,
+                )?;
+
+                buffer_cache.circle_hole_center_buffer = Some(hole_center_buffer);
+                buffer_cache.circle_hole_radius_buffer = Some(hole_radius_buffer);
+            }
 
             // Unbind VAO
             self.gl.bind_vertex_array(None);
@@ -960,8 +1036,6 @@ impl Renderer {
             buffer_cache.circle_vao = Some(vao);
             buffer_cache.circle_center_buffer = Some(center_buffer);
             buffer_cache.circle_radius_buffer = Some(radius_buffer);
-            buffer_cache.circle_hole_center_buffer = Some(hole_center_buffer);
-            buffer_cache.circle_hole_radius_buffer = Some(hole_radius_buffer);
         }
 
         // Re-get immutable reference for rendering
@@ -970,6 +1044,16 @@ impl Renderer {
 
         // Bind cached VAO for this sublayer
         self.gl.bind_vertex_array(buffer_cache.circle_vao.as_ref());
+        if buffer_cache.circle_hole_radius_buffer.is_none() {
+            Self::use_constant_vertex_attrib_2f(
+                &self.gl,
+                program,
+                "hole_center_instance",
+                0.0,
+                0.0,
+            )?;
+            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_radius_instance", 0.0)?;
+        }
 
         // Set uniforms (only these change per frame)
         if let Some(loc) = program.uniforms.get("transform") {
@@ -1035,7 +1119,7 @@ impl Renderer {
                 .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
             // Create instance buffers
-            let centers = Self::interleave_xy(&arcs.x, &arcs.y);
+            let centers = Self::interleave_xy(&arcs.x, &arcs.y, "arc centers")?;
             let center_buffer =
                 Self::create_instance_buffer_2d(&self.gl, &centers, program, "center_instance", 1)?;
             let radius_buffer = Self::create_instance_buffer(
@@ -1150,7 +1234,7 @@ impl Renderer {
                 .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
             // Create instance buffers
-            let centers = Self::interleave_xy(&thermals.x, &thermals.y);
+            let centers = Self::interleave_xy(&thermals.x, &thermals.y, "thermal centers")?;
             let center_buffer =
                 Self::create_instance_buffer_2d(&self.gl, &centers, program, "center_instance", 1)?;
             let outer_diameter_buffer = Self::create_instance_buffer(

--- a/wasm/src/renderer/buffer.rs
+++ b/wasm/src/renderer/buffer.rs
@@ -12,7 +12,6 @@ pub struct BufferCache {
     // Triangles cache
     pub triangle_vao: Option<WebGlVertexArrayObject>,
     pub triangle_vertex_buffer: Option<WebGlBuffer>,
-    pub triangle_index_buffer: Option<WebGlBuffer>,
     pub triangle_hole_center_buffer: Option<WebGlBuffer>,
     pub triangle_hole_radius_buffer: Option<WebGlBuffer>,
 

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -6,9 +6,7 @@ use web_sys::{WebGl2RenderingContext, WebGlProgram, WebGlShader, WebGlUniformLoc
 pub const COLOR_BUFFER_BIT: u32 = WebGl2RenderingContext::COLOR_BUFFER_BIT;
 pub const TRIANGLES: u32 = WebGl2RenderingContext::TRIANGLES;
 pub const FLOAT: u32 = WebGl2RenderingContext::FLOAT;
-pub const UNSIGNED_INT: u32 = WebGl2RenderingContext::UNSIGNED_INT;
 pub const ARRAY_BUFFER: u32 = WebGl2RenderingContext::ARRAY_BUFFER;
-pub const ELEMENT_ARRAY_BUFFER: u32 = WebGl2RenderingContext::ELEMENT_ARRAY_BUFFER;
 pub const STATIC_DRAW: u32 = WebGl2RenderingContext::STATIC_DRAW;
 pub const VERTEX_SHADER: u32 = WebGl2RenderingContext::VERTEX_SHADER;
 pub const FRAGMENT_SHADER: u32 = WebGl2RenderingContext::FRAGMENT_SHADER;

--- a/wasm/src/shape.rs
+++ b/wasm/src/shape.rs
@@ -3,7 +3,6 @@ use wasm_bindgen::prelude::*;
 /// Triangle mesh data structure
 pub struct Triangles {
     pub(crate) vertices: Vec<f32>,
-    pub(crate) indices: Vec<u32>,
     pub(crate) hole_x: Vec<f32>,
     pub(crate) hole_y: Vec<f32>,
     pub(crate) hole_radius: Vec<f32>,
@@ -12,14 +11,12 @@ pub struct Triangles {
 impl Triangles {
     pub fn new(
         vertices: Vec<f32>,
-        indices: Vec<u32>,
         hole_x: Vec<f32>,
         hole_y: Vec<f32>,
         hole_radius: Vec<f32>,
     ) -> Triangles {
         Triangles {
             vertices,
-            indices,
             hole_x,
             hole_y,
             hole_radius,
@@ -190,7 +187,7 @@ impl GerberData {
 
     /// Check if this GerberData contains any geometry
     pub fn has_geometry(&self) -> bool {
-        !self.triangles.indices.is_empty()
+        !self.triangles.vertices.is_empty()
             || !self.circles.x.is_empty()
             || !self.arcs.x.is_empty()
             || !self.thermals.x.is_empty()


### PR DESCRIPTION
## Summary
- Skip triangle and circle hole buffers when the parsed geometry has no aperture holes.
- Render no-hole attributes with constant WebGL vertex attributes instead of zero-filled buffers.
- Remove the redundant sequential triangle index buffer and draw triangle vertices directly.
- Replace the fixed primitive-count guard with actual allocation preflight/reserve checks.
- Reduce extended-command parsing copies and make renderer temporary buffer allocation failures catchable.

## Impact
Large no-hole Gerber layers use substantially less WASM and WebGL memory. Allocation failures should now be based on the buffers actually needed by the layer rather than a fixed primitive count limit.

## Validation
- `cargo test --manifest-path wasm/Cargo.toml`
- `node --check js/main.js`
- `wasm-pack build wasm --target web --out-dir pkg --release`