### PR TITLE
[codex] Further reduce Gerber render memory usage

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -496,6 +496,7 @@ export class GerberViewer {
       color: [...layer.color],
       sourceContent: layer.sourceContent,
     }));
+    const viewState = this.captureCanvasViewState();
 
     this.isRestoringWebGlContext = true;
     this.updateUiState();
@@ -505,10 +506,18 @@ export class GerberViewer {
       if (!this.wasmProcessor) {
         throw new Error("No parsed layer data available for WebGL restore");
       }
-      this.wasmProcessor.restore_context(this.gl);
-      this.isWebGlContextLost = false;
-      this.resizeCanvas({ allowProcessorResize: true });
-      this.layers = layerSnapshot;
+      try {
+        this.wasmProcessor.restore_context(this.gl);
+        this.isWebGlContextLost = false;
+        this.resizeCanvas({ allowProcessorResize: true, preserveViewState: viewState });
+        this.layers = layerSnapshot;
+      } catch (restoreError) {
+        await this.rebuildWebGlProcessorFromSnapshot(
+          layerSnapshot,
+          viewState,
+          restoreError,
+        );
+      }
 
       this.renderLayerList();
     } catch (error) {
@@ -521,6 +530,30 @@ export class GerberViewer {
       this.isRestoringWebGlContext = false;
       this.updateUiState();
       this.render();
+    }
+  }
+
+  async rebuildWebGlProcessorFromSnapshot(layerSnapshot, viewState, restoreError) {
+    this.addDiagnostic(
+      "warning",
+      "WebGL renderer rebuilt",
+      `Rebuilding layers after WebGL restore could not reuse cached geometry: ${getErrorMessage(restoreError)}`,
+    );
+
+    this.disposeWasmProcessor();
+    this.layers = [];
+    this.createWebGlProcessor();
+    this.isWebGlContextLost = false;
+    this.resizeCanvas({ allowProcessorResize: true, preserveViewState: viewState });
+
+    for (const layer of layerSnapshot) {
+      await this.addLayer(layer.name, layer.sourceContent, {
+        id: layer.id,
+        visible: layer.visible,
+        color: layer.color,
+        sourceContent: layer.sourceContent,
+        skipFatalRecovery: true,
+      });
     }
   }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -77,8 +77,9 @@ impl GerberProcessor {
 
     /// Recreate WebGL-owned resources after browser context restoration.
     ///
-    /// Parsed Gerber geometry is kept in Rust memory, so this does not require
-    /// JS to retain or reparse the original uploaded file contents.
+    /// This can recreate GPU resources only while parsed geometry is still retained.
+    /// After geometry has been released to reduce WASM memory, JS should rebuild
+    /// layers from the retained source file contents.
     pub fn restore_context(&mut self, gl: WebGl2RenderingContext) -> Result<String, JsValue> {
         if let Some(renderer) = &mut self.renderer {
             renderer.restore_context(gl.clone())?;

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -40,25 +40,54 @@ struct PrimitiveBufferCounts {
 }
 
 impl PrimitiveBufferCounts {
+    fn include(&mut self, primitive: &Primitive) {
+        match primitive {
+            Primitive::Triangle { hole_radius, .. } => {
+                self.triangles += 1;
+                self.has_triangle_holes |= *hole_radius != 0.0;
+            }
+            Primitive::Circle { hole_radius, .. } => {
+                self.circles += 1;
+                self.has_circle_holes |= *hole_radius != 0.0;
+            }
+            Primitive::Arc { .. } => self.arcs += 1,
+            Primitive::Thermal { .. } => self.thermals += 1,
+        }
+    }
+
+    fn has_geometry(&self) -> bool {
+        self.triangles > 0 || self.circles > 0 || self.arcs > 0 || self.thermals > 0
+    }
+}
+
+#[derive(Default)]
+struct SplitPrimitiveBufferCounts {
+    plain: PrimitiveBufferCounts,
+    holed: PrimitiveBufferCounts,
+}
+
+impl SplitPrimitiveBufferCounts {
     fn from_primitives(primitives: &[Primitive]) -> Self {
         let mut counts = Self::default();
 
         for primitive in primitives {
-            match primitive {
-                Primitive::Triangle { hole_radius, .. } => {
-                    counts.triangles += 1;
-                    counts.has_triangle_holes |= *hole_radius != 0.0;
-                }
-                Primitive::Circle { hole_radius, .. } => {
-                    counts.circles += 1;
-                    counts.has_circle_holes |= *hole_radius != 0.0;
-                }
-                Primitive::Arc { .. } => counts.arcs += 1,
-                Primitive::Thermal { .. } => counts.thermals += 1,
+            if primitive_has_hole(primitive) {
+                counts.holed.include(primitive);
+            } else {
+                counts.plain.include(primitive);
             }
         }
 
         counts
+    }
+}
+
+fn primitive_has_hole(primitive: &Primitive) -> bool {
+    match primitive {
+        Primitive::Triangle { hole_radius, .. } | Primitive::Circle { hole_radius, .. } => {
+            *hole_radius != 0.0
+        }
+        Primitive::Arc { .. } | Primitive::Thermal { .. } => false,
     }
 }
 
@@ -90,8 +119,7 @@ struct PrimitiveOutputBuffers {
 }
 
 impl PrimitiveOutputBuffers {
-    fn reserved_for(primitives: &[Primitive]) -> Result<Self, JsValue> {
-        let counts = PrimitiveBufferCounts::from_primitives(primitives);
+    fn reserved_for(counts: &PrimitiveBufferCounts) -> Result<Self, JsValue> {
         let triangle_vertex_values =
             checked_capacity(counts.triangles, 6, "triangle vertex buffer")?;
 
@@ -215,6 +243,177 @@ impl PrimitiveOutputBuffers {
         )?;
 
         Ok(buffers)
+    }
+
+    fn push_primitive(&mut self, primitive: Primitive) {
+        // Unit conversion: aperture.rs already converts to mm using unit_multiplier.
+        const TO_MM: f32 = 1.0;
+
+        match primitive {
+            Primitive::Triangle {
+                vertices,
+                hole_x,
+                hole_y,
+                hole_radius,
+                ..
+            } => {
+                for vertex in vertices {
+                    self.triangle_vertices.push(vertex[0] * TO_MM);
+                    self.triangle_vertices.push(vertex[1] * TO_MM);
+                }
+
+                if self.has_triangle_holes {
+                    for _ in 0..3 {
+                        self.triangle_hole_x.push(hole_x * TO_MM);
+                        self.triangle_hole_y.push(hole_y * TO_MM);
+                        self.triangle_hole_radius.push(hole_radius * TO_MM);
+                    }
+                }
+            }
+            Primitive::Circle {
+                x,
+                y,
+                radius,
+                hole_x,
+                hole_y,
+                hole_radius,
+                ..
+            } => {
+                self.circles_x.push(x * TO_MM);
+                self.circles_y.push(y * TO_MM);
+                self.circles_radius.push(radius * TO_MM);
+                if self.has_circle_holes {
+                    self.circles_hole_x.push(hole_x * TO_MM);
+                    self.circles_hole_y.push(hole_y * TO_MM);
+                    self.circles_hole_radius.push(hole_radius * TO_MM);
+                }
+            }
+            Primitive::Arc {
+                x,
+                y,
+                radius,
+                start_angle,
+                end_angle,
+                thickness,
+                ..
+            } => {
+                self.arcs_x.push(x * TO_MM);
+                self.arcs_y.push(y * TO_MM);
+                self.arcs_radius.push(radius * TO_MM);
+                self.arcs_start_angle.push(start_angle);
+                self.arcs_sweep_angle.push(end_angle - start_angle);
+                self.arcs_thickness.push(thickness * TO_MM);
+            }
+            Primitive::Thermal {
+                x,
+                y,
+                outer_diameter,
+                inner_diameter,
+                gap_thickness,
+                rotation,
+                ..
+            } => {
+                self.thermals_x.push(x * TO_MM);
+                self.thermals_y.push(y * TO_MM);
+                self.thermals_outer_diameter.push(outer_diameter * TO_MM);
+                self.thermals_inner_diameter.push(inner_diameter * TO_MM);
+                self.thermals_gap_thickness.push(gap_thickness * TO_MM);
+                self.thermals_rotation.push(rotation);
+            }
+        }
+    }
+
+    fn into_gerber_data(self, is_negative: bool) -> GerberData {
+        let boundary = self.boundary();
+
+        GerberData::new(
+            Triangles::new(
+                self.triangle_vertices,
+                self.triangle_hole_x,
+                self.triangle_hole_y,
+                self.triangle_hole_radius,
+            ),
+            Circles::new(
+                self.circles_x,
+                self.circles_y,
+                self.circles_radius,
+                self.circles_hole_x,
+                self.circles_hole_y,
+                self.circles_hole_radius,
+            ),
+            Arcs::new(
+                self.arcs_x,
+                self.arcs_y,
+                self.arcs_radius,
+                self.arcs_start_angle,
+                self.arcs_sweep_angle,
+                self.arcs_thickness,
+            ),
+            Thermals::new(
+                self.thermals_x,
+                self.thermals_y,
+                self.thermals_outer_diameter,
+                self.thermals_inner_diameter,
+                self.thermals_gap_thickness,
+                self.thermals_rotation,
+            ),
+            boundary,
+            is_negative,
+        )
+    }
+
+    fn boundary(&self) -> Boundary {
+        let mut min_x = f32::INFINITY;
+        let mut max_x = f32::NEG_INFINITY;
+        let mut min_y = f32::INFINITY;
+        let mut max_y = f32::NEG_INFINITY;
+
+        for point in self.triangle_vertices.chunks_exact(2) {
+            let x = point[0];
+            let y = point[1];
+            min_x = min_x.min(x);
+            max_x = max_x.max(x);
+            min_y = min_y.min(y);
+            max_y = max_y.max(y);
+        }
+
+        for i in 0..self.circles_x.len() {
+            let x = self.circles_x[i];
+            let y = self.circles_y[i];
+            let r = self.circles_radius[i];
+            min_x = min_x.min(x - r);
+            max_x = max_x.max(x + r);
+            min_y = min_y.min(y - r);
+            max_y = max_y.max(y + r);
+        }
+
+        for i in 0..self.arcs_x.len() {
+            let x = self.arcs_x[i];
+            let y = self.arcs_y[i];
+            let r = self.arcs_radius[i];
+            let t = self.arcs_thickness[i];
+            let outer = r + t / 2.0;
+            min_x = min_x.min(x - outer);
+            max_x = max_x.max(x + outer);
+            min_y = min_y.min(y - outer);
+            max_y = max_y.max(y + outer);
+        }
+
+        for i in 0..self.thermals_x.len() {
+            let x = self.thermals_x[i];
+            let y = self.thermals_y[i];
+            let r = self.thermals_outer_diameter[i] / 2.0;
+            min_x = min_x.min(x - r);
+            max_x = max_x.max(x + r);
+            min_y = min_y.min(y - r);
+            max_y = max_y.max(y + r);
+        }
+
+        if min_x == f32::INFINITY {
+            return Boundary::new(0.0, 0.0, 0.0, 0.0);
+        }
+
+        Boundary::new(min_x, max_x, min_y, max_y)
     }
 }
 
@@ -387,16 +586,18 @@ impl GerberParser {
         // can be dropped as soon as their render buffers are built.
         let polarity_layers = take(&mut self.polarity_layers);
         let mut gerber_data_layers: Vec<GerberData> = Vec::new();
+        let gerber_data_layer_capacity =
+            checked_capacity(polarity_layers.len(), 2, "Gerber data layer list")?;
         try_reserve_exact(
             &mut gerber_data_layers,
-            polarity_layers.len(),
+            gerber_data_layer_capacity,
             "Gerber data layer list",
         )?;
 
         for (polarity, primitives) in polarity_layers {
-            let gerber_data =
+            let mut gerber_data =
                 Self::primitives_to_gerber_data(primitives, polarity == Polarity::Negative)?;
-            gerber_data_layers.push(gerber_data);
+            gerber_data_layers.append(&mut gerber_data);
         }
 
         Ok(gerber_data_layers)
@@ -406,184 +607,36 @@ impl GerberParser {
     fn primitives_to_gerber_data(
         primitives: Vec<Primitive>,
         is_negative: bool,
-    ) -> Result<GerberData, JsValue> {
-        let mut buffers = PrimitiveOutputBuffers::reserved_for(&primitives)?;
-
-        // Unit conversion: aperture.rs already converts to mm using unit_multiplier
-        // No additional conversion needed
-        const TO_MM: f32 = 1.0;
+    ) -> Result<Vec<GerberData>, JsValue> {
+        let counts = SplitPrimitiveBufferCounts::from_primitives(&primitives);
+        let mut plain_buffers = PrimitiveOutputBuffers::reserved_for(&counts.plain)?;
+        let mut holed_buffers = PrimitiveOutputBuffers::reserved_for(&counts.holed)?;
 
         for primitive in primitives {
-            match primitive {
-                Primitive::Triangle {
-                    vertices,
-                    hole_x,
-                    hole_y,
-                    hole_radius,
-                    ..
-                } => {
-                    // Add triangle vertices to array (convert to mm units)
-                    for vertex in vertices {
-                        buffers.triangle_vertices.push(vertex[0] * TO_MM);
-                        buffers.triangle_vertices.push(vertex[1] * TO_MM);
-                    }
-
-                    if buffers.has_triangle_holes {
-                        // Add hole data for each vertex (3 times per triangle)
-                        for _ in 0..3 {
-                            buffers.triangle_hole_x.push(hole_x * TO_MM);
-                            buffers.triangle_hole_y.push(hole_y * TO_MM);
-                            buffers.triangle_hole_radius.push(hole_radius * TO_MM);
-                        }
-                    }
-                }
-                Primitive::Circle {
-                    x,
-                    y,
-                    radius,
-                    hole_x,
-                    hole_y,
-                    hole_radius,
-                    ..
-                } => {
-                    buffers.circles_x.push(x * TO_MM);
-                    buffers.circles_y.push(y * TO_MM);
-                    buffers.circles_radius.push(radius * TO_MM);
-                    if buffers.has_circle_holes {
-                        buffers.circles_hole_x.push(hole_x * TO_MM);
-                        buffers.circles_hole_y.push(hole_y * TO_MM);
-                        buffers.circles_hole_radius.push(hole_radius * TO_MM);
-                    }
-                }
-                Primitive::Arc {
-                    x,
-                    y,
-                    radius,
-                    start_angle,
-                    end_angle,
-                    thickness,
-                    ..
-                } => {
-                    buffers.arcs_x.push(x * TO_MM);
-                    buffers.arcs_y.push(y * TO_MM);
-                    buffers.arcs_radius.push(radius * TO_MM);
-                    buffers.arcs_start_angle.push(start_angle);
-                    // sweep_angle = end_angle - start_angle
-                    buffers.arcs_sweep_angle.push(end_angle - start_angle);
-                    buffers.arcs_thickness.push(thickness * TO_MM);
-                }
-                Primitive::Thermal {
-                    x,
-                    y,
-                    outer_diameter,
-                    inner_diameter,
-                    gap_thickness,
-                    rotation,
-                    ..
-                } => {
-                    buffers.thermals_x.push(x * TO_MM);
-                    buffers.thermals_y.push(y * TO_MM);
-                    buffers.thermals_outer_diameter.push(outer_diameter * TO_MM);
-                    buffers.thermals_inner_diameter.push(inner_diameter * TO_MM);
-                    buffers.thermals_gap_thickness.push(gap_thickness * TO_MM);
-                    buffers.thermals_rotation.push(rotation);
-                }
+            if primitive_has_hole(&primitive) {
+                holed_buffers.push_primitive(primitive);
+            } else {
+                plain_buffers.push_primitive(primitive);
             }
         }
 
-        // Calculate boundary from all geometry
-        let mut min_x = f32::INFINITY;
-        let mut max_x = f32::NEG_INFINITY;
-        let mut min_y = f32::INFINITY;
-        let mut max_y = f32::NEG_INFINITY;
+        let mut gerber_data_layers = Vec::new();
+        let layer_count =
+            usize::from(counts.plain.has_geometry()) + usize::from(counts.holed.has_geometry());
+        try_reserve_exact(
+            &mut gerber_data_layers,
+            layer_count,
+            "Gerber data layer list",
+        )?;
 
-        // Include triangle vertices in boundary
-        for i in (0..buffers.triangle_vertices.len()).step_by(2) {
-            let x = buffers.triangle_vertices[i];
-            let y = buffers.triangle_vertices[i + 1];
-            min_x = min_x.min(x);
-            max_x = max_x.max(x);
-            min_y = min_y.min(y);
-            max_y = max_y.max(y);
+        if counts.plain.has_geometry() {
+            gerber_data_layers.push(plain_buffers.into_gerber_data(is_negative));
+        }
+        if counts.holed.has_geometry() {
+            gerber_data_layers.push(holed_buffers.into_gerber_data(is_negative));
         }
 
-        // Include circles in boundary (center +/- radius)
-        for i in 0..buffers.circles_x.len() {
-            let x = buffers.circles_x[i];
-            let y = buffers.circles_y[i];
-            let r = buffers.circles_radius[i];
-            min_x = min_x.min(x - r);
-            max_x = max_x.max(x + r);
-            min_y = min_y.min(y - r);
-            max_y = max_y.max(y + r);
-        }
-
-        // Include arcs in boundary (center +/- radius + thickness/2)
-        for i in 0..buffers.arcs_x.len() {
-            let x = buffers.arcs_x[i];
-            let y = buffers.arcs_y[i];
-            let r = buffers.arcs_radius[i];
-            let t = buffers.arcs_thickness[i];
-            let outer = r + t / 2.0;
-            min_x = min_x.min(x - outer);
-            max_x = max_x.max(x + outer);
-            min_y = min_y.min(y - outer);
-            max_y = max_y.max(y + outer);
-        }
-
-        // Include thermals in boundary (center +/- outer_diameter/2)
-        for i in 0..buffers.thermals_x.len() {
-            let x = buffers.thermals_x[i];
-            let y = buffers.thermals_y[i];
-            let r = buffers.thermals_outer_diameter[i] / 2.0;
-            min_x = min_x.min(x - r);
-            max_x = max_x.max(x + r);
-            min_y = min_y.min(y - r);
-            max_y = max_y.max(y + r);
-        }
-
-        // Handle empty geometry case
-        if min_x == f32::INFINITY {
-            min_x = 0.0;
-            max_x = 0.0;
-            min_y = 0.0;
-            max_y = 0.0;
-        }
-
-        Ok(GerberData::new(
-            Triangles::new(
-                buffers.triangle_vertices,
-                buffers.triangle_hole_x,
-                buffers.triangle_hole_y,
-                buffers.triangle_hole_radius,
-            ),
-            Circles::new(
-                buffers.circles_x,
-                buffers.circles_y,
-                buffers.circles_radius,
-                buffers.circles_hole_x,
-                buffers.circles_hole_y,
-                buffers.circles_hole_radius,
-            ),
-            Arcs::new(
-                buffers.arcs_x,
-                buffers.arcs_y,
-                buffers.arcs_radius,
-                buffers.arcs_start_angle,
-                buffers.arcs_sweep_angle,
-                buffers.arcs_thickness,
-            ),
-            Thermals::new(
-                buffers.thermals_x,
-                buffers.thermals_y,
-                buffers.thermals_outer_diameter,
-                buffers.thermals_inner_diameter,
-                buffers.thermals_gap_thickness,
-                buffers.thermals_rotation,
-            ),
-            Boundary::new(min_x, max_x, min_y, max_y),
-            is_negative,
-        ))
+        Ok(gerber_data_layers)
     }
 }
 

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -383,17 +383,19 @@ impl GerberParser {
             ));
         }
 
-        // Convert each layer to individual GerberData
+        // Convert each polarity layer one at a time so parsed Primitive buffers
+        // can be dropped as soon as their render buffers are built.
+        let polarity_layers = take(&mut self.polarity_layers);
         let mut gerber_data_layers: Vec<GerberData> = Vec::new();
         try_reserve_exact(
             &mut gerber_data_layers,
-            self.polarity_layers.len(),
+            polarity_layers.len(),
             "Gerber data layer list",
         )?;
 
-        for (polarity, primitives) in &self.polarity_layers {
+        for (polarity, primitives) in polarity_layers {
             let gerber_data =
-                Self::primitives_to_gerber_data(primitives, *polarity == Polarity::Negative)?;
+                Self::primitives_to_gerber_data(primitives, polarity == Polarity::Negative)?;
             gerber_data_layers.push(gerber_data);
         }
 
@@ -402,10 +404,10 @@ impl GerberParser {
 
     /// Convert a vector of primitives to GerberData
     fn primitives_to_gerber_data(
-        primitives: &[Primitive],
+        primitives: Vec<Primitive>,
         is_negative: bool,
     ) -> Result<GerberData, JsValue> {
-        let mut buffers = PrimitiveOutputBuffers::reserved_for(primitives)?;
+        let mut buffers = PrimitiveOutputBuffers::reserved_for(&primitives)?;
 
         // Unit conversion: aperture.rs already converts to mm using unit_multiplier
         // No additional conversion needed
@@ -429,9 +431,9 @@ impl GerberParser {
                     if buffers.has_triangle_holes {
                         // Add hole data for each vertex (3 times per triangle)
                         for _ in 0..3 {
-                            buffers.triangle_hole_x.push(*hole_x * TO_MM);
-                            buffers.triangle_hole_y.push(*hole_y * TO_MM);
-                            buffers.triangle_hole_radius.push(*hole_radius * TO_MM);
+                            buffers.triangle_hole_x.push(hole_x * TO_MM);
+                            buffers.triangle_hole_y.push(hole_y * TO_MM);
+                            buffers.triangle_hole_radius.push(hole_radius * TO_MM);
                         }
                     }
                 }
@@ -444,13 +446,13 @@ impl GerberParser {
                     hole_radius,
                     ..
                 } => {
-                    buffers.circles_x.push(*x * TO_MM);
-                    buffers.circles_y.push(*y * TO_MM);
-                    buffers.circles_radius.push(*radius * TO_MM);
+                    buffers.circles_x.push(x * TO_MM);
+                    buffers.circles_y.push(y * TO_MM);
+                    buffers.circles_radius.push(radius * TO_MM);
                     if buffers.has_circle_holes {
-                        buffers.circles_hole_x.push(*hole_x * TO_MM);
-                        buffers.circles_hole_y.push(*hole_y * TO_MM);
-                        buffers.circles_hole_radius.push(*hole_radius * TO_MM);
+                        buffers.circles_hole_x.push(hole_x * TO_MM);
+                        buffers.circles_hole_y.push(hole_y * TO_MM);
+                        buffers.circles_hole_radius.push(hole_radius * TO_MM);
                     }
                 }
                 Primitive::Arc {
@@ -462,13 +464,13 @@ impl GerberParser {
                     thickness,
                     ..
                 } => {
-                    buffers.arcs_x.push(*x * TO_MM);
-                    buffers.arcs_y.push(*y * TO_MM);
-                    buffers.arcs_radius.push(*radius * TO_MM);
-                    buffers.arcs_start_angle.push(*start_angle);
+                    buffers.arcs_x.push(x * TO_MM);
+                    buffers.arcs_y.push(y * TO_MM);
+                    buffers.arcs_radius.push(radius * TO_MM);
+                    buffers.arcs_start_angle.push(start_angle);
                     // sweep_angle = end_angle - start_angle
-                    buffers.arcs_sweep_angle.push(*end_angle - *start_angle);
-                    buffers.arcs_thickness.push(*thickness * TO_MM);
+                    buffers.arcs_sweep_angle.push(end_angle - start_angle);
+                    buffers.arcs_thickness.push(thickness * TO_MM);
                 }
                 Primitive::Thermal {
                     x,
@@ -479,16 +481,12 @@ impl GerberParser {
                     rotation,
                     ..
                 } => {
-                    buffers.thermals_x.push(*x * TO_MM);
-                    buffers.thermals_y.push(*y * TO_MM);
-                    buffers
-                        .thermals_outer_diameter
-                        .push(*outer_diameter * TO_MM);
-                    buffers
-                        .thermals_inner_diameter
-                        .push(*inner_diameter * TO_MM);
-                    buffers.thermals_gap_thickness.push(*gap_thickness * TO_MM);
-                    buffers.thermals_rotation.push(*rotation);
+                    buffers.thermals_x.push(x * TO_MM);
+                    buffers.thermals_y.push(y * TO_MM);
+                    buffers.thermals_outer_diameter.push(outer_diameter * TO_MM);
+                    buffers.thermals_inner_diameter.push(inner_diameter * TO_MM);
+                    buffers.thermals_gap_thickness.push(gap_thickness * TO_MM);
+                    buffers.thermals_rotation.push(rotation);
                 }
             }
         }

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -376,6 +376,38 @@ M02*",
 }
 
 #[test]
+fn mixed_hole_apertures_are_split_into_separate_sublayers() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+%ADD11C,1.0X0.2*%
+D10*
+X000000Y000000D03*
+D11*
+X2000000Y000000D03*
+M02*",
+    )
+    .expect("apertures should parse");
+
+    assert_eq!(layers.len(), 2);
+
+    let plain_circles = &layers[0].circles;
+    assert_eq!(plain_circles.x.len(), 1);
+    assert!(plain_circles.hole_x.is_empty());
+    assert!(plain_circles.hole_y.is_empty());
+    assert!(plain_circles.hole_radius.is_empty());
+
+    let holed_circles = &layers[1].circles;
+    assert_eq!(holed_circles.x.len(), 1);
+    assert_eq!(holed_circles.hole_x.len(), 1);
+    assert_eq!(holed_circles.hole_y.len(), 1);
+    assert_eq!(holed_circles.hole_radius.len(), 1);
+    assert!(holed_circles.hole_radius[0] > 0.0);
+}
+
+#[test]
 fn golden_macro_center_line_output_matches_current_parser() {
     assert_gerber_snapshot(
         "\

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -392,7 +392,10 @@ impl Renderer {
         if let Some(buf) = cache.triangle_vertex_buffer {
             gl.delete_buffer(Some(&buf));
         }
-        if let Some(buf) = cache.triangle_hole_center_buffer {
+        if let Some(buf) = cache.triangle_hole_x_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.triangle_hole_y_buffer {
             gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.triangle_hole_radius_buffer {
@@ -402,13 +405,19 @@ impl Renderer {
         if let Some(vao) = cache.circle_vao {
             gl.delete_vertex_array(Some(&vao));
         }
-        if let Some(buf) = cache.circle_center_buffer {
+        if let Some(buf) = cache.circle_center_x_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.circle_center_y_buffer {
             gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.circle_radius_buffer {
             gl.delete_buffer(Some(&buf));
         }
-        if let Some(buf) = cache.circle_hole_center_buffer {
+        if let Some(buf) = cache.circle_hole_x_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.circle_hole_y_buffer {
             gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.circle_hole_radius_buffer {
@@ -418,7 +427,10 @@ impl Renderer {
         if let Some(vao) = cache.arc_vao {
             gl.delete_vertex_array(Some(&vao));
         }
-        if let Some(buf) = cache.arc_center_buffer {
+        if let Some(buf) = cache.arc_center_x_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.arc_center_y_buffer {
             gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.arc_radius_buffer {
@@ -437,7 +449,10 @@ impl Renderer {
         if let Some(vao) = cache.thermal_vao {
             gl.delete_vertex_array(Some(&vao));
         }
-        if let Some(buf) = cache.thermal_center_buffer {
+        if let Some(buf) = cache.thermal_center_x_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.thermal_center_y_buffer {
             gl.delete_buffer(Some(&buf));
         }
         if let Some(buf) = cache.thermal_outer_diameter_buffer {
@@ -566,31 +581,6 @@ impl Renderer {
         Ok(buffer)
     }
 
-    /// Create and bind a dual-channel (2D) instance buffer
-    fn create_instance_buffer_2d(
-        gl: &WebGl2RenderingContext,
-        data: &[f32],
-        program: &ShaderProgram,
-        attr_name: &str,
-        divisor: u32,
-    ) -> Result<WebGlBuffer, JsValue> {
-        let buffer = gl
-            .create_buffer()
-            .ok_or_else(|| JsValue::from_str("Failed to create buffer"))?;
-        gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
-        unsafe {
-            let array = Float32Array::view(data);
-            gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
-        }
-        let loc = program.attributes.get(attr_name).ok_or_else(|| {
-            JsValue::from_str(&format!("Missing shader attribute: {}", attr_name))
-        })?;
-        gl.enable_vertex_attrib_array(*loc);
-        gl.vertex_attrib_pointer_with_i32(*loc, 2, FLOAT, false, 0, 0);
-        gl.vertex_attrib_divisor(*loc, divisor);
-        Ok(buffer)
-    }
-
     fn use_constant_vertex_attrib_1f(
         gl: &WebGl2RenderingContext,
         program: &ShaderProgram,
@@ -601,41 +591,6 @@ impl Renderer {
         gl.disable_vertex_attrib_array(loc);
         gl.vertex_attrib1f(loc, x);
         Ok(())
-    }
-
-    fn use_constant_vertex_attrib_2f(
-        gl: &WebGl2RenderingContext,
-        program: &ShaderProgram,
-        attr_name: &str,
-        x: f32,
-        y: f32,
-    ) -> Result<(), JsValue> {
-        let loc = Self::shader_attribute(program, attr_name)?;
-        gl.disable_vertex_attrib_array(loc);
-        gl.vertex_attrib2f(loc, x, y);
-        Ok(())
-    }
-
-    /// Interleave x,y arrays into a single flat array
-    fn interleave_xy(x: &[f32], y: &[f32], label: &str) -> Result<Vec<f32>, JsValue> {
-        let capacity = x.len().checked_mul(2).ok_or_else(|| {
-            JsValue::from_str(&format!(
-                "Renderer temporary buffer is too large: {} size overflow",
-                label
-            ))
-        })?;
-        let mut result = Vec::new();
-        result.try_reserve_exact(capacity).map_err(|_| {
-            JsValue::from_str(&format!(
-                "Not enough memory for renderer temporary buffer: {} ({} values)",
-                label, capacity
-            ))
-        })?;
-        for i in 0..x.len() {
-            result.push(x[i]);
-            result.push(y[i]);
-        }
-        Ok(result)
     }
 
     /// Create quad buffer for instanced rendering
@@ -831,13 +786,8 @@ impl Renderer {
                     .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
                 if triangles.hole_radius.is_empty() {
-                    Self::use_constant_vertex_attrib_2f(
-                        &self.gl,
-                        program,
-                        "hole_center_instance",
-                        0.0,
-                        0.0,
-                    )?;
+                    Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
+                    Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
                     Self::use_constant_vertex_attrib_1f(
                         &self.gl,
                         program,
@@ -845,49 +795,30 @@ impl Renderer {
                         0.0,
                     )?;
                 } else {
-                    // Create regular attribute buffers for hole data (per-vertex)
-                    let hole_centers = Self::interleave_xy(
+                    let hole_x_buffer = Self::create_instance_buffer(
+                        &self.gl,
                         &triangles.hole_x,
-                        &triangles.hole_y,
-                        "triangle holes",
+                        program,
+                        "hole_x_instance",
+                        0,
                     )?;
-                    let hole_center_buffer = self
-                        .gl
-                        .create_buffer()
-                        .ok_or_else(|| JsValue::from_str("Failed to create hole center buffer"))?;
-                    self.gl.bind_buffer(ARRAY_BUFFER, Some(&hole_center_buffer));
-                    unsafe {
-                        let array = Float32Array::view(&hole_centers);
-                        self.gl.buffer_data_with_array_buffer_view(
-                            ARRAY_BUFFER,
-                            &array,
-                            STATIC_DRAW,
-                        );
-                    }
-                    let hole_center_loc = Self::shader_attribute(program, "hole_center_instance")?;
-                    self.gl.enable_vertex_attrib_array(hole_center_loc);
-                    self.gl
-                        .vertex_attrib_pointer_with_i32(hole_center_loc, 2, FLOAT, false, 0, 0);
+                    let hole_y_buffer = Self::create_instance_buffer(
+                        &self.gl,
+                        &triangles.hole_y,
+                        program,
+                        "hole_y_instance",
+                        0,
+                    )?;
+                    let hole_radius_buffer = Self::create_instance_buffer(
+                        &self.gl,
+                        &triangles.hole_radius,
+                        program,
+                        "hole_radius_instance",
+                        0,
+                    )?;
 
-                    let hole_radius_buffer = self
-                        .gl
-                        .create_buffer()
-                        .ok_or_else(|| JsValue::from_str("Failed to create hole radius buffer"))?;
-                    self.gl.bind_buffer(ARRAY_BUFFER, Some(&hole_radius_buffer));
-                    unsafe {
-                        let array = Float32Array::view(&triangles.hole_radius);
-                        self.gl.buffer_data_with_array_buffer_view(
-                            ARRAY_BUFFER,
-                            &array,
-                            STATIC_DRAW,
-                        );
-                    }
-                    let hole_radius_loc = Self::shader_attribute(program, "hole_radius_instance")?;
-                    self.gl.enable_vertex_attrib_array(hole_radius_loc);
-                    self.gl
-                        .vertex_attrib_pointer_with_i32(hole_radius_loc, 1, FLOAT, false, 0, 0);
-
-                    buffer_cache.triangle_hole_center_buffer = Some(hole_center_buffer);
+                    buffer_cache.triangle_hole_x_buffer = Some(hole_x_buffer);
+                    buffer_cache.triangle_hole_y_buffer = Some(hole_y_buffer);
                     buffer_cache.triangle_hole_radius_buffer = Some(hole_radius_buffer);
                 }
 
@@ -910,13 +841,8 @@ impl Renderer {
         self.gl
             .bind_vertex_array(buffer_cache.triangle_vao.as_ref());
         if buffer_cache.triangle_hole_radius_buffer.is_none() {
-            Self::use_constant_vertex_attrib_2f(
-                &self.gl,
-                program,
-                "hole_center_instance",
-                0.0,
-                0.0,
-            )?;
+            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
+            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
             Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_radius_instance", 0.0)?;
         }
 
@@ -982,10 +908,20 @@ impl Renderer {
             self.gl
                 .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
-            // Create instance buffers
-            let centers = Self::interleave_xy(&circles.x, &circles.y, "circle centers")?;
-            let center_buffer =
-                Self::create_instance_buffer_2d(&self.gl, &centers, program, "center_instance", 1)?;
+            let center_x_buffer = Self::create_instance_buffer(
+                &self.gl,
+                &circles.x,
+                program,
+                "center_x_instance",
+                1,
+            )?;
+            let center_y_buffer = Self::create_instance_buffer(
+                &self.gl,
+                &circles.y,
+                program,
+                "center_y_instance",
+                1,
+            )?;
             let radius_buffer = Self::create_instance_buffer(
                 &self.gl,
                 &circles.radius,
@@ -994,13 +930,8 @@ impl Renderer {
                 1,
             )?;
             if circles.hole_radius.is_empty() {
-                Self::use_constant_vertex_attrib_2f(
-                    &self.gl,
-                    program,
-                    "hole_center_instance",
-                    0.0,
-                    0.0,
-                )?;
+                Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
+                Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
                 Self::use_constant_vertex_attrib_1f(
                     &self.gl,
                     program,
@@ -1008,13 +939,18 @@ impl Renderer {
                     0.0,
                 )?;
             } else {
-                let hole_centers =
-                    Self::interleave_xy(&circles.hole_x, &circles.hole_y, "circle holes")?;
-                let hole_center_buffer = Self::create_instance_buffer_2d(
+                let hole_x_buffer = Self::create_instance_buffer(
                     &self.gl,
-                    &hole_centers,
+                    &circles.hole_x,
                     program,
-                    "hole_center_instance",
+                    "hole_x_instance",
+                    1,
+                )?;
+                let hole_y_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &circles.hole_y,
+                    program,
+                    "hole_y_instance",
                     1,
                 )?;
                 let hole_radius_buffer = Self::create_instance_buffer(
@@ -1025,7 +961,8 @@ impl Renderer {
                     1,
                 )?;
 
-                buffer_cache.circle_hole_center_buffer = Some(hole_center_buffer);
+                buffer_cache.circle_hole_x_buffer = Some(hole_x_buffer);
+                buffer_cache.circle_hole_y_buffer = Some(hole_y_buffer);
                 buffer_cache.circle_hole_radius_buffer = Some(hole_radius_buffer);
             }
 
@@ -1034,7 +971,8 @@ impl Renderer {
 
             // Cache VAO and buffers for this sublayer
             buffer_cache.circle_vao = Some(vao);
-            buffer_cache.circle_center_buffer = Some(center_buffer);
+            buffer_cache.circle_center_x_buffer = Some(center_x_buffer);
+            buffer_cache.circle_center_y_buffer = Some(center_y_buffer);
             buffer_cache.circle_radius_buffer = Some(radius_buffer);
         }
 
@@ -1045,13 +983,8 @@ impl Renderer {
         // Bind cached VAO for this sublayer
         self.gl.bind_vertex_array(buffer_cache.circle_vao.as_ref());
         if buffer_cache.circle_hole_radius_buffer.is_none() {
-            Self::use_constant_vertex_attrib_2f(
-                &self.gl,
-                program,
-                "hole_center_instance",
-                0.0,
-                0.0,
-            )?;
+            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
+            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
             Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_radius_instance", 0.0)?;
         }
 
@@ -1118,10 +1051,10 @@ impl Renderer {
             self.gl
                 .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
-            // Create instance buffers
-            let centers = Self::interleave_xy(&arcs.x, &arcs.y, "arc centers")?;
-            let center_buffer =
-                Self::create_instance_buffer_2d(&self.gl, &centers, program, "center_instance", 1)?;
+            let center_x_buffer =
+                Self::create_instance_buffer(&self.gl, &arcs.x, program, "center_x_instance", 1)?;
+            let center_y_buffer =
+                Self::create_instance_buffer(&self.gl, &arcs.y, program, "center_y_instance", 1)?;
             let radius_buffer = Self::create_instance_buffer(
                 &self.gl,
                 &arcs.radius,
@@ -1156,7 +1089,8 @@ impl Renderer {
 
             // Cache VAO and buffers for this sublayer
             buffer_cache.arc_vao = Some(vao);
-            buffer_cache.arc_center_buffer = Some(center_buffer);
+            buffer_cache.arc_center_x_buffer = Some(center_x_buffer);
+            buffer_cache.arc_center_y_buffer = Some(center_y_buffer);
             buffer_cache.arc_radius_buffer = Some(radius_buffer);
             buffer_cache.arc_start_angle_buffer = Some(start_angle_buffer);
             buffer_cache.arc_sweep_angle_buffer = Some(sweep_angle_buffer);
@@ -1233,10 +1167,20 @@ impl Renderer {
             self.gl
                 .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
-            // Create instance buffers
-            let centers = Self::interleave_xy(&thermals.x, &thermals.y, "thermal centers")?;
-            let center_buffer =
-                Self::create_instance_buffer_2d(&self.gl, &centers, program, "center_instance", 1)?;
+            let center_x_buffer = Self::create_instance_buffer(
+                &self.gl,
+                &thermals.x,
+                program,
+                "center_x_instance",
+                1,
+            )?;
+            let center_y_buffer = Self::create_instance_buffer(
+                &self.gl,
+                &thermals.y,
+                program,
+                "center_y_instance",
+                1,
+            )?;
             let outer_diameter_buffer = Self::create_instance_buffer(
                 &self.gl,
                 &thermals.outer_diameter,
@@ -1271,7 +1215,8 @@ impl Renderer {
 
             // Cache VAO and buffers for this sublayer
             buffer_cache.thermal_vao = Some(vao);
-            buffer_cache.thermal_center_buffer = Some(center_buffer);
+            buffer_cache.thermal_center_x_buffer = Some(center_x_buffer);
+            buffer_cache.thermal_center_y_buffer = Some(center_y_buffer);
             buffer_cache.thermal_outer_diameter_buffer = Some(outer_diameter_buffer);
             buffer_cache.thermal_inner_diameter_buffer = Some(inner_diameter_buffer);
             buffer_cache.thermal_gap_thickness_buffer = Some(gap_thickness_buffer);

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -23,6 +23,7 @@ pub struct LayerMetadata {
     boundary: Boundary,              // Combined boundary
     fbo_dirty: bool,
     fbo_transform: Option<[f32; 9]>,
+    cpu_geometry_released: bool,
 }
 
 /// WebGL renderer for Gerber graphics with multi-layer support
@@ -93,6 +94,7 @@ impl Renderer {
             boundary,
             fbo_dirty: true,
             fbo_transform: None,
+            cpu_geometry_released: false,
         };
 
         // Find next free slot or extend vec
@@ -729,22 +731,6 @@ impl Renderer {
             return Err(JsValue::from_str("Invalid layer index"));
         }
 
-        // Check if data is empty (short-lived borrow)
-        {
-            let layer = if let Some(l) = &self.layers[layer_id] {
-                l
-            } else {
-                return Err(JsValue::from_str("Layer deallocated"));
-            };
-            if layer.gerber_data[sublayer_idx]
-                .triangles
-                .vertices
-                .is_empty()
-            {
-                return Ok(());
-            }
-        }
-
         let program = &self.programs.triangle;
         self.gl.use_program(Some(&program.program));
 
@@ -755,11 +741,15 @@ impl Renderer {
             } else {
                 return Err(JsValue::from_str("Layer deallocated"));
             };
-            let triangles = &layer.gerber_data[sublayer_idx].triangles;
-            let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
 
             // Check if VAO is cached for this sublayer
-            if buffer_cache.triangle_vao.is_none() {
+            if layer.buffer_caches[sublayer_idx].triangle_vao.is_none() {
+                let triangles = &layer.gerber_data[sublayer_idx].triangles;
+                if triangles.vertices.is_empty() {
+                    return Ok(());
+                }
+                let vertex_count = (triangles.vertices.len() / 2) as i32;
+
                 // Create VAO
                 let vao = self
                     .gl
@@ -817,6 +807,7 @@ impl Renderer {
                         0,
                     )?;
 
+                    let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
                     buffer_cache.triangle_hole_x_buffer = Some(hole_x_buffer);
                     buffer_cache.triangle_hole_y_buffer = Some(hole_y_buffer);
                     buffer_cache.triangle_hole_radius_buffer = Some(hole_radius_buffer);
@@ -826,12 +817,21 @@ impl Renderer {
                 self.gl.bind_vertex_array(None);
 
                 // Cache VAO and buffers for this sublayer
+                let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
                 buffer_cache.triangle_vao = Some(vao);
+                buffer_cache.triangle_vertex_count = vertex_count;
                 buffer_cache.triangle_vertex_buffer = Some(vertex_buffer);
+                layer.gerber_data[sublayer_idx]
+                    .triangles
+                    .release_cpu_geometry();
+                layer.cpu_geometry_released = true;
             }
 
-            triangles.vertices.len() / 2
+            layer.buffer_caches[sublayer_idx].triangle_vertex_count
         }; // Borrow ends here
+        if vertex_count == 0 {
+            return Ok(());
+        }
 
         // Rendering phase (new borrow)
         let layer = self.get_layer(layer_id)?;
@@ -856,7 +856,7 @@ impl Renderer {
         }
 
         // Draw
-        self.gl.draw_arrays(TRIANGLES, 0, vertex_count as i32);
+        self.gl.draw_arrays(TRIANGLES, 0, vertex_count);
 
         // Unbind VAO to prevent state leakage
         self.gl.bind_vertex_array(None);
@@ -872,108 +872,114 @@ impl Renderer {
         layer_id: usize,
         sublayer_idx: usize,
     ) -> Result<(), JsValue> {
-        // Check if data is empty (short-lived borrow)
-        let instance_count = {
-            let layer = self.get_layer(layer_id)?;
-            layer.gerber_data[sublayer_idx].circles.x.len()
-        };
-        if instance_count == 0 {
-            return Ok(());
-        }
-
         let program = &self.programs.circle;
         self.gl.use_program(Some(&program.program));
 
-        // Get mutable reference to buffer cache and immutable reference to data
-        // Split borrowing: gerber_data and buffer_caches are different fields
-        let layer = self.layers[layer_id]
-            .as_mut()
-            .ok_or_else(|| JsValue::from_str("Layer not found"))?;
-        let circles = &layer.gerber_data[sublayer_idx].circles;
-        let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+        let instance_count = {
+            let layer = self.layers[layer_id]
+                .as_mut()
+                .ok_or_else(|| JsValue::from_str("Layer not found"))?;
 
-        // Check if VAO is cached for this sublayer
-        if buffer_cache.circle_vao.is_none() {
-            // Create VAO
-            let vao = self
-                .gl
-                .create_vertex_array()
-                .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
-            self.gl.bind_vertex_array(Some(&vao));
+            if layer.buffer_caches[sublayer_idx].circle_vao.is_none() {
+                let circles = &layer.gerber_data[sublayer_idx].circles;
+                if circles.x.is_empty() {
+                    return Ok(());
+                }
+                let instance_count = circles.x.len() as i32;
 
-            // Bind shared quad buffer for position attribute
-            self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
-            let position_loc = Self::shader_attribute(program, "position")?;
-            self.gl.enable_vertex_attrib_array(position_loc);
-            self.gl
-                .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
+                // Create VAO
+                let vao = self
+                    .gl
+                    .create_vertex_array()
+                    .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+                self.gl.bind_vertex_array(Some(&vao));
 
-            let center_x_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &circles.x,
-                program,
-                "center_x_instance",
-                1,
-            )?;
-            let center_y_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &circles.y,
-                program,
-                "center_y_instance",
-                1,
-            )?;
-            let radius_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &circles.radius,
-                program,
-                "radius_instance",
-                1,
-            )?;
-            if circles.hole_radius.is_empty() {
-                Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
-                Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
-                Self::use_constant_vertex_attrib_1f(
+                // Bind shared quad buffer for position attribute
+                self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
+                let position_loc = Self::shader_attribute(program, "position")?;
+                self.gl.enable_vertex_attrib_array(position_loc);
+                self.gl
+                    .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
+
+                let center_x_buffer = Self::create_instance_buffer(
                     &self.gl,
+                    &circles.x,
                     program,
-                    "hole_radius_instance",
-                    0.0,
-                )?;
-            } else {
-                let hole_x_buffer = Self::create_instance_buffer(
-                    &self.gl,
-                    &circles.hole_x,
-                    program,
-                    "hole_x_instance",
+                    "center_x_instance",
                     1,
                 )?;
-                let hole_y_buffer = Self::create_instance_buffer(
+                let center_y_buffer = Self::create_instance_buffer(
                     &self.gl,
-                    &circles.hole_y,
+                    &circles.y,
                     program,
-                    "hole_y_instance",
+                    "center_y_instance",
                     1,
                 )?;
-                let hole_radius_buffer = Self::create_instance_buffer(
+                let radius_buffer = Self::create_instance_buffer(
                     &self.gl,
-                    &circles.hole_radius,
+                    &circles.radius,
                     program,
-                    "hole_radius_instance",
+                    "radius_instance",
                     1,
                 )?;
+                if circles.hole_radius.is_empty() {
+                    Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
+                    Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
+                    Self::use_constant_vertex_attrib_1f(
+                        &self.gl,
+                        program,
+                        "hole_radius_instance",
+                        0.0,
+                    )?;
+                } else {
+                    let hole_x_buffer = Self::create_instance_buffer(
+                        &self.gl,
+                        &circles.hole_x,
+                        program,
+                        "hole_x_instance",
+                        1,
+                    )?;
+                    let hole_y_buffer = Self::create_instance_buffer(
+                        &self.gl,
+                        &circles.hole_y,
+                        program,
+                        "hole_y_instance",
+                        1,
+                    )?;
+                    let hole_radius_buffer = Self::create_instance_buffer(
+                        &self.gl,
+                        &circles.hole_radius,
+                        program,
+                        "hole_radius_instance",
+                        1,
+                    )?;
 
-                buffer_cache.circle_hole_x_buffer = Some(hole_x_buffer);
-                buffer_cache.circle_hole_y_buffer = Some(hole_y_buffer);
-                buffer_cache.circle_hole_radius_buffer = Some(hole_radius_buffer);
+                    let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+                    buffer_cache.circle_hole_x_buffer = Some(hole_x_buffer);
+                    buffer_cache.circle_hole_y_buffer = Some(hole_y_buffer);
+                    buffer_cache.circle_hole_radius_buffer = Some(hole_radius_buffer);
+                }
+
+                // Unbind VAO
+                self.gl.bind_vertex_array(None);
+
+                // Cache VAO and buffers for this sublayer
+                let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+                buffer_cache.circle_vao = Some(vao);
+                buffer_cache.circle_instance_count = instance_count;
+                buffer_cache.circle_center_x_buffer = Some(center_x_buffer);
+                buffer_cache.circle_center_y_buffer = Some(center_y_buffer);
+                buffer_cache.circle_radius_buffer = Some(radius_buffer);
+                layer.gerber_data[sublayer_idx]
+                    .circles
+                    .release_cpu_geometry();
+                layer.cpu_geometry_released = true;
             }
 
-            // Unbind VAO
-            self.gl.bind_vertex_array(None);
-
-            // Cache VAO and buffers for this sublayer
-            buffer_cache.circle_vao = Some(vao);
-            buffer_cache.circle_center_x_buffer = Some(center_x_buffer);
-            buffer_cache.circle_center_y_buffer = Some(center_y_buffer);
-            buffer_cache.circle_radius_buffer = Some(radius_buffer);
+            layer.buffer_caches[sublayer_idx].circle_instance_count
+        };
+        if instance_count == 0 {
+            return Ok(());
         }
 
         // Re-get immutable reference for rendering
@@ -999,7 +1005,7 @@ impl Renderer {
 
         // Draw
         self.gl
-            .draw_arrays_instanced(TRIANGLES, 0, 6, instance_count as i32);
+            .draw_arrays_instanced(TRIANGLES, 0, 6, instance_count);
 
         // Unbind VAO to prevent state leakage
         self.gl.bind_vertex_array(None);
@@ -1015,86 +1021,99 @@ impl Renderer {
         layer_id: usize,
         sublayer_idx: usize,
     ) -> Result<(), JsValue> {
-        // Check if data is empty (short-lived borrow)
-        let instance_count = {
-            let layer = self.get_layer(layer_id)?;
-            layer.gerber_data[sublayer_idx].arcs.x.len()
-        };
-        if instance_count == 0 {
-            return Ok(());
-        }
-
         let program = &self.programs.arc;
         self.gl.use_program(Some(&program.program));
 
-        // Get mutable reference to buffer cache and immutable reference to data
-        // Split borrowing: gerber_data and buffer_caches are different fields
-        let layer = self.layers[layer_id]
-            .as_mut()
-            .ok_or_else(|| JsValue::from_str("Layer not found"))?;
-        let arcs = &layer.gerber_data[sublayer_idx].arcs;
-        let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+        let instance_count = {
+            let layer = self.layers[layer_id]
+                .as_mut()
+                .ok_or_else(|| JsValue::from_str("Layer not found"))?;
 
-        // Check if VAO is cached for this sublayer
-        if buffer_cache.arc_vao.is_none() {
-            // Create VAO
-            let vao = self
-                .gl
-                .create_vertex_array()
-                .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
-            self.gl.bind_vertex_array(Some(&vao));
+            if layer.buffer_caches[sublayer_idx].arc_vao.is_none() {
+                let arcs = &layer.gerber_data[sublayer_idx].arcs;
+                if arcs.x.is_empty() {
+                    return Ok(());
+                }
+                let instance_count = arcs.x.len() as i32;
 
-            // Bind shared quad buffer for position attribute
-            self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
-            let position_loc = Self::shader_attribute(program, "position")?;
-            self.gl.enable_vertex_attrib_array(position_loc);
-            self.gl
-                .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
+                // Create VAO
+                let vao = self
+                    .gl
+                    .create_vertex_array()
+                    .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+                self.gl.bind_vertex_array(Some(&vao));
 
-            let center_x_buffer =
-                Self::create_instance_buffer(&self.gl, &arcs.x, program, "center_x_instance", 1)?;
-            let center_y_buffer =
-                Self::create_instance_buffer(&self.gl, &arcs.y, program, "center_y_instance", 1)?;
-            let radius_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &arcs.radius,
-                program,
-                "radius_instance",
-                1,
-            )?;
-            let start_angle_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &arcs.start_angle,
-                program,
-                "startAngle_instance",
-                1,
-            )?;
-            let sweep_angle_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &arcs.sweep_angle,
-                program,
-                "sweepAngle_instance",
-                1,
-            )?;
-            let thickness_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &arcs.thickness,
-                program,
-                "thickness_instance",
-                1,
-            )?;
+                // Bind shared quad buffer for position attribute
+                self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
+                let position_loc = Self::shader_attribute(program, "position")?;
+                self.gl.enable_vertex_attrib_array(position_loc);
+                self.gl
+                    .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
-            // Unbind VAO
-            self.gl.bind_vertex_array(None);
+                let center_x_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &arcs.x,
+                    program,
+                    "center_x_instance",
+                    1,
+                )?;
+                let center_y_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &arcs.y,
+                    program,
+                    "center_y_instance",
+                    1,
+                )?;
+                let radius_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &arcs.radius,
+                    program,
+                    "radius_instance",
+                    1,
+                )?;
+                let start_angle_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &arcs.start_angle,
+                    program,
+                    "startAngle_instance",
+                    1,
+                )?;
+                let sweep_angle_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &arcs.sweep_angle,
+                    program,
+                    "sweepAngle_instance",
+                    1,
+                )?;
+                let thickness_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &arcs.thickness,
+                    program,
+                    "thickness_instance",
+                    1,
+                )?;
 
-            // Cache VAO and buffers for this sublayer
-            buffer_cache.arc_vao = Some(vao);
-            buffer_cache.arc_center_x_buffer = Some(center_x_buffer);
-            buffer_cache.arc_center_y_buffer = Some(center_y_buffer);
-            buffer_cache.arc_radius_buffer = Some(radius_buffer);
-            buffer_cache.arc_start_angle_buffer = Some(start_angle_buffer);
-            buffer_cache.arc_sweep_angle_buffer = Some(sweep_angle_buffer);
-            buffer_cache.arc_thickness_buffer = Some(thickness_buffer);
+                // Unbind VAO
+                self.gl.bind_vertex_array(None);
+
+                // Cache VAO and buffers for this sublayer
+                let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+                buffer_cache.arc_vao = Some(vao);
+                buffer_cache.arc_instance_count = instance_count;
+                buffer_cache.arc_center_x_buffer = Some(center_x_buffer);
+                buffer_cache.arc_center_y_buffer = Some(center_y_buffer);
+                buffer_cache.arc_radius_buffer = Some(radius_buffer);
+                buffer_cache.arc_start_angle_buffer = Some(start_angle_buffer);
+                buffer_cache.arc_sweep_angle_buffer = Some(sweep_angle_buffer);
+                buffer_cache.arc_thickness_buffer = Some(thickness_buffer);
+                layer.gerber_data[sublayer_idx].arcs.release_cpu_geometry();
+                layer.cpu_geometry_released = true;
+            }
+
+            layer.buffer_caches[sublayer_idx].arc_instance_count
+        };
+        if instance_count == 0 {
+            return Ok(());
         }
 
         // Re-get immutable reference for rendering
@@ -1115,7 +1134,7 @@ impl Renderer {
 
         // Draw
         self.gl
-            .draw_arrays_instanced(TRIANGLES, 0, 6, instance_count as i32);
+            .draw_arrays_instanced(TRIANGLES, 0, 6, instance_count);
 
         // Unbind VAO to prevent state leakage
         self.gl.bind_vertex_array(None);
@@ -1131,96 +1150,101 @@ impl Renderer {
         layer_id: usize,
         sublayer_idx: usize,
     ) -> Result<(), JsValue> {
-        // Check if data is empty (short-lived borrow)
-        let instance_count = {
-            let layer = self.get_layer(layer_id)?;
-            layer.gerber_data[sublayer_idx].thermals.x.len()
-        };
-        if instance_count == 0 {
-            return Ok(());
-        }
-
         let program = &self.programs.thermal;
         self.gl.use_program(Some(&program.program));
 
-        // Get mutable reference to buffer cache and immutable reference to data
-        // Split borrowing: gerber_data and buffer_caches are different fields
-        let layer = self.layers[layer_id]
-            .as_mut()
-            .ok_or_else(|| JsValue::from_str("Layer not found"))?;
-        let thermals = &layer.gerber_data[sublayer_idx].thermals;
-        let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+        let instance_count = {
+            let layer = self.layers[layer_id]
+                .as_mut()
+                .ok_or_else(|| JsValue::from_str("Layer not found"))?;
 
-        // Check if VAO is cached for this sublayer
-        if buffer_cache.thermal_vao.is_none() {
-            // Create VAO
-            let vao = self
-                .gl
-                .create_vertex_array()
-                .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
-            self.gl.bind_vertex_array(Some(&vao));
+            if layer.buffer_caches[sublayer_idx].thermal_vao.is_none() {
+                let thermals = &layer.gerber_data[sublayer_idx].thermals;
+                if thermals.x.is_empty() {
+                    return Ok(());
+                }
+                let instance_count = thermals.x.len() as i32;
 
-            // Bind shared quad buffer for position attribute
-            self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
-            let position_loc = Self::shader_attribute(program, "position")?;
-            self.gl.enable_vertex_attrib_array(position_loc);
-            self.gl
-                .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
+                // Create VAO
+                let vao = self
+                    .gl
+                    .create_vertex_array()
+                    .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+                self.gl.bind_vertex_array(Some(&vao));
 
-            let center_x_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &thermals.x,
-                program,
-                "center_x_instance",
-                1,
-            )?;
-            let center_y_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &thermals.y,
-                program,
-                "center_y_instance",
-                1,
-            )?;
-            let outer_diameter_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &thermals.outer_diameter,
-                program,
-                "outer_diameter_instance",
-                1,
-            )?;
-            let inner_diameter_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &thermals.inner_diameter,
-                program,
-                "inner_diameter_instance",
-                1,
-            )?;
-            let gap_thickness_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &thermals.gap_thickness,
-                program,
-                "gap_thickness_instance",
-                1,
-            )?;
-            let rotation_buffer = Self::create_instance_buffer(
-                &self.gl,
-                &thermals.rotation,
-                program,
-                "rotation_instance",
-                1,
-            )?;
+                // Bind shared quad buffer for position attribute
+                self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
+                let position_loc = Self::shader_attribute(program, "position")?;
+                self.gl.enable_vertex_attrib_array(position_loc);
+                self.gl
+                    .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
 
-            // Unbind VAO
-            self.gl.bind_vertex_array(None);
+                let center_x_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &thermals.x,
+                    program,
+                    "center_x_instance",
+                    1,
+                )?;
+                let center_y_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &thermals.y,
+                    program,
+                    "center_y_instance",
+                    1,
+                )?;
+                let outer_diameter_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &thermals.outer_diameter,
+                    program,
+                    "outer_diameter_instance",
+                    1,
+                )?;
+                let inner_diameter_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &thermals.inner_diameter,
+                    program,
+                    "inner_diameter_instance",
+                    1,
+                )?;
+                let gap_thickness_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &thermals.gap_thickness,
+                    program,
+                    "gap_thickness_instance",
+                    1,
+                )?;
+                let rotation_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &thermals.rotation,
+                    program,
+                    "rotation_instance",
+                    1,
+                )?;
 
-            // Cache VAO and buffers for this sublayer
-            buffer_cache.thermal_vao = Some(vao);
-            buffer_cache.thermal_center_x_buffer = Some(center_x_buffer);
-            buffer_cache.thermal_center_y_buffer = Some(center_y_buffer);
-            buffer_cache.thermal_outer_diameter_buffer = Some(outer_diameter_buffer);
-            buffer_cache.thermal_inner_diameter_buffer = Some(inner_diameter_buffer);
-            buffer_cache.thermal_gap_thickness_buffer = Some(gap_thickness_buffer);
-            buffer_cache.thermal_rotation_buffer = Some(rotation_buffer);
+                // Unbind VAO
+                self.gl.bind_vertex_array(None);
+
+                // Cache VAO and buffers for this sublayer
+                let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+                buffer_cache.thermal_vao = Some(vao);
+                buffer_cache.thermal_instance_count = instance_count;
+                buffer_cache.thermal_center_x_buffer = Some(center_x_buffer);
+                buffer_cache.thermal_center_y_buffer = Some(center_y_buffer);
+                buffer_cache.thermal_outer_diameter_buffer = Some(outer_diameter_buffer);
+                buffer_cache.thermal_inner_diameter_buffer = Some(inner_diameter_buffer);
+                buffer_cache.thermal_gap_thickness_buffer = Some(gap_thickness_buffer);
+                buffer_cache.thermal_rotation_buffer = Some(rotation_buffer);
+                layer.gerber_data[sublayer_idx]
+                    .thermals
+                    .release_cpu_geometry();
+                layer.cpu_geometry_released = true;
+            }
+
+            layer.buffer_caches[sublayer_idx].thermal_instance_count
+        };
+        if instance_count == 0 {
+            return Ok(());
         }
 
         // Re-get immutable reference for rendering
@@ -1241,7 +1265,7 @@ impl Renderer {
 
         // Draw
         self.gl
-            .draw_arrays_instanced(TRIANGLES, 0, 6, instance_count as i32);
+            .draw_arrays_instanced(TRIANGLES, 0, 6, instance_count);
 
         // Unbind VAO to prevent state leakage
         self.gl.bind_vertex_array(None);
@@ -1585,6 +1609,17 @@ impl Renderer {
     /// Recreate WebGL-owned resources after the browser restores a lost context.
     /// Parsed Gerber geometry and stable layer IDs are preserved.
     pub fn restore_context(&mut self, gl: WebGl2RenderingContext) -> Result<(), JsValue> {
+        if self
+            .layers
+            .iter()
+            .flatten()
+            .any(|layer| layer.cpu_geometry_released)
+        {
+            return Err(JsValue::from_str(
+                "Layer geometry has been released from WebAssembly memory; rebuild layers from source files to restore WebGL context",
+            ));
+        }
+
         let programs = ShaderPrograms::new(&gl)?;
         let quad_buffer = Self::create_quad_buffer(&gl)?;
         let (width, height) = Self::get_canvas_size_from_gl(&gl)?;

--- a/wasm/src/renderer/buffer.rs
+++ b/wasm/src/renderer/buffer.rs
@@ -12,19 +12,23 @@ pub struct BufferCache {
     // Triangles cache
     pub triangle_vao: Option<WebGlVertexArrayObject>,
     pub triangle_vertex_buffer: Option<WebGlBuffer>,
-    pub triangle_hole_center_buffer: Option<WebGlBuffer>,
+    pub triangle_hole_x_buffer: Option<WebGlBuffer>,
+    pub triangle_hole_y_buffer: Option<WebGlBuffer>,
     pub triangle_hole_radius_buffer: Option<WebGlBuffer>,
 
     // Circles cache
     pub circle_vao: Option<WebGlVertexArrayObject>,
-    pub circle_center_buffer: Option<WebGlBuffer>,
+    pub circle_center_x_buffer: Option<WebGlBuffer>,
+    pub circle_center_y_buffer: Option<WebGlBuffer>,
     pub circle_radius_buffer: Option<WebGlBuffer>,
-    pub circle_hole_center_buffer: Option<WebGlBuffer>,
+    pub circle_hole_x_buffer: Option<WebGlBuffer>,
+    pub circle_hole_y_buffer: Option<WebGlBuffer>,
     pub circle_hole_radius_buffer: Option<WebGlBuffer>,
 
     // Arcs cache
     pub arc_vao: Option<WebGlVertexArrayObject>,
-    pub arc_center_buffer: Option<WebGlBuffer>,
+    pub arc_center_x_buffer: Option<WebGlBuffer>,
+    pub arc_center_y_buffer: Option<WebGlBuffer>,
     pub arc_radius_buffer: Option<WebGlBuffer>,
     pub arc_start_angle_buffer: Option<WebGlBuffer>,
     pub arc_sweep_angle_buffer: Option<WebGlBuffer>,
@@ -32,7 +36,8 @@ pub struct BufferCache {
 
     // Thermals cache
     pub thermal_vao: Option<WebGlVertexArrayObject>,
-    pub thermal_center_buffer: Option<WebGlBuffer>,
+    pub thermal_center_x_buffer: Option<WebGlBuffer>,
+    pub thermal_center_y_buffer: Option<WebGlBuffer>,
     pub thermal_outer_diameter_buffer: Option<WebGlBuffer>,
     pub thermal_inner_diameter_buffer: Option<WebGlBuffer>,
     pub thermal_gap_thickness_buffer: Option<WebGlBuffer>,

--- a/wasm/src/renderer/buffer.rs
+++ b/wasm/src/renderer/buffer.rs
@@ -11,6 +11,7 @@ pub struct Fbo {
 pub struct BufferCache {
     // Triangles cache
     pub triangle_vao: Option<WebGlVertexArrayObject>,
+    pub triangle_vertex_count: i32,
     pub triangle_vertex_buffer: Option<WebGlBuffer>,
     pub triangle_hole_x_buffer: Option<WebGlBuffer>,
     pub triangle_hole_y_buffer: Option<WebGlBuffer>,
@@ -18,6 +19,7 @@ pub struct BufferCache {
 
     // Circles cache
     pub circle_vao: Option<WebGlVertexArrayObject>,
+    pub circle_instance_count: i32,
     pub circle_center_x_buffer: Option<WebGlBuffer>,
     pub circle_center_y_buffer: Option<WebGlBuffer>,
     pub circle_radius_buffer: Option<WebGlBuffer>,
@@ -27,6 +29,7 @@ pub struct BufferCache {
 
     // Arcs cache
     pub arc_vao: Option<WebGlVertexArrayObject>,
+    pub arc_instance_count: i32,
     pub arc_center_x_buffer: Option<WebGlBuffer>,
     pub arc_center_y_buffer: Option<WebGlBuffer>,
     pub arc_radius_buffer: Option<WebGlBuffer>,
@@ -36,6 +39,7 @@ pub struct BufferCache {
 
     // Thermals cache
     pub thermal_vao: Option<WebGlVertexArrayObject>,
+    pub thermal_instance_count: i32,
     pub thermal_center_x_buffer: Option<WebGlBuffer>,
     pub thermal_center_y_buffer: Option<WebGlBuffer>,
     pub thermal_outer_diameter_buffer: Option<WebGlBuffer>,

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -20,7 +20,8 @@ pub const ZERO: u32 = WebGl2RenderingContext::ZERO;
 pub const TRIANGLE_VERTEX_SHADER: &str = r#"#version 300 es
 precision highp float;
 in vec2 position;
-in vec2 hole_center_instance;
+in float hole_x_instance;
+in float hole_y_instance;
 in float hole_radius_instance;
 uniform mat3 transform;
 out highp vec2 vPosition;
@@ -30,7 +31,7 @@ void main() {
     vec3 transformed = transform * vec3(position, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
     vPosition = position;
-    vHoleCenter = hole_center_instance;
+    vHoleCenter = vec2(hole_x_instance, hole_y_instance);
     vHoleRadius = hole_radius_instance;
 }
 "#;
@@ -54,21 +55,24 @@ void main() {
 pub const CIRCLE_VERTEX_SHADER: &str = r#"#version 300 es
 precision highp float;
 in vec2 position;
-in vec2 center_instance;
+in float center_x_instance;
+in float center_y_instance;
 in float radius_instance;
-in vec2 hole_center_instance;
+in float hole_x_instance;
+in float hole_y_instance;
 in float hole_radius_instance;
 uniform mat3 transform;
 out highp vec2 vPosition;
 out highp vec2 vHoleCenter;
 out highp float vHoleRadius;
 void main() {
-    vec2 scaledPos = position * radius_instance + center_instance;
+    vec2 center = vec2(center_x_instance, center_y_instance);
+    vec2 scaledPos = position * radius_instance + center;
     vec3 transformed = transform * vec3(scaledPos, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
     vPosition = position;
     float safeRadius = max(radius_instance, 0.000000001);
-    vHoleCenter = (hole_center_instance - center_instance) / safeRadius;
+    vHoleCenter = (vec2(hole_x_instance, hole_y_instance) - center) / safeRadius;
     vHoleRadius = hole_radius_instance / safeRadius;
 }
 "#;
@@ -94,7 +98,8 @@ void main() {
 pub const ARC_VERTEX_SHADER: &str = r#"#version 300 es
 precision highp float;
 in vec2 position;
-in vec2 center_instance;
+in float center_x_instance;
+in float center_y_instance;
 in float radius_instance;
 in float startAngle_instance;
 in float sweepAngle_instance;
@@ -107,7 +112,7 @@ out highp float vSweepAngle;
 out highp float vThickness;
 void main() {
     float maxRadius = max(radius_instance + thickness_instance * 0.5, 0.0);
-    vec2 scaledPos = position * maxRadius + center_instance;
+    vec2 scaledPos = position * maxRadius + vec2(center_x_instance, center_y_instance);
     vec3 transformed = transform * vec3(scaledPos, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
     vPosition = position * maxRadius;
@@ -180,7 +185,8 @@ void main() {
 pub const THERMAL_VERTEX_SHADER: &str = r#"#version 300 es
 precision highp float;
 in vec2 position;
-in vec2 center_instance;
+in float center_x_instance;
+in float center_y_instance;
 in float outer_diameter_instance;
 in float inner_diameter_instance;
 in float gap_thickness_instance;
@@ -193,7 +199,7 @@ out highp float vGapThickness;
 out highp float vRotation;
 void main() {
     float outer_radius = max(outer_diameter_instance, 0.0) * 0.5;
-    vec2 scaledPos = position * outer_radius + center_instance;
+    vec2 scaledPos = position * outer_radius + vec2(center_x_instance, center_y_instance);
     vec3 transformed = transform * vec3(scaledPos, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
     vPosition = position;
@@ -292,7 +298,12 @@ impl ShaderPrograms {
             gl,
             TRIANGLE_VERTEX_SHADER,
             TRIANGLE_FRAGMENT_SHADER,
-            &["position", "hole_center_instance", "hole_radius_instance"],
+            &[
+                "position",
+                "hole_x_instance",
+                "hole_y_instance",
+                "hole_radius_instance",
+            ],
             &["transform", "color"],
         )?;
 
@@ -302,9 +313,11 @@ impl ShaderPrograms {
             CIRCLE_FRAGMENT_SHADER,
             &[
                 "position",
-                "center_instance",
+                "center_x_instance",
+                "center_y_instance",
                 "radius_instance",
-                "hole_center_instance",
+                "hole_x_instance",
+                "hole_y_instance",
                 "hole_radius_instance",
             ],
             &["transform", "color"],
@@ -316,7 +329,8 @@ impl ShaderPrograms {
             ARC_FRAGMENT_SHADER,
             &[
                 "position",
-                "center_instance",
+                "center_x_instance",
+                "center_y_instance",
                 "radius_instance",
                 "startAngle_instance",
                 "sweepAngle_instance",
@@ -331,7 +345,8 @@ impl ShaderPrograms {
             THERMAL_FRAGMENT_SHADER,
             &[
                 "position",
-                "center_instance",
+                "center_x_instance",
+                "center_y_instance",
                 "outer_diameter_instance",
                 "inner_diameter_instance",
                 "gap_thickness_instance",

--- a/wasm/src/shape.rs
+++ b/wasm/src/shape.rs
@@ -22,6 +22,13 @@ impl Triangles {
             hole_radius,
         }
     }
+
+    pub(crate) fn release_cpu_geometry(&mut self) {
+        self.vertices = Vec::new();
+        self.hole_x = Vec::new();
+        self.hole_y = Vec::new();
+        self.hole_radius = Vec::new();
+    }
 }
 
 /// Circle primitive data structure
@@ -51,6 +58,15 @@ impl Circles {
             hole_y,
             hole_radius,
         }
+    }
+
+    pub(crate) fn release_cpu_geometry(&mut self) {
+        self.x = Vec::new();
+        self.y = Vec::new();
+        self.radius = Vec::new();
+        self.hole_x = Vec::new();
+        self.hole_y = Vec::new();
+        self.hole_radius = Vec::new();
     }
 }
 
@@ -82,6 +98,15 @@ impl Arcs {
             thickness,
         }
     }
+
+    pub(crate) fn release_cpu_geometry(&mut self) {
+        self.x = Vec::new();
+        self.y = Vec::new();
+        self.radius = Vec::new();
+        self.start_angle = Vec::new();
+        self.sweep_angle = Vec::new();
+        self.thickness = Vec::new();
+    }
 }
 
 /// Thermal primitive data structure
@@ -111,6 +136,15 @@ impl Thermals {
             gap_thickness,
             rotation,
         }
+    }
+
+    pub(crate) fn release_cpu_geometry(&mut self) {
+        self.x = Vec::new();
+        self.y = Vec::new();
+        self.outer_diameter = Vec::new();
+        self.inner_diameter = Vec::new();
+        self.gap_thickness = Vec::new();
+        self.rotation = Vec::new();
     }
 }
 


### PR DESCRIPTION
## Summary
- Consume parser polarity primitive batches as render buffers are built so intermediate `Primitive` storage can be dropped earlier.
- Remove renderer-side x/y interleave temporary buffers by using separate scalar WebGL attributes for centers and hole centers.
- Split mixed hole/no-hole primitives into separate sublayers so a few holed apertures do not force hole buffers for all primitives.
- Release CPU geometry vectors after WebGL buffers are uploaded, while preserving layer bounds and draw counts.
- Rebuild the renderer from retained source content when WebGL restore cannot reuse released CPU geometry.

## Notes
Aperture/macro instancing remains a larger design task because aperture identity is currently lost when flashes are expanded into primitives.

## Validation
- `cargo test --manifest-path wasm/Cargo.toml`
- `node --check js/main.js`
- `wasm-pack build wasm --target web --out-dir pkg --release`