### PR TITLE
Instance repeated triangle aperture flashes

### DIFF
--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -15,7 +15,9 @@ use state::{
 };
 
 use self::geometry::{parse_graphic_command, Primitive};
-use crate::shape::{Arcs, Boundary, Circles, GerberData, Thermals, Triangles};
+use crate::shape::{
+    Arcs, Boundary, Circles, GerberData, Thermals, TriangleTemplateInstances, Triangles,
+};
 use std::collections::HashMap;
 use std::mem::size_of;
 use std::mem::take;
@@ -33,6 +35,7 @@ fn collect_lines(data: &str) -> Result<Vec<&str>, JsValue> {
 struct PrimitiveBufferCounts {
     triangles: usize,
     has_triangle_holes: bool,
+    triangle_template_instance_counts: HashMap<usize, usize>,
     circles: usize,
     has_circle_holes: bool,
     arcs: usize,
@@ -52,11 +55,14 @@ impl PrimitiveBufferCounts {
             }
             Primitive::Arc { .. } => self.arcs += 1,
             Primitive::Thermal { .. } => self.thermals += 1,
+            Primitive::TriangleTemplateFlash { template, .. } => {
+                let key = std::rc::Rc::as_ptr(template) as usize;
+                *self
+                    .triangle_template_instance_counts
+                    .entry(key)
+                    .or_default() += 1;
+            }
         }
-    }
-
-    fn has_geometry(&self) -> bool {
-        self.triangles > 0 || self.circles > 0 || self.arcs > 0 || self.thermals > 0
     }
 }
 
@@ -87,8 +93,16 @@ fn primitive_has_hole(primitive: &Primitive) -> bool {
         Primitive::Triangle { hole_radius, .. } | Primitive::Circle { hole_radius, .. } => {
             *hole_radius != 0.0
         }
-        Primitive::Arc { .. } | Primitive::Thermal { .. } => false,
+        Primitive::Arc { .. }
+        | Primitive::Thermal { .. }
+        | Primitive::TriangleTemplateFlash { .. } => false,
     }
+}
+
+struct TriangleTemplateOutputBuffers {
+    vertices: Vec<f32>,
+    instance_x: Vec<f32>,
+    instance_y: Vec<f32>,
 }
 
 struct PrimitiveOutputBuffers {
@@ -97,6 +111,9 @@ struct PrimitiveOutputBuffers {
     triangle_hole_x: Vec<f32>,
     triangle_hole_y: Vec<f32>,
     triangle_hole_radius: Vec<f32>,
+    triangle_templates: Vec<TriangleTemplateOutputBuffers>,
+    triangle_template_indices: HashMap<usize, usize>,
+    triangle_template_instance_counts: HashMap<usize, usize>,
     has_circle_holes: bool,
     circles_x: Vec<f32>,
     circles_y: Vec<f32>,
@@ -129,6 +146,9 @@ impl PrimitiveOutputBuffers {
             triangle_hole_x: Vec::new(),
             triangle_hole_y: Vec::new(),
             triangle_hole_radius: Vec::new(),
+            triangle_templates: Vec::new(),
+            triangle_template_indices: HashMap::new(),
+            triangle_template_instance_counts: counts.triangle_template_instance_counts.clone(),
             has_circle_holes: counts.has_circle_holes,
             circles_x: Vec::new(),
             circles_y: Vec::new(),
@@ -174,6 +194,19 @@ impl PrimitiveOutputBuffers {
                 "triangle hole radius buffer",
             )?;
         }
+        try_reserve_exact(
+            &mut buffers.triangle_templates,
+            counts.triangle_template_instance_counts.len(),
+            "triangle template list",
+        )?;
+        buffers
+            .triangle_template_indices
+            .try_reserve(counts.triangle_template_instance_counts.len())
+            .map_err(|_| {
+                JsValue::from_str(
+                    "Gerber layer is too large to render: not enough memory for triangle template index map",
+                )
+            })?;
 
         try_reserve_exact(&mut buffers.circles_x, counts.circles, "circle X buffer")?;
         try_reserve_exact(&mut buffers.circles_y, counts.circles, "circle Y buffer")?;
@@ -245,7 +278,7 @@ impl PrimitiveOutputBuffers {
         Ok(buffers)
     }
 
-    fn push_primitive(&mut self, primitive: Primitive) {
+    fn push_primitive(&mut self, primitive: Primitive) -> Result<(), JsValue> {
         // Unit conversion: aperture.rs already converts to mm using unit_multiplier.
         const TO_MM: f32 = 1.0;
 
@@ -320,11 +353,70 @@ impl PrimitiveOutputBuffers {
                 self.thermals_gap_thickness.push(gap_thickness * TO_MM);
                 self.thermals_rotation.push(rotation);
             }
+            Primitive::TriangleTemplateFlash { template, x, y } => {
+                let key = std::rc::Rc::as_ptr(&template) as usize;
+                let template_idx =
+                    if let Some(index) = self.triangle_template_indices.get(&key).copied() {
+                        index
+                    } else {
+                        let expected_instances = self
+                            .triangle_template_instance_counts
+                            .get(&key)
+                            .copied()
+                            .unwrap_or(1);
+                        let mut vertices = Vec::new();
+                        try_reserve_exact(
+                            &mut vertices,
+                            template.len(),
+                            "triangle template vertex buffer",
+                        )?;
+                        vertices.extend(template.iter().copied());
+
+                        let mut instance_x = Vec::new();
+                        let mut instance_y = Vec::new();
+                        try_reserve_exact(
+                            &mut instance_x,
+                            expected_instances,
+                            "triangle template instance X buffer",
+                        )?;
+                        try_reserve_exact(
+                            &mut instance_y,
+                            expected_instances,
+                            "triangle template instance Y buffer",
+                        )?;
+
+                        let index = self.triangle_templates.len();
+                        self.triangle_templates.push(TriangleTemplateOutputBuffers {
+                            vertices,
+                            instance_x,
+                            instance_y,
+                        });
+                        self.triangle_template_indices.insert(key, index);
+                        index
+                    };
+
+                let template = &mut self.triangle_templates[template_idx];
+                template.instance_x.push(x * TO_MM);
+                template.instance_y.push(y * TO_MM);
+            }
         }
+
+        Ok(())
     }
 
     fn into_gerber_data(self, is_negative: bool) -> GerberData {
         let boundary = self.boundary();
+        let triangle_templates = self
+            .triangle_templates
+            .into_iter()
+            .map(|template| {
+                TriangleTemplateInstances::new(
+                    template.vertices,
+                    template.instance_x,
+                    template.instance_y,
+                )
+            })
+            .collect();
 
         GerberData::new(
             Triangles::new(
@@ -333,6 +425,7 @@ impl PrimitiveOutputBuffers {
                 self.triangle_hole_y,
                 self.triangle_hole_radius,
             ),
+            triangle_templates,
             Circles::new(
                 self.circles_x,
                 self.circles_y,
@@ -362,6 +455,17 @@ impl PrimitiveOutputBuffers {
         )
     }
 
+    fn has_geometry(&self) -> bool {
+        !self.triangle_vertices.is_empty()
+            || self
+                .triangle_templates
+                .iter()
+                .any(|template| !template.vertices.is_empty() && !template.instance_x.is_empty())
+            || !self.circles_x.is_empty()
+            || !self.arcs_x.is_empty()
+            || !self.thermals_x.is_empty()
+    }
+
     fn boundary(&self) -> Boundary {
         let mut min_x = f32::INFINITY;
         let mut max_x = f32::NEG_INFINITY;
@@ -375,6 +479,32 @@ impl PrimitiveOutputBuffers {
             max_x = max_x.max(x);
             min_y = min_y.min(y);
             max_y = max_y.max(y);
+        }
+
+        for template in &self.triangle_templates {
+            if template.vertices.is_empty() {
+                continue;
+            }
+
+            let mut template_min_x = f32::INFINITY;
+            let mut template_max_x = f32::NEG_INFINITY;
+            let mut template_min_y = f32::INFINITY;
+            let mut template_max_y = f32::NEG_INFINITY;
+            for point in template.vertices.chunks_exact(2) {
+                template_min_x = template_min_x.min(point[0]);
+                template_max_x = template_max_x.max(point[0]);
+                template_min_y = template_min_y.min(point[1]);
+                template_max_y = template_max_y.max(point[1]);
+            }
+
+            for i in 0..template.instance_x.len() {
+                let x = template.instance_x[i];
+                let y = template.instance_y[i];
+                min_x = min_x.min(template_min_x + x);
+                max_x = max_x.max(template_max_x + x);
+                min_y = min_y.min(template_min_y + y);
+                max_y = max_y.max(template_max_y + y);
+            }
         }
 
         for i in 0..self.circles_x.len() {
@@ -614,25 +744,25 @@ impl GerberParser {
 
         for primitive in primitives {
             if primitive_has_hole(&primitive) {
-                holed_buffers.push_primitive(primitive);
+                holed_buffers.push_primitive(primitive)?;
             } else {
-                plain_buffers.push_primitive(primitive);
+                plain_buffers.push_primitive(primitive)?;
             }
         }
 
         let mut gerber_data_layers = Vec::new();
         let layer_count =
-            usize::from(counts.plain.has_geometry()) + usize::from(counts.holed.has_geometry());
+            usize::from(plain_buffers.has_geometry()) + usize::from(holed_buffers.has_geometry());
         try_reserve_exact(
             &mut gerber_data_layers,
             layer_count,
             "Gerber data layer list",
         )?;
 
-        if counts.plain.has_geometry() {
+        if plain_buffers.has_geometry() {
             gerber_data_layers.push(plain_buffers.into_gerber_data(is_negative));
         }
-        if counts.holed.has_geometry() {
+        if holed_buffers.has_geometry() {
             gerber_data_layers.push(holed_buffers.into_gerber_data(is_negative));
         }
 

--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -2,6 +2,7 @@ use super::aperture_macro::ApertureMacro;
 use super::geometry::{scale_primitive, Primitive};
 use super::state::Polarity;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 /// Aperture definition (Circle, Rectangle, Obround, Polygon, or Macro reference)
 #[derive(Clone, Debug)]
@@ -10,6 +11,7 @@ pub struct Aperture {
     pub primitives: Vec<Primitive>, // Aperture contains multiple basic primitives
     pub has_negative: bool,         // true if primitives contain exposure=0
     pub block_layers: Option<Vec<(Polarity, Vec<Primitive>)>>,
+    pub triangle_template: Option<Rc<Vec<f32>>>,
 }
 
 impl Aperture {
@@ -19,6 +21,7 @@ impl Aperture {
             primitives: Vec::new(),
             has_negative: false,
             block_layers: None,
+            triangle_template: None,
         }
     }
 
@@ -32,8 +35,35 @@ impl Aperture {
             primitives: Vec::new(),
             has_negative,
             block_layers: Some(block_layers),
+            triangle_template: None,
         }
     }
+}
+
+fn build_triangle_template(primitives: &[Primitive]) -> Option<Rc<Vec<f32>>> {
+    if primitives.is_empty() {
+        return None;
+    }
+
+    let mut vertices = Vec::with_capacity(primitives.len() * 6);
+    for primitive in primitives {
+        match primitive {
+            Primitive::Triangle {
+                vertices: triangle,
+                exposure,
+                hole_radius,
+                ..
+            } if *exposure >= 0.5 && *hole_radius == 0.0 => {
+                for vertex in triangle {
+                    vertices.push(vertex[0]);
+                    vertices.push(vertex[1]);
+                }
+            }
+            _ => return None,
+        }
+    }
+
+    Some(Rc::new(vertices))
 }
 
 /// Parse Aperture definition - %ADD{code}{shape}{params}*%
@@ -372,7 +402,9 @@ pub fn parse_aperture(
         Primitive::Triangle { exposure, .. } => *exposure < 0.5,
         Primitive::Arc { exposure, .. } => *exposure < 0.5,
         Primitive::Thermal { exposure, .. } => *exposure < 0.5,
+        Primitive::TriangleTemplateFlash { .. } => false,
     });
+    aperture.triangle_template = build_triangle_template(&aperture.primitives);
 
     apertures.insert(code, aperture);
 }

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -6,6 +6,7 @@ use i_triangle::float::triangulatable::Triangulatable;
 use std::collections::HashMap;
 use std::mem::size_of;
 use std::mem::take;
+use std::rc::Rc;
 
 fn format_count(value: usize) -> String {
     let digits = value.to_string();
@@ -125,6 +126,11 @@ pub enum Primitive {
         rotation: f32,
         exposure: f32, // 1.0 = positive, 0.0 = negative
     },
+    TriangleTemplateFlash {
+        template: Rc<Vec<f32>>,
+        x: f32,
+        y: f32,
+    },
 }
 
 /// Rotate point around given center
@@ -201,6 +207,13 @@ pub fn scale_primitive(primitive: &mut Primitive, scale: f32) {
             *outer_diameter *= scale;
             *inner_diameter *= scale;
             *gap_thickness *= scale;
+        }
+        Primitive::TriangleTemplateFlash { template, x, y } => {
+            for value in Rc::make_mut(template).iter_mut() {
+                *value *= scale;
+            }
+            *x *= scale;
+            *y *= scale;
         }
     }
 }
@@ -286,6 +299,23 @@ pub fn mirror_primitive(primitive: &mut Primitive, mirror_x: bool, mirror_y: boo
             }
             mirror_angle(rotation);
         }
+        Primitive::TriangleTemplateFlash { template, x, y } => {
+            let vertices = Rc::make_mut(template);
+            for point in vertices.chunks_exact_mut(2) {
+                if mirror_x {
+                    point[0] = -point[0];
+                }
+                if mirror_y {
+                    point[1] = -point[1];
+                }
+            }
+            if mirror_x {
+                *x = -*x;
+            }
+            if mirror_y {
+                *y = -*y;
+            }
+        }
     }
 }
 
@@ -352,6 +382,19 @@ pub fn rotate_primitive(primitive: &mut Primitive, angle: f32) {
             *x = center[0];
             *y = center[1];
             rotate_angle(rotation);
+        }
+        Primitive::TriangleTemplateFlash { template, x, y } => {
+            let vertices = Rc::make_mut(template);
+            for point in vertices.chunks_exact_mut(2) {
+                let mut vertex = [point[0], point[1]];
+                rotate_point(&mut vertex, angle, 0.0, 0.0);
+                point[0] = vertex[0];
+                point[1] = vertex[1];
+            }
+            let mut center = [*x, *y];
+            rotate_point(&mut center, angle, 0.0, 0.0);
+            *x = center[0];
+            *y = center[1];
         }
     }
 }
@@ -515,6 +558,10 @@ pub fn primitive_to_polygon(primitive: &Primitive) -> Vec<[f32; 2]> {
             }
             vertices
         }
+        Primitive::TriangleTemplateFlash { template, x, y } => template
+            .chunks_exact(2)
+            .map(|point| [point[0] + *x, point[1] + *y])
+            .collect(),
     }
 }
 
@@ -537,12 +584,9 @@ pub fn apply_boolean_operations(shapes: &[(Vec<Vec<[f32; 2]>>, f32)]) -> Vec<Pri
     // Start with first positive shape
     let mut result_shapes: Vec<Vec<Vec<[f32; 2]>>> = vec![shapes[first_idx].0.clone()];
 
-    // Apply boolean operations sequentially
-    for (i, (shape, exposure)) in shapes.iter().enumerate() {
-        if i == first_idx {
-            continue; // Skip the first shape we already added
-        }
-
+    // Apply boolean operations sequentially. Exposure-off primitives before
+    // the first positive primitive have no earlier macro solid to erase.
+    for (shape, exposure) in shapes.iter().skip(first_idx + 1) {
         if *exposure > 0.5 {
             // Positive: UNION
             result_shapes =
@@ -719,6 +763,11 @@ pub fn offset_primitive_by(primitive: &Primitive, dx: f32, dy: f32) -> Primitive
             rotation: *rotation,
             exposure: *exposure,
         },
+        Primitive::TriangleTemplateFlash { template, x, y } => Primitive::TriangleTemplateFlash {
+            template: Rc::clone(template),
+            x: x + dx,
+            y: y + dy,
+        },
     }
 }
 
@@ -816,6 +865,7 @@ fn flash_aperture_no_sr(
                     Primitive::Triangle { exposure, .. } => *exposure,
                     Primitive::Arc { exposure, .. } => *exposure,
                     Primitive::Thermal { exposure, .. } => *exposure,
+                    Primitive::TriangleTemplateFlash { .. } => 1.0,
                 };
                 // Wrap polygon in shape format (single contour)
                 (vec![poly], exposure)
@@ -827,6 +877,18 @@ fn flash_aperture_no_sr(
         try_reserve_primitives(primitives, result_primitives.len(), "aperture flash")?;
         primitives.extend(result_primitives);
     } else {
+        if let Some(template) = &aperture.triangle_template {
+            if layer_scale == 1.0 && !mirror_x && !mirror_y && layer_rotation == 0.0 {
+                try_reserve_primitives(primitives, 1, "aperture triangle template flash")?;
+                primitives.push(Primitive::TriangleTemplateFlash {
+                    template: Rc::clone(template),
+                    x,
+                    y,
+                });
+                return Ok(());
+            }
+        }
+
         // Direct primitive cloning
         try_reserve_primitives(primitives, aperture.primitives.len(), "aperture flash")?;
         for primitive in &aperture.primitives {
@@ -865,6 +927,10 @@ fn flash_aperture_no_sr(
                     *ay += y;
                 }
                 Primitive::Thermal { x: tx, y: ty, .. } => {
+                    *tx += x;
+                    *ty += y;
+                }
+                Primitive::TriangleTemplateFlash { x: tx, y: ty, .. } => {
                     *tx += x;
                     *ty += y;
                 }

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1,5 +1,6 @@
 use super::aperture_macro::{evaluate_expression, parse_macro};
 use super::{format_count, parse_gerber};
+use crate::shape::GerberData;
 use std::collections::HashMap;
 
 fn assert_approx_eq(actual: f32, expected: f32) {
@@ -23,6 +24,27 @@ fn triangle_bounds(vertices: &[f32]) -> (f32, f32, f32, f32) {
     }
 
     (min_x, max_x, min_y, max_y)
+}
+
+fn collect_triangle_vertices(layer: &GerberData) -> Vec<f32> {
+    let mut vertices = layer.triangles.vertices.clone();
+
+    for template in &layer.triangle_templates {
+        for i in 0..template.instance_x.len() {
+            let offset_x = template.instance_x[i];
+            let offset_y = template.instance_y[i];
+            for point in template.vertices.chunks_exact(2) {
+                vertices.push(point[0] + offset_x);
+                vertices.push(point[1] + offset_y);
+            }
+        }
+    }
+
+    vertices
+}
+
+fn layer_triangle_bounds(layer: &GerberData) -> (f32, f32, f32, f32) {
+    triangle_bounds(&collect_triangle_vertices(layer))
 }
 
 fn has_circle_at(
@@ -103,6 +125,23 @@ fn gerber_snapshot(data: &str) -> String {
             &format!("layer[{idx}].triangles.hole_radius"),
             &layer.triangles.hole_radius,
         );
+        for (template_idx, template) in layer.triangle_templates.iter().enumerate() {
+            push_scaled_vec(
+                &mut output,
+                &format!("layer[{idx}].triangle_templates[{template_idx}].vertices"),
+                &template.vertices,
+            );
+            push_scaled_vec(
+                &mut output,
+                &format!("layer[{idx}].triangle_templates[{template_idx}].instance_x"),
+                &template.instance_x,
+            );
+            push_scaled_vec(
+                &mut output,
+                &format!("layer[{idx}].triangle_templates[{template_idx}].instance_y"),
+                &template.instance_y,
+            );
+        }
         push_scaled_vec(
             &mut output,
             &format!("layer[{idx}].circles.x"),
@@ -252,7 +291,8 @@ M02*",
     .expect("macro should parse omitted parameters");
     let mut occupied_quadrants = [false; 4];
 
-    for triangle in layers[0].triangles.vertices.chunks_exact(6) {
+    let vertices = collect_triangle_vertices(&layers[0]);
+    for triangle in vertices.chunks_exact(6) {
         let centroid_x = (triangle[0] + triangle[2] + triangle[4]) / 3.0;
         let centroid_y = (triangle[1] + triangle[3] + triangle[5]) / 3.0;
 
@@ -332,7 +372,13 @@ M02*",
     .expect("apertures should parse");
 
     let triangles = &layers[0].triangles;
-    assert!(!triangles.vertices.is_empty());
+    assert!(
+        !triangles.vertices.is_empty()
+            || layers[0]
+                .triangle_templates
+                .iter()
+                .any(|template| !template.vertices.is_empty())
+    );
     assert!(triangles.hole_x.is_empty());
     assert!(triangles.hole_y.is_empty());
     assert!(triangles.hole_radius.is_empty());
@@ -373,6 +419,32 @@ M02*",
     assert_eq!(circles.hole_y.len(), circles.x.len());
     assert_eq!(circles.hole_radius.len(), circles.x.len());
     assert!(circles.hole_radius.iter().all(|radius| *radius > 0.0));
+}
+
+#[test]
+fn macro_exposure_off_only_erases_earlier_macro_primitives() {
+    let data = "\
+%FSLAX26Y26*%
+%MOMM*%
+%AMCLEARFIRST*
+1,0,0.6,0,0,0*
+21,1,1.0,1.0,0,0,0*%
+%ADD10CLEARFIRST*%
+D10*
+X000000Y000000D03*
+M02*";
+
+    let layers = parse_gerber(data).expect("macro exposure order should parse");
+    let vertices = collect_triangle_vertices(&layers[0]);
+
+    // The leading exposure-off circle has no earlier macro solid to erase, so
+    // the result is the plain square rather than a square with a circular hole.
+    assert_eq!(vertices.len(), 12);
+    let (min_x, max_x, min_y, max_y) = triangle_bounds(&vertices);
+    assert_approx_eq(min_x, -0.5);
+    assert_approx_eq(max_x, 0.5);
+    assert_approx_eq(min_y, -0.5);
+    assert_approx_eq(max_y, 0.5);
 }
 
 #[test]
@@ -422,7 +494,9 @@ M02*",
 layers=1
 layer[0].negative=false
 layer[0].boundary=[-5000,5000,0,20000]
-layer[0].triangles.vertices=[5000, 0, 5000, 20000, -5000, 20000, 5000, 0, -5000, 20000, -5000, 0]",
+layer[0].triangle_templates[0].vertices=[5000, 0, 5000, 20000, -5000, 20000, 5000, 0, -5000, 20000, -5000, 0]
+layer[0].triangle_templates[0].instance_x=[0]
+layer[0].triangle_templates[0].instance_y=[0]",
     );
 }
 
@@ -508,7 +582,9 @@ M02*",
 layers=1
 layer[0].negative=false
 layer[0].boundary=[-2000,0,-9000,11000]
-layer[0].triangles.vertices=[-2000, 8000, -2000, -6000, 0, -9000, 0, 11000, -2000, 8000, 0, -9000]",
+layer[0].triangle_templates[0].vertices=[-2000, 8000, -2000, -6000, 0, -9000, 0, 11000, -2000, 8000, 0, -9000]
+layer[0].triangle_templates[0].instance_x=[0]
+layer[0].triangle_templates[0].instance_y=[0]",
     );
 }
 
@@ -663,7 +739,7 @@ X000000Y000000D03*
 M02*";
 
     let layers = parse_gerber(data).expect("macro rectangle should parse");
-    let (min_x, max_x, min_y, max_y) = triangle_bounds(&layers[0].triangles.vertices);
+    let (min_x, max_x, min_y, max_y) = layer_triangle_bounds(&layers[0]);
 
     assert_approx_eq(min_x, -0.5);
     assert_approx_eq(max_x, 0.5);
@@ -683,7 +759,7 @@ X000000Y000000D03*
 M02*";
 
     let layers = parse_gerber(data).expect("macro outline should parse");
-    let (min_x, max_x, min_y, max_y) = triangle_bounds(&layers[0].triangles.vertices);
+    let (min_x, max_x, min_y, max_y) = layer_triangle_bounds(&layers[0]);
 
     assert_approx_eq(min_x, -1.0);
     assert_approx_eq(max_x, 0.0);
@@ -751,7 +827,7 @@ M02*";
     let layers = parse_gerber(data).expect("macro expression should parse");
 
     assert_eq!(layers.len(), 1);
-    assert!(!layers[0].triangles.vertices.is_empty());
+    assert!(!collect_triangle_vertices(&layers[0]).is_empty());
 }
 
 #[test]
@@ -772,6 +848,29 @@ M02*";
     assert_eq!(circles.x.len(), 2);
     assert_approx_eq(circles.x[0], 0.0);
     assert_approx_eq(circles.x[1], 25.4);
+}
+
+#[test]
+fn repeated_triangle_aperture_flashes_use_template_instances() {
+    let data = "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X0.5*%
+D10*
+X000000Y000000D03*
+X2000000Y000000D03*
+M02*";
+
+    let layers = parse_gerber(data).expect("rectangle flashes should parse");
+
+    assert_eq!(layers.len(), 1);
+    assert!(layers[0].triangles.vertices.is_empty());
+    assert_eq!(layers[0].triangle_templates.len(), 1);
+    assert_eq!(layers[0].triangle_templates[0].vertices.len(), 12);
+    assert_eq!(layers[0].triangle_templates[0].instance_x.len(), 2);
+    assert_eq!(layers[0].triangle_templates[0].instance_y.len(), 2);
+    assert_approx_eq(layers[0].triangle_templates[0].instance_x[0], 0.0);
+    assert_approx_eq(layers[0].triangle_templates[0].instance_x[1], 2.0);
 }
 
 #[test]
@@ -1003,7 +1102,7 @@ X000000Y000000D03*
 M02*";
 
     let layers = parse_gerber(data).expect("rotated aperture should parse");
-    let (min_x, max_x, min_y, max_y) = triangle_bounds(&layers[0].triangles.vertices);
+    let (min_x, max_x, min_y, max_y) = layer_triangle_bounds(&layers[0]);
 
     assert_approx_eq(min_x, -0.5);
     assert_approx_eq(max_x, 0.5);

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -3,14 +3,16 @@ mod camera;
 mod shader;
 
 // Internal use only
-use buffer::{BufferCache, Fbo};
+use buffer::{BufferCache, Fbo, TriangleTemplateBufferCache};
 use camera::Camera;
 use shader::{
     ShaderProgram, ShaderPrograms, ARRAY_BUFFER, BLEND, COLOR_BUFFER_BIT, FLOAT, FUNC_ADD, ONE,
     ONE_MINUS_SRC_ALPHA, STATIC_DRAW, TRIANGLES, ZERO,
 };
 
-use crate::shape::{Arcs, Boundary, Circles, GerberData, Thermals, Triangles};
+use crate::shape::{
+    Arcs, Boundary, Circles, GerberData, Thermals, TriangleTemplateInstances, Triangles,
+};
 use js_sys::Float32Array;
 use wasm_bindgen::prelude::*;
 use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlTexture};
@@ -123,6 +125,7 @@ impl Renderer {
 
     fn validate_gerber_data(data: &GerberData, sublayer_idx: usize) -> Result<(), JsValue> {
         Self::validate_triangle_data(&data.triangles, sublayer_idx)?;
+        Self::validate_triangle_template_data(&data.triangle_templates, sublayer_idx)?;
         Self::validate_circle_data(&data.circles, sublayer_idx)?;
         Self::validate_arc_data(&data.arcs, sublayer_idx)?;
         Self::validate_thermal_data(&data.thermals, sublayer_idx)?;
@@ -181,6 +184,47 @@ impl Renderer {
                 "Sublayer {} triangle vertex count exceeds WebGL draw limits",
                 sublayer_idx
             )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_triangle_template_data(
+        templates: &[TriangleTemplateInstances],
+        sublayer_idx: usize,
+    ) -> Result<(), JsValue> {
+        for (template_idx, template) in templates.iter().enumerate() {
+            if !template.vertices.len().is_multiple_of(2) {
+                return Err(JsValue::from_str(&format!(
+                    "Sublayer {} triangle template {} vertex buffer has an odd number of coordinates",
+                    sublayer_idx, template_idx
+                )));
+            }
+            let vertex_count = template.vertices.len() / 2;
+            if !vertex_count.is_multiple_of(3) {
+                return Err(JsValue::from_str(&format!(
+                    "Sublayer {} triangle template {} vertex count is not divisible by 3",
+                    sublayer_idx, template_idx
+                )));
+            }
+            let instance_count = template.instance_x.len();
+            Self::validate_instance_count("triangle template", sublayer_idx, instance_count)?;
+            Self::validate_len(
+                "triangle template instance_y",
+                sublayer_idx,
+                template.instance_y.len(),
+                instance_count,
+            )?;
+            Self::validate_finite_slice("triangle template vertices", &template.vertices)?;
+            Self::validate_finite_slice("triangle template instance_x", &template.instance_x)?;
+            Self::validate_finite_slice("triangle template instance_y", &template.instance_y)?;
+
+            if vertex_count > i32::MAX as usize {
+                return Err(JsValue::from_str(&format!(
+                    "Sublayer {} triangle template {} vertex count exceeds WebGL draw limits",
+                    sublayer_idx, template_idx
+                )));
+            }
         }
 
         Ok(())
@@ -381,6 +425,7 @@ impl Renderer {
 
     fn delete_shader_programs(gl: &WebGl2RenderingContext, programs: &ShaderPrograms) {
         gl.delete_program(Some(&programs.triangle.program));
+        gl.delete_program(Some(&programs.triangle_template.program));
         gl.delete_program(Some(&programs.circle.program));
         gl.delete_program(Some(&programs.arc.program));
         gl.delete_program(Some(&programs.thermal.program));
@@ -402,6 +447,20 @@ impl Renderer {
         }
         if let Some(buf) = cache.triangle_hole_radius_buffer {
             gl.delete_buffer(Some(&buf));
+        }
+        for template_cache in cache.triangle_template_caches {
+            if let Some(vao) = template_cache.vao {
+                gl.delete_vertex_array(Some(&vao));
+            }
+            if let Some(buf) = template_cache.vertex_buffer {
+                gl.delete_buffer(Some(&buf));
+            }
+            if let Some(buf) = template_cache.instance_x_buffer {
+                gl.delete_buffer(Some(&buf));
+            }
+            if let Some(buf) = template_cache.instance_y_buffer {
+                gl.delete_buffer(Some(&buf));
+            }
         }
 
         if let Some(vao) = cache.circle_vao {
@@ -864,6 +923,139 @@ impl Renderer {
         Ok(())
     }
 
+    /// Draw repeated triangle mesh templates.
+    fn draw_instanced_triangle_templates(
+        &mut self,
+        transform: &[f32; 9],
+        color: &[f32; 4],
+        layer_id: usize,
+        sublayer_idx: usize,
+    ) -> Result<(), JsValue> {
+        if layer_id >= self.layers.len() {
+            return Err(JsValue::from_str("Invalid layer index"));
+        }
+
+        let program = &self.programs.triangle_template;
+        self.gl.use_program(Some(&program.program));
+
+        let template_count = self.get_layer(layer_id)?.gerber_data[sublayer_idx]
+            .triangle_templates
+            .len();
+
+        for template_idx in 0..template_count {
+            let (vertex_count, instance_count) = {
+                let layer = if let Some(l) = &mut self.layers[layer_id] {
+                    l
+                } else {
+                    return Err(JsValue::from_str("Layer deallocated"));
+                };
+
+                let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+                if buffer_cache.triangle_template_caches.len() < template_count {
+                    buffer_cache
+                        .triangle_template_caches
+                        .resize_with(template_count, TriangleTemplateBufferCache::default);
+                }
+
+                if buffer_cache.triangle_template_caches[template_idx]
+                    .vao
+                    .is_none()
+                {
+                    let template =
+                        &layer.gerber_data[sublayer_idx].triangle_templates[template_idx];
+                    if template.vertices.is_empty() || template.instance_x.is_empty() {
+                        continue;
+                    }
+
+                    let vertex_count = (template.vertices.len() / 2) as i32;
+                    let instance_count = template.instance_x.len() as i32;
+
+                    let vao = self
+                        .gl
+                        .create_vertex_array()
+                        .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+                    self.gl.bind_vertex_array(Some(&vao));
+
+                    let vertex_buffer = self
+                        .gl
+                        .create_buffer()
+                        .ok_or_else(|| JsValue::from_str("Failed to create vertex buffer"))?;
+                    self.gl.bind_buffer(ARRAY_BUFFER, Some(&vertex_buffer));
+                    unsafe {
+                        let array = Float32Array::view(&template.vertices);
+                        self.gl.buffer_data_with_array_buffer_view(
+                            ARRAY_BUFFER,
+                            &array,
+                            STATIC_DRAW,
+                        );
+                    }
+
+                    let position_loc = Self::shader_attribute(program, "position")?;
+                    self.gl.enable_vertex_attrib_array(position_loc);
+                    self.gl
+                        .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
+
+                    let instance_x_buffer = Self::create_instance_buffer(
+                        &self.gl,
+                        &template.instance_x,
+                        program,
+                        "instance_x",
+                        1,
+                    )?;
+                    let instance_y_buffer = Self::create_instance_buffer(
+                        &self.gl,
+                        &template.instance_y,
+                        program,
+                        "instance_y",
+                        1,
+                    )?;
+
+                    self.gl.bind_vertex_array(None);
+
+                    let template_cache = &mut layer.buffer_caches[sublayer_idx]
+                        .triangle_template_caches[template_idx];
+                    template_cache.vao = Some(vao);
+                    template_cache.vertex_count = vertex_count;
+                    template_cache.instance_count = instance_count;
+                    template_cache.vertex_buffer = Some(vertex_buffer);
+                    template_cache.instance_x_buffer = Some(instance_x_buffer);
+                    template_cache.instance_y_buffer = Some(instance_y_buffer);
+
+                    layer.gerber_data[sublayer_idx].triangle_templates[template_idx]
+                        .release_cpu_geometry();
+                    layer.cpu_geometry_released = true;
+                }
+
+                let template_cache =
+                    &layer.buffer_caches[sublayer_idx].triangle_template_caches[template_idx];
+                (template_cache.vertex_count, template_cache.instance_count)
+            };
+
+            if vertex_count == 0 || instance_count == 0 {
+                continue;
+            }
+
+            let layer = self.get_layer(layer_id)?;
+            let template_cache =
+                &layer.buffer_caches[sublayer_idx].triangle_template_caches[template_idx];
+
+            self.gl.bind_vertex_array(template_cache.vao.as_ref());
+            if let Some(loc) = program.uniforms.get("transform") {
+                self.gl
+                    .uniform_matrix3fv_with_f32_array(Some(loc), false, transform);
+            }
+            if let Some(loc) = program.uniforms.get("color") {
+                self.gl.uniform4fv_with_f32_array(Some(loc), color);
+            }
+
+            self.gl
+                .draw_arrays_instanced(TRIANGLES, 0, vertex_count, instance_count);
+            self.gl.bind_vertex_array(None);
+        }
+
+        Ok(())
+    }
+
     /// Draw instanced circles
     fn draw_instanced_circles(
         &mut self,
@@ -1306,6 +1498,12 @@ impl Renderer {
 
             // Render all shapes (empty checks done inside draw methods)
             self.draw_instanced_triangles(transform, &white_color, layer_id, sublayer_idx)?;
+            self.draw_instanced_triangle_templates(
+                transform,
+                &white_color,
+                layer_id,
+                sublayer_idx,
+            )?;
             self.draw_instanced_circles(transform, &white_color, layer_id, sublayer_idx)?;
             self.draw_instanced_arcs(transform, &white_color, layer_id, sublayer_idx)?;
             self.draw_instanced_thermals(transform, &white_color, layer_id, sublayer_idx)?;

--- a/wasm/src/renderer/buffer.rs
+++ b/wasm/src/renderer/buffer.rs
@@ -6,6 +6,17 @@ pub struct Fbo {
     pub texture: WebGlTexture,
 }
 
+/// Buffer cache for one repeated triangle mesh template.
+#[derive(Default)]
+pub struct TriangleTemplateBufferCache {
+    pub vao: Option<WebGlVertexArrayObject>,
+    pub vertex_count: i32,
+    pub instance_count: i32,
+    pub vertex_buffer: Option<WebGlBuffer>,
+    pub instance_x_buffer: Option<WebGlBuffer>,
+    pub instance_y_buffer: Option<WebGlBuffer>,
+}
+
 /// Buffer cache for geometry rendering (per polarity sublayer)
 #[derive(Default)]
 pub struct BufferCache {
@@ -16,6 +27,7 @@ pub struct BufferCache {
     pub triangle_hole_x_buffer: Option<WebGlBuffer>,
     pub triangle_hole_y_buffer: Option<WebGlBuffer>,
     pub triangle_hole_radius_buffer: Option<WebGlBuffer>,
+    pub triangle_template_caches: Vec<TriangleTemplateBufferCache>,
 
     // Circles cache
     pub circle_vao: Option<WebGlVertexArrayObject>,

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -52,6 +52,28 @@ void main() {
 }
 "#;
 
+pub const TRIANGLE_TEMPLATE_VERTEX_SHADER: &str = r#"#version 300 es
+precision highp float;
+in vec2 position;
+in float instance_x;
+in float instance_y;
+uniform mat3 transform;
+void main() {
+    vec2 worldPosition = position + vec2(instance_x, instance_y);
+    vec3 transformed = transform * vec3(worldPosition, 1.0);
+    gl_Position = vec4(transformed.xy, 0.0, 1.0);
+}
+"#;
+
+pub const TRIANGLE_TEMPLATE_FRAGMENT_SHADER: &str = r#"#version 300 es
+precision highp float;
+uniform lowp vec4 color;
+out lowp vec4 fragColor;
+void main() {
+    fragColor = color;
+}
+"#;
+
 pub const CIRCLE_VERTEX_SHADER: &str = r#"#version 300 es
 precision highp float;
 in vec2 position;
@@ -285,6 +307,7 @@ pub struct ShaderProgram {
 /// All shader programs
 pub struct ShaderPrograms {
     pub triangle: ShaderProgram,
+    pub triangle_template: ShaderProgram,
     pub circle: ShaderProgram,
     pub arc: ShaderProgram,
     pub thermal: ShaderProgram,
@@ -304,6 +327,14 @@ impl ShaderPrograms {
                 "hole_y_instance",
                 "hole_radius_instance",
             ],
+            &["transform", "color"],
+        )?;
+
+        let triangle_template = compile_program(
+            gl,
+            TRIANGLE_TEMPLATE_VERTEX_SHADER,
+            TRIANGLE_TEMPLATE_FRAGMENT_SHADER,
+            &["position", "instance_x", "instance_y"],
             &["transform", "color"],
         )?;
 
@@ -365,6 +396,7 @@ impl ShaderPrograms {
 
         Ok(ShaderPrograms {
             triangle,
+            triangle_template,
             circle,
             arc,
             thermal,

--- a/wasm/src/shape.rs
+++ b/wasm/src/shape.rs
@@ -31,6 +31,33 @@ impl Triangles {
     }
 }
 
+/// Triangle mesh template rendered at many flash positions.
+pub struct TriangleTemplateInstances {
+    pub(crate) vertices: Vec<f32>,
+    pub(crate) instance_x: Vec<f32>,
+    pub(crate) instance_y: Vec<f32>,
+}
+
+impl TriangleTemplateInstances {
+    pub fn new(
+        vertices: Vec<f32>,
+        instance_x: Vec<f32>,
+        instance_y: Vec<f32>,
+    ) -> TriangleTemplateInstances {
+        TriangleTemplateInstances {
+            vertices,
+            instance_x,
+            instance_y,
+        }
+    }
+
+    pub(crate) fn release_cpu_geometry(&mut self) {
+        self.vertices = Vec::new();
+        self.instance_x = Vec::new();
+        self.instance_y = Vec::new();
+    }
+}
+
 /// Circle primitive data structure
 pub struct Circles {
     pub(crate) x: Vec<f32>,
@@ -193,6 +220,7 @@ impl Boundary {
 /// Container for all parsed Gerber data
 pub struct GerberData {
     pub(crate) triangles: Triangles,
+    pub(crate) triangle_templates: Vec<TriangleTemplateInstances>,
     pub(crate) circles: Circles,
     pub(crate) arcs: Arcs,
     pub(crate) thermals: Thermals,
@@ -203,6 +231,7 @@ pub struct GerberData {
 impl GerberData {
     pub fn new(
         triangles: Triangles,
+        triangle_templates: Vec<TriangleTemplateInstances>,
         circles: Circles,
         arcs: Arcs,
         thermals: Thermals,
@@ -211,6 +240,7 @@ impl GerberData {
     ) -> GerberData {
         GerberData {
             triangles,
+            triangle_templates,
             circles,
             arcs,
             thermals,
@@ -222,6 +252,10 @@ impl GerberData {
     /// Check if this GerberData contains any geometry
     pub fn has_geometry(&self) -> bool {
         !self.triangles.vertices.is_empty()
+            || self
+                .triangle_templates
+                .iter()
+                .any(|template| !template.vertices.is_empty() && !template.instance_x.is_empty())
             || !self.circles.x.is_empty()
             || !self.arcs.x.is_empty()
             || !self.thermals.x.is_empty()


### PR DESCRIPTION
## Summary
- store positive triangle-only apertures as reusable triangle templates
- record repeated D03 flashes as instance positions instead of duplicating template vertices
- add a WebGL instanced rendering path for triangle templates
- preserve macro exposure-off semantics so clear primitives only erase earlier macro primitives

## Tests
- cargo test --manifest-path wasm/Cargo.toml
- wasm-pack build wasm --target web --out-dir pkg --release
- node --check js/main.js
- git diff --check