### PR TITLE
Restrict draw apertures to solid circles

### DIFF
--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -12,6 +12,7 @@ pub struct Aperture {
     pub has_negative: bool,         // true if primitives contain exposure=0
     pub block_layers: Option<Vec<(Polarity, Vec<Primitive>)>>,
     pub triangle_template: Option<Rc<Vec<f32>>>,
+    pub is_solid_circle: bool,
 }
 
 impl Aperture {
@@ -22,6 +23,7 @@ impl Aperture {
             has_negative: false,
             block_layers: None,
             triangle_template: None,
+            is_solid_circle: false,
         }
     }
 
@@ -36,6 +38,7 @@ impl Aperture {
             has_negative,
             block_layers: Some(block_layers),
             triangle_template: None,
+            is_solid_circle: false,
         }
     }
 }
@@ -124,6 +127,7 @@ pub fn parse_aperture(
                     };
 
                     aperture.radius = diameter_mm / 2.0;
+                    aperture.is_solid_circle = hole_diameter_mm == 0.0;
                     aperture.primitives.push(Primitive::Circle {
                         x: 0.0,
                         y: 0.0,

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1081,12 +1081,7 @@ pub fn execute_interpolation(
     let start_x = state.x;
     let start_y = state.y;
 
-    // RS-274X draw and arc objects can only be created with a solid standard circle aperture.
     if let Some(aperture) = apertures.get(&state.current_aperture) {
-        if !aperture.is_solid_circle {
-            return Ok(());
-        }
-
         match state.interpolation_mode.as_str() {
             "linear" | "linear_x10" | "linear_x01" | "linear_x001" => {
                 // Draw line with Step and Repeat
@@ -1110,6 +1105,12 @@ pub fn execute_interpolation(
                                 state.mirror_y,
                                 state.layer_rotation,
                             )?;
+                            continue;
+                        }
+
+                        // RS-274X draw objects can only be created with a solid standard circle
+                        // aperture. Non-zero-length draws with other apertures are non-image.
+                        if !aperture.is_solid_circle {
                             continue;
                         }
 
@@ -1161,6 +1162,26 @@ pub fn execute_interpolation(
                         let sr_start_y = start_y + offset_y;
                         let sr_end_x = end_x + offset_x;
                         let sr_end_y = end_y + offset_y;
+
+                        if points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y) {
+                            flash_aperture_no_sr(
+                                aperture,
+                                primitives,
+                                sr_start_x,
+                                sr_start_y,
+                                state.layer_scale,
+                                state.mirror_x,
+                                state.mirror_y,
+                                state.layer_rotation,
+                            )?;
+                            continue;
+                        }
+
+                        // RS-274X arc objects can only be created with a solid standard circle
+                        // aperture. Non-zero-length arcs with other apertures are non-image.
+                        if !aperture.is_solid_circle {
+                            continue;
+                        }
 
                         if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
                             calculate_arc_parameters(

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1081,22 +1081,25 @@ pub fn execute_interpolation(
     let start_x = state.x;
     let start_y = state.y;
 
-    // Get current aperture
-    if let Some(_aperture) = apertures.get(&state.current_aperture) {
+    // RS-274X draw and arc objects can only be created with a solid standard circle aperture.
+    if let Some(aperture) = apertures.get(&state.current_aperture) {
+        if !aperture.is_solid_circle {
+            return Ok(());
+        }
+
         match state.interpolation_mode.as_str() {
             "linear" | "linear_x10" | "linear_x01" | "linear_x001" => {
                 // Draw line with Step and Repeat
-                if let Some(aperture) = apertures.get(&state.current_aperture) {
-                    for sy in 0..state.sr_y {
-                        for sx in 0..state.sr_x {
-                            let offset_x = sx as f32 * state.sr_i;
-                            let offset_y = sy as f32 * state.sr_j;
-                            let sr_start_x = start_x + offset_x;
-                            let sr_start_y = start_y + offset_y;
-                            let sr_end_x = end_x + offset_x;
-                            let sr_end_y = end_y + offset_y;
+                for sy in 0..state.sr_y {
+                    for sx in 0..state.sr_x {
+                        let offset_x = sx as f32 * state.sr_i;
+                        let offset_y = sy as f32 * state.sr_j;
+                        let sr_start_x = start_x + offset_x;
+                        let sr_start_y = start_y + offset_y;
+                        let sr_end_x = end_x + offset_x;
+                        let sr_end_y = end_y + offset_y;
 
-                            // Flash aperture at start point (no SR since we're already in SR loop)
+                        if points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y) {
                             flash_aperture_no_sr(
                                 aperture,
                                 primitives,
@@ -1107,105 +1110,118 @@ pub fn execute_interpolation(
                                 state.mirror_y,
                                 state.layer_rotation,
                             )?;
-
-                            // Convert vector line with width of aperture diameter to triangle
-                            let diameter = aperture.radius * 2.0 * state.layer_scale;
-                            let line_triangles = line_to_triangles(
-                                sr_start_x, sr_start_y, sr_end_x, sr_end_y, diameter, 1.0,
-                            );
-                            try_reserve_primitives(
-                                primitives,
-                                line_triangles.len(),
-                                "linear interpolation",
-                            )?;
-                            primitives.extend(line_triangles);
-
-                            // Flash aperture at end point (no SR since we're already in SR loop)
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_end_x,
-                                sr_end_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            )?;
+                            continue;
                         }
+
+                        // Flash aperture at start point (no SR since we're already in SR loop)
+                        flash_aperture_no_sr(
+                            aperture,
+                            primitives,
+                            sr_start_x,
+                            sr_start_y,
+                            state.layer_scale,
+                            state.mirror_x,
+                            state.mirror_y,
+                            state.layer_rotation,
+                        )?;
+
+                        // Convert vector line with width of aperture diameter to triangle
+                        let diameter = aperture.radius * 2.0 * state.layer_scale;
+                        let line_triangles = line_to_triangles(
+                            sr_start_x, sr_start_y, sr_end_x, sr_end_y, diameter, 1.0,
+                        );
+                        try_reserve_primitives(
+                            primitives,
+                            line_triangles.len(),
+                            "linear interpolation",
+                        )?;
+                        primitives.extend(line_triangles);
+
+                        // Flash aperture at end point (no SR since we're already in SR loop)
+                        flash_aperture_no_sr(
+                            aperture,
+                            primitives,
+                            sr_end_x,
+                            sr_end_y,
+                            state.layer_scale,
+                            state.mirror_x,
+                            state.mirror_y,
+                            state.layer_rotation,
+                        )?;
                     }
                 }
             }
             "clockwise" | "counterclockwise" => {
                 // Draw arc with Step and Repeat
-                if let Some(aperture) = apertures.get(&state.current_aperture) {
-                    for sy in 0..state.sr_y {
-                        for sx in 0..state.sr_x {
-                            let offset_x = sx as f32 * state.sr_i;
-                            let offset_y = sy as f32 * state.sr_j;
-                            let sr_start_x = start_x + offset_x;
-                            let sr_start_y = start_y + offset_y;
-                            let sr_end_x = end_x + offset_x;
-                            let sr_end_y = end_y + offset_y;
+                for sy in 0..state.sr_y {
+                    for sx in 0..state.sr_x {
+                        let offset_x = sx as f32 * state.sr_i;
+                        let offset_y = sy as f32 * state.sr_j;
+                        let sr_start_x = start_x + offset_x;
+                        let sr_start_y = start_y + offset_y;
+                        let sr_end_x = end_x + offset_x;
+                        let sr_end_y = end_y + offset_y;
 
-                            if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
-                                calculate_arc_parameters(
-                                    state, sr_start_x, sr_start_y, sr_end_x, sr_end_y, i, j,
-                                )
-                            {
-                                let thickness = aperture.radius * 2.0 * state.layer_scale;
-                                let end_angle = start_angle + sweep_angle;
+                        if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
+                            calculate_arc_parameters(
+                                state, sr_start_x, sr_start_y, sr_end_x, sr_end_y, i, j,
+                            )
+                        {
+                            let thickness = aperture.radius * 2.0 * state.layer_scale;
+                            let end_angle = start_angle + sweep_angle;
 
-                                let cap_start_x = center_x + radius * start_angle.cos();
-                                let cap_start_y = center_y + radius * start_angle.sin();
-                                let cap_end_x = center_x + radius * end_angle.cos();
-                                let cap_end_y = center_y + radius * end_angle.sin();
+                            let cap_start_x = center_x + radius * start_angle.cos();
+                            let cap_start_y = center_y + radius * start_angle.sin();
+                            let cap_end_x = center_x + radius * end_angle.cos();
+                            let cap_end_y = center_y + radius * end_angle.sin();
 
-                                // Flash aperture at rendered arc start point.
-                                flash_aperture_no_sr(
-                                    aperture,
-                                    primitives,
-                                    cap_start_x,
-                                    cap_start_y,
-                                    state.layer_scale,
-                                    state.mirror_x,
-                                    state.mirror_y,
-                                    state.layer_rotation,
-                                )?;
+                            // Flash aperture at rendered arc start point.
+                            flash_aperture_no_sr(
+                                aperture,
+                                primitives,
+                                cap_start_x,
+                                cap_start_y,
+                                state.layer_scale,
+                                state.mirror_x,
+                                state.mirror_y,
+                                state.layer_rotation,
+                            )?;
 
-                                // Add Arc primitive
-                                try_reserve_primitives(primitives, 1, "arc interpolation")?;
-                                primitives.push(Primitive::Arc {
-                                    x: center_x,
-                                    y: center_y,
-                                    radius,
-                                    start_angle,
-                                    end_angle: start_angle + sweep_angle,
-                                    thickness,
-                                    exposure: 1.0,
-                                });
+                            // Add Arc primitive
+                            try_reserve_primitives(primitives, 1, "arc interpolation")?;
+                            primitives.push(Primitive::Arc {
+                                x: center_x,
+                                y: center_y,
+                                radius,
+                                start_angle,
+                                end_angle: start_angle + sweep_angle,
+                                thickness,
+                                exposure: 1.0,
+                            });
 
-                                // Flash aperture at rendered arc end point.
-                                flash_aperture_no_sr(
-                                    aperture,
-                                    primitives,
-                                    cap_end_x,
-                                    cap_end_y,
-                                    state.layer_scale,
-                                    state.mirror_x,
-                                    state.mirror_y,
-                                    state.layer_rotation,
-                                )?;
-                            } else {
-                                flash_aperture_no_sr(
-                                    aperture,
-                                    primitives,
-                                    sr_start_x,
-                                    sr_start_y,
-                                    state.layer_scale,
-                                    state.mirror_x,
-                                    state.mirror_y,
-                                    state.layer_rotation,
-                                )?;
+                            // Flash aperture at rendered arc end point.
+                            flash_aperture_no_sr(
+                                aperture,
+                                primitives,
+                                cap_end_x,
+                                cap_end_y,
+                                state.layer_scale,
+                                state.mirror_x,
+                                state.mirror_y,
+                                state.layer_rotation,
+                            )?;
+                        } else {
+                            flash_aperture_no_sr(
+                                aperture,
+                                primitives,
+                                sr_start_x,
+                                sr_start_y,
+                                state.layer_scale,
+                                state.mirror_x,
+                                state.mirror_y,
+                                state.layer_rotation,
+                            )?;
+                            if !points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y) {
                                 flash_aperture_no_sr(
                                     aperture,
                                     primitives,

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1163,7 +1163,9 @@ pub fn execute_interpolation(
                         let sr_end_x = end_x + offset_x;
                         let sr_end_y = end_y + offset_y;
 
-                        if points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y) {
+                        if points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y)
+                            && !arc_center_offset_present(i, j)
+                        {
                             flash_aperture_no_sr(
                                 aperture,
                                 primitives,
@@ -1373,6 +1375,10 @@ fn normalize_arc_sweep(
 
 fn points_coincide(start_x: f32, start_y: f32, end_x: f32, end_y: f32) -> bool {
     (start_x - end_x).abs() < 0.0001 && (start_y - end_y).abs() < 0.0001
+}
+
+fn arc_center_offset_present(i: f32, j: f32) -> bool {
+    i.abs() >= 0.0001 || j.abs() >= 0.0001
 }
 
 fn append_region_segment(

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1152,6 +1152,30 @@ M02*",
 }
 
 #[test]
+fn zero_length_non_solid_draw_matches_flash_image() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X1.0*%
+D10*
+X0000000Y0000000D02*
+X0000000Y0000000D01*
+M02*",
+    )
+    .expect("zero-length rectangle D01 should parse");
+
+    assert_eq!(layers.len(), 1);
+    let vertices = collect_triangle_vertices(&layers[0]);
+    assert_eq!(vertices.len(), 12);
+    let (min_x, max_x, min_y, max_y) = triangle_bounds(&vertices);
+    assert_approx_eq(min_x, -0.5);
+    assert_approx_eq(max_x, 0.5);
+    assert_approx_eq(min_y, -0.5);
+    assert_approx_eq(max_y, 0.5);
+}
+
+#[test]
 fn layer_scaling_transforms_aperture_block_about_origin() {
     let data = "\
 %FSLAX24Y24*%

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1068,6 +1068,90 @@ M02*",
 }
 
 #[test]
+fn linear_draw_requires_solid_standard_circle_aperture() {
+    let rectangle_layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X1.0*%
+D10*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+M02*",
+    )
+    .expect("rectangle D01 should parse without image geometry");
+    assert!(rectangle_layers.is_empty());
+
+    let holed_circle_layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0X0.2*%
+D10*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+M02*",
+    )
+    .expect("holed circle D01 should parse without image geometry");
+    assert!(holed_circle_layers.is_empty());
+
+    let macro_circle_layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%AMCIRC*1,1,1.0,0,0,0*%
+%ADD10CIRC*%
+D10*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+M02*",
+    )
+    .expect("macro circle D01 should parse without image geometry");
+    assert!(macro_circle_layers.is_empty());
+}
+
+#[test]
+fn solid_circle_linear_draw_still_renders_round_caps_and_body() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+M02*",
+    )
+    .expect("solid circle D01 should parse");
+    let layer = &layers[0];
+
+    assert_eq!(layer.circles.x.len(), 2);
+    assert!(has_circle_at(&layer.circles, 0.0, 0.0, 0.5));
+    assert!(has_circle_at(&layer.circles, 1.0, 0.0, 0.5));
+    assert!(!layer.triangles.vertices.is_empty());
+}
+
+#[test]
+fn zero_length_solid_circle_draw_matches_single_flash_image() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+X0000000Y0000000D02*
+X0000000Y0000000D01*
+M02*",
+    )
+    .expect("zero-length solid circle D01 should parse");
+    let layer = &layers[0];
+
+    assert_eq!(layer.circles.x.len(), 1);
+    assert!(has_circle_at(&layer.circles, 0.0, 0.0, 0.5));
+    assert!(layer.triangles.vertices.is_empty());
+}
+
+#[test]
 fn layer_scaling_transforms_aperture_block_about_origin() {
     let data = "\
 %FSLAX24Y24*%

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1068,6 +1068,51 @@ M02*",
 }
 
 #[test]
+fn full_circle_arc_preserves_equal_start_end_with_center_offset() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+G03*
+G75*
+X1000000Y0000000D02*
+X1000000Y0000000I-1000000J0000000D01*
+M02*",
+    )
+    .expect("full-circle arc should parse");
+    let layer = &layers[0];
+
+    assert_eq!(layer.arcs.x.len(), 1);
+    assert_approx_eq(layer.arcs.x[0], 0.0);
+    assert_approx_eq(layer.arcs.y[0], 0.0);
+    assert_approx_eq(layer.arcs.radius[0], 1.0);
+    assert_approx_eq(layer.arcs.sweep_angle[0], 2.0 * std::f32::consts::PI);
+    assert_eq!(layer.circles.x.len(), 2);
+    assert!(has_circle_at(&layer.circles, 1.0, 0.0, 0.5));
+}
+
+#[test]
+fn full_circle_arc_requires_solid_standard_circle_aperture() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X1.0*%
+D10*
+G03*
+G75*
+X1000000Y0000000D02*
+X1000000Y0000000I-1000000J0000000D01*
+M02*",
+    )
+    .expect("non-solid full-circle arc should parse without image geometry");
+
+    assert!(layers.is_empty());
+}
+
+#[test]
 fn linear_draw_requires_solid_standard_circle_aperture() {
     let rectangle_layers = parse_gerber(
         "\


### PR DESCRIPTION
## Summary
- mark solid standard circle apertures during aperture parsing
- create D01 draw and arc geometry only for solid circle standard apertures
- make zero-length solid circle draws render as a single flash image
- add tests for non-circle, holed circle, macro circle, solid circle, and zero-length draw behavior

## Tests
- cargo test --manifest-path wasm/Cargo.toml
- wasm-pack build wasm --target web --out-dir pkg --release
- git diff --check