### PR TITLE
Improve parallel Gerber parsing memory handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@
 
           <div class="loading-progress-header">
             <span id="loading-progress-count">0 / 0</span>
-            <strong id="loading-progress-value">0%</strong>
+            <strong id="loading-progress-value" hidden></strong>
           </div>
           <progress
             class="loading-progress-bar"

--- a/js/gerber-parse-worker.js
+++ b/js/gerber-parse-worker.js
@@ -1,6 +1,12 @@
 const WASM_INPUT_RESERVE_MARGIN_BYTES = 1024 * 1024;
 
 let wasmModulePromise = null;
+let wasmExports = null;
+
+function getWorkerWasmMemoryBytes() {
+  const wasmMemoryBytes = Number(wasmExports?.memory?.buffer?.byteLength);
+  return Number.isFinite(wasmMemoryBytes) ? wasmMemoryBytes : null;
+}
 
 function getUtf8ByteLength(value) {
   let bytes = 0;
@@ -43,7 +49,7 @@ async function getWasmModule() {
   if (!wasmModulePromise) {
     wasmModulePromise = import("../wasm/pkg/wasm_gerber_processor.js").then(
       async (wasmModule) => {
-        await wasmModule.default();
+        wasmExports = await wasmModule.default();
         wasmModule.init_panic_hook?.();
         return wasmModule;
       },
@@ -92,28 +98,39 @@ function collectTransferables(value, transferables = [], seen = new Set()) {
 self.addEventListener("message", async (event) => {
   const { id, offset = {} } = event.data ?? {};
   let content = event.data?.content;
+  let beforeBytes = null;
 
   try {
     const wasmModule = await getWasmModule();
+    beforeBytes = getWorkerWasmMemoryBytes();
     reserveWasmInputCapacity(wasmModule, content);
     const parsedLayer = wasmModule.parse_gerber_layer(
       content,
       Number(offset.x ?? 0),
       Number(offset.y ?? 0),
     );
+    const transferables = collectTransferables(parsedLayer);
     self.postMessage(
       {
         id,
         ok: true,
         parsedLayer,
+        workerMemory: {
+          beforeBytes,
+          afterBytes: getWorkerWasmMemoryBytes(),
+        },
       },
-      collectTransferables(parsedLayer),
+      transferables,
     );
   } catch (error) {
     self.postMessage({
       id,
       ok: false,
       error: getErrorMessage(error),
+      workerMemory: {
+        beforeBytes,
+        afterBytes: getWorkerWasmMemoryBytes(),
+      },
     });
   } finally {
     content = null;

--- a/js/gerber-parse-worker.js
+++ b/js/gerber-parse-worker.js
@@ -1,0 +1,121 @@
+const WASM_INPUT_RESERVE_MARGIN_BYTES = 1024 * 1024;
+
+let wasmModulePromise = null;
+
+function getUtf8ByteLength(value) {
+  let bytes = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < value.length) {
+      const next = value.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i += 1;
+      } else {
+        bytes += 3;
+      }
+    } else {
+      bytes += 3;
+    }
+  }
+
+  return bytes;
+}
+
+function getErrorMessage(error) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unknown error";
+}
+
+async function getWasmModule() {
+  if (!wasmModulePromise) {
+    wasmModulePromise = import("../wasm/pkg/wasm_gerber_processor.js").then(
+      async (wasmModule) => {
+        await wasmModule.default();
+        wasmModule.init_panic_hook?.();
+        return wasmModule;
+      },
+    );
+  }
+
+  return wasmModulePromise;
+}
+
+function reserveWasmInputCapacity(wasmModule, content) {
+  if (typeof wasmModule.reserve_input_capacity !== "function") {
+    return;
+  }
+
+  const byteLength = getUtf8ByteLength(content);
+  wasmModule.reserve_input_capacity(byteLength + WASM_INPUT_RESERVE_MARGIN_BYTES);
+}
+
+function collectTransferables(value, transferables = [], seen = new Set()) {
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return transferables;
+  }
+  seen.add(value);
+
+  if (ArrayBuffer.isView(value)) {
+    if (value.buffer.byteLength > 0 && !transferables.includes(value.buffer)) {
+      transferables.push(value.buffer);
+    }
+    return transferables;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    if (value.byteLength > 0 && !transferables.includes(value)) {
+      transferables.push(value);
+    }
+    return transferables;
+  }
+
+  for (const child of Object.values(value)) {
+    collectTransferables(child, transferables, seen);
+  }
+
+  return transferables;
+}
+
+self.addEventListener("message", async (event) => {
+  const { id, offset = {} } = event.data ?? {};
+  let content = event.data?.content;
+
+  try {
+    const wasmModule = await getWasmModule();
+    reserveWasmInputCapacity(wasmModule, content);
+    const parsedLayer = wasmModule.parse_gerber_layer(
+      content,
+      Number(offset.x ?? 0),
+      Number(offset.y ?? 0),
+    );
+    self.postMessage(
+      {
+        id,
+        ok: true,
+        parsedLayer,
+      },
+      collectTransferables(parsedLayer),
+    );
+  } catch (error) {
+    self.postMessage({
+      id,
+      ok: false,
+      error: getErrorMessage(error),
+    });
+  } finally {
+    content = null;
+  }
+});

--- a/js/gerber-parse-worker.js
+++ b/js/gerber-parse-worker.js
@@ -45,6 +45,17 @@ function getErrorMessage(error) {
   return "Unknown error";
 }
 
+function isWorkerUnavailableErrorMessage(message) {
+  const normalizedMessage = String(message ?? "").toLowerCase();
+  return (
+    normalizedMessage.includes("parse_gerber_layer") ||
+    normalizedMessage.includes("parse worker api") ||
+    normalizedMessage.includes("parse worker requires an updated wasm module") ||
+    normalizedMessage.includes("failed to fetch dynamically imported module") ||
+    normalizedMessage.includes("wasm_gerber_processor")
+  );
+}
+
 async function getWasmModule() {
   if (!wasmModulePromise) {
     wasmModulePromise = import("../wasm/pkg/wasm_gerber_processor.js").then(
@@ -102,6 +113,9 @@ self.addEventListener("message", async (event) => {
 
   try {
     const wasmModule = await getWasmModule();
+    if (typeof wasmModule.parse_gerber_layer !== "function") {
+      throw new Error("Parse worker API unavailable: parse_gerber_layer is missing");
+    }
     beforeBytes = getWorkerWasmMemoryBytes();
     reserveWasmInputCapacity(wasmModule, content);
     const parsedLayer = wasmModule.parse_gerber_layer(
@@ -123,10 +137,12 @@ self.addEventListener("message", async (event) => {
       transferables,
     );
   } catch (error) {
+    const errorMessage = getErrorMessage(error);
     self.postMessage({
       id,
       ok: false,
-      error: getErrorMessage(error),
+      error: errorMessage,
+      workerUnavailable: isWorkerUnavailableErrorMessage(errorMessage),
       workerMemory: {
         beforeBytes,
         afterBytes: getWorkerWasmMemoryBytes(),

--- a/js/main.js
+++ b/js/main.js
@@ -37,6 +37,15 @@ import {
 } from "./viewport.js";
 
 const WASM_INPUT_RESERVE_MARGIN_BYTES = 1024 * 1024;
+const MAX_PARSE_WORKERS = 4;
+const BYTES_PER_MIB = 1024 * 1024;
+const UNKNOWN_LAYER_SOURCE_SIZE_BYTES = 16 * BYTES_PER_MIB;
+const MIN_PARSE_TASK_MEMORY_BYTES = 32 * BYTES_PER_MIB;
+const DEFAULT_PARSE_MEMORY_BUDGET_BYTES = 512 * BYTES_PER_MIB;
+const MIN_PARSE_MEMORY_BUDGET_BYTES = 128 * BYTES_PER_MIB;
+const MAX_PARSE_MEMORY_BUDGET_BYTES = 1536 * BYTES_PER_MIB;
+const PARSE_MEMORY_ESTIMATE_MULTIPLIER = 8;
+const PARSE_MEMORY_HEADROOM_RATIO = 0.5;
 
 function getUtf8ByteLength(value) {
   let bytes = 0;
@@ -80,6 +89,184 @@ function normalizeLayerOffset(offset = {}) {
 
 function hasLayerOffset(offset) {
   return offset.x !== 0 || offset.y !== 0;
+}
+
+function getParseWorkerCount(layerCount) {
+  if (layerCount <= 1 || typeof Worker === "undefined") {
+    return 0;
+  }
+
+  const hardwareConcurrency = Number(globalThis.navigator?.hardwareConcurrency);
+  const availableWorkers = Number.isFinite(hardwareConcurrency)
+    ? Math.max(1, hardwareConcurrency - 1)
+    : 2;
+
+  return Math.min(layerCount, availableWorkers, MAX_PARSE_WORKERS);
+}
+
+function getLayerSourceSizeBytes(source) {
+  const sizeBytes = Number(source?.sizeBytes);
+  return Number.isFinite(sizeBytes) && sizeBytes > 0
+    ? sizeBytes
+    : UNKNOWN_LAYER_SOURCE_SIZE_BYTES;
+}
+
+function estimateLayerParseMemoryBytes(source) {
+  return Math.max(
+    getLayerSourceSizeBytes(source) * PARSE_MEMORY_ESTIMATE_MULTIPLIER,
+    MIN_PARSE_TASK_MEMORY_BYTES,
+  );
+}
+
+function getBrowserAvailableHeapBytes() {
+  const memory = globalThis.performance?.memory;
+  const heapLimit = Number(memory?.jsHeapSizeLimit);
+  const usedHeap = Number(memory?.usedJSHeapSize);
+
+  if (!Number.isFinite(heapLimit) || !Number.isFinite(usedHeap)) {
+    return null;
+  }
+
+  return Math.max(0, heapLimit - usedHeap);
+}
+
+function getDeviceMemoryBudgetBytes() {
+  const deviceMemory = Number(globalThis.navigator?.deviceMemory);
+  if (!Number.isFinite(deviceMemory) || deviceMemory <= 0) {
+    return DEFAULT_PARSE_MEMORY_BUDGET_BYTES;
+  }
+
+  return deviceMemory * 1024 * BYTES_PER_MIB * 0.25;
+}
+
+function getParseMemoryBudgetBytes() {
+  const availableHeapBytes = getBrowserAvailableHeapBytes();
+  const rawBudget =
+    availableHeapBytes === null
+      ? getDeviceMemoryBudgetBytes()
+      : Math.min(
+          getDeviceMemoryBudgetBytes(),
+          availableHeapBytes * PARSE_MEMORY_HEADROOM_RATIO,
+        );
+
+  return Math.min(
+    Math.max(rawBudget, MIN_PARSE_MEMORY_BUDGET_BYTES),
+    MAX_PARSE_MEMORY_BUDGET_BYTES,
+  );
+}
+
+class GerberParseWorkerPool {
+  constructor(workerCount) {
+    this.workers = [];
+    this.idleWorkers = [];
+    this.queue = [];
+    this.activeTasks = new Map();
+    this.nextTaskId = 0;
+    this.isDisposed = false;
+
+    const workerUrl = new URL("./gerber-parse-worker.js", import.meta.url);
+    for (let index = 0; index < workerCount; index++) {
+      const worker = new Worker(workerUrl, { type: "module" });
+      worker.addEventListener("message", (event) =>
+        this.handleWorkerMessage(worker, event),
+      );
+      worker.addEventListener("error", (event) =>
+        this.handleWorkerError(worker, event),
+      );
+      this.workers.push(worker);
+      this.idleWorkers.push(worker);
+    }
+  }
+
+  get size() {
+    return this.workers.length;
+  }
+
+  parse(content, offset) {
+    if (this.isDisposed) {
+      return Promise.reject(new Error("Parse worker pool has been disposed"));
+    }
+    if (this.workers.length === 0) {
+      return Promise.reject(new Error("No parse workers are available"));
+    }
+
+    const id = this.nextTaskId++;
+    return new Promise((resolve, reject) => {
+      this.queue.push({ id, content, offset, resolve, reject });
+      this.pump();
+    });
+  }
+
+  pump() {
+    while (this.idleWorkers.length > 0 && this.queue.length > 0) {
+      const worker = this.idleWorkers.pop();
+      const task = this.queue.shift();
+      this.activeTasks.set(worker, task);
+      worker.postMessage({
+        id: task.id,
+        content: task.content,
+        offset: task.offset,
+      });
+    }
+  }
+
+  handleWorkerMessage(worker, event) {
+    const task = this.activeTasks.get(worker);
+    if (!task || event.data?.id !== task.id) {
+      return;
+    }
+
+    this.activeTasks.delete(worker);
+    if (!this.isDisposed) {
+      this.idleWorkers.push(worker);
+    }
+
+    if (event.data.ok) {
+      task.resolve(event.data.parsedLayer);
+    } else {
+      task.reject(new Error(event.data.error || "Failed to parse Gerber layer"));
+    }
+
+    this.pump();
+  }
+
+  handleWorkerError(worker, event) {
+    const task = this.activeTasks.get(worker);
+    this.activeTasks.delete(worker);
+    worker.terminate();
+    this.workers = this.workers.filter((item) => item !== worker);
+    this.idleWorkers = this.idleWorkers.filter((item) => item !== worker);
+
+    if (task) {
+      task.reject(new Error(event.message || "Gerber parse worker failed"));
+    }
+    if (this.workers.length === 0) {
+      for (const queuedTask of this.queue) {
+        queuedTask.reject(new Error("No parse workers are available"));
+      }
+      this.queue = [];
+    }
+
+    this.pump();
+  }
+
+  dispose() {
+    this.isDisposed = true;
+    for (const task of this.queue) {
+      task.reject(new Error("Parse worker pool has been disposed"));
+    }
+    for (const task of this.activeTasks.values()) {
+      task.reject(new Error("Parse worker pool has been disposed"));
+    }
+    this.queue = [];
+    this.activeTasks.clear();
+
+    for (const worker of this.workers) {
+      worker.terminate();
+    }
+    this.workers = [];
+    this.idleWorkers = [];
+  }
 }
 
 function isFatalWasmRuntimeError(error) {
@@ -748,7 +935,6 @@ export class GerberViewer {
     fileName = null,
     current = null,
     total = null,
-    progress = null,
     indeterminate = false,
   } = {}) {
     if (title !== null) {
@@ -761,21 +947,27 @@ export class GerberViewer {
     if (fileName !== null) {
       this.loadingFileName.textContent = fileName || "-";
     }
-    if (current !== null || total !== null) {
-      const currentValue = Number.isFinite(current) ? current : 0;
-      const totalValue = Number.isFinite(total) ? total : 0;
-      this.loadingProgressCount.textContent = `${currentValue} / ${totalValue}`;
+    const currentValue = Number.isFinite(current) ? current : null;
+    const totalValue = Number.isFinite(total) ? total : null;
+    if (currentValue !== null || totalValue !== null) {
+      this.loadingProgressCount.textContent =
+        `${currentValue ?? 0} / ${totalValue ?? 0}`;
     }
 
     if (indeterminate) {
       this.loadingProgressBar.removeAttribute("value");
-      this.loadingProgressValue.textContent = "-";
+      this.loadingProgressValue.textContent = "";
+      this.loadingProgressValue.hidden = true;
       return;
     }
 
-    const percent = Math.round(clampProgress(progress ?? 0) * 100);
-    this.loadingProgressBar.value = percent;
-    this.loadingProgressValue.textContent = `${percent}%`;
+    this.loadingProgressValue.textContent = "";
+    this.loadingProgressValue.hidden = true;
+    const progressRatio =
+      totalValue && totalValue > 0 ? (currentValue ?? 0) / totalValue : 0;
+    this.loadingProgressBar.value = Math.round(
+      clampProgress(progressRatio) * 100,
+    );
   }
 
   hideLoadingModal() {
@@ -783,14 +975,6 @@ export class GerberViewer {
     this.isLoadingLayers = false;
     this.loadingWorkspaceStatus = "Loading files";
     this.updateUiState();
-  }
-
-  getLayerLoadProgress(index, total, fileProgress) {
-    if (!Number.isFinite(total) || total <= 0) {
-      return 0;
-    }
-
-    return (index + clampProgress(fileProgress)) / total;
   }
 
   addDiagnostic(level, title, detail = "") {
@@ -1074,13 +1258,13 @@ export class GerberViewer {
 
     try {
       const file = await fetchRemoteFile(url, {
-        onProgress: (progress) => {
+        onProgress: () => {
           this.updateLoadingModal({
             stage: "Downloading",
             fileName: url.href,
             current: 0,
             total: 0,
-            progress,
+            indeterminate: true,
           });
         },
       });
@@ -1145,7 +1329,6 @@ export class GerberViewer {
         stage: "Preparing",
         current: 0,
         total: validFiles.length,
-        progress: 0,
       });
 
       try {
@@ -1177,31 +1360,50 @@ export class GerberViewer {
 
   async loadLayerSources(layerSources, { title = "Loading files" } = {}) {
     const total = layerSources.length;
-    const readProgresses = Array(total).fill(0);
+    const parseWorkerPool = this.createParseWorkerPool(total);
+
+    if (!parseWorkerPool) {
+      return this.loadLayerSourcesSerially(layerSources, { title, total });
+    }
+
+    const concurrency = parseWorkerPool.size;
+    const progress = this.createLayerLoadProgress(total);
+    const parseTasks = this.createLayerParseTasks(layerSources);
 
     this.showLoadingModal({
       title,
       stage: "Reading",
       current: 0,
       total,
-      progress: 0,
     });
 
-    const readResults = await Promise.all(
-      layerSources.map((source, index) =>
-        this.readLayerSource(source, {
+    try {
+      return await this.runLayerParsePipeline(layerSources, {
+        title,
+        total,
+        concurrency,
+        progress,
+        parseWorkerPool,
+        parseTasks,
+      });
+    } finally {
+      parseWorkerPool?.dispose();
+    }
+  }
+
+  async loadLayerSourcesSerially(
+    layerSources,
+    { title = "Loading files", total = layerSources.length } = {},
+  ) {
+    const results = [];
+
+    for (const [index, source] of layerSources.entries()) {
+      results.push(
+        await this.loadLayerSourceSerially(source, {
           index,
           total,
           title,
-          readProgresses,
         }),
-      ),
-    );
-
-    const results = [];
-    for (const readResult of readResults) {
-      results.push(
-        await this.addBufferedLayerSource(readResult, { title, total }),
       );
     }
 
@@ -1225,32 +1427,207 @@ export class GerberViewer {
         this.updateLoadingModal({
           stage: "Preparing",
           fileName: name,
-          current,
+          current: Math.max(0, current - 1),
           total,
-          progress: total > 0 ? (current - 1) / total : 0,
         });
       },
     });
   }
 
-  getAggregateReadProgress(readProgresses) {
-    if (readProgresses.length === 0) {
+  runLayerParsePipeline(
+    layerSources,
+    { title, total, concurrency, progress, parseWorkerPool, parseTasks },
+  ) {
+    const results = Array(total).fill(false);
+    const layerRecords = Array(total).fill(null);
+    let activeTasks = 0;
+    let scheduledTasks = 0;
+    let completedTasks = 0;
+    let activeMemoryBytes = 0;
+    let isResolved = false;
+
+    return new Promise((resolve) => {
+      const finishIfDone = () => {
+        if (isResolved || completedTasks < total) {
+          return;
+        }
+
+        isResolved = true;
+        let didCommitLayer = false;
+        for (const layerRecord of layerRecords) {
+          if (layerRecord) {
+            this.commitLayerMetadata(layerRecord, { updateUiState: false });
+            didCommitLayer = true;
+          }
+        }
+        if (didCommitLayer) {
+          this.updateUiState();
+        }
+        resolve(results);
+      };
+
+      const launchMore = () => {
+        while (activeTasks < concurrency && scheduledTasks < total) {
+          const task = this.pickNextLayerParseTask(parseTasks, {
+            activeTasks,
+            activeMemoryBytes,
+          });
+          if (!task) break;
+
+          task.scheduled = true;
+          scheduledTasks++;
+          const { index, source, estimatedMemoryBytes } = task;
+          activeTasks++;
+          activeMemoryBytes += estimatedMemoryBytes;
+
+          this.readAndParseLayerSource(source, {
+            index,
+            total,
+            title,
+            progress,
+            parseWorkerPool,
+          })
+            .then(async (parseResult) => {
+              const layerRecord = await this.addParsedLayerSource(parseResult, {
+                title,
+                total,
+                progress,
+              });
+              if (layerRecord) {
+                layerRecords[index] = layerRecord;
+                results[index] = true;
+              }
+            })
+            .catch((error) => {
+              const completed = this.markLayerLoadComplete(progress);
+              this.handleLayerLoadError(source.name, error);
+              this.updateLoadingModal({
+                title,
+                stage: "Skipped",
+                fileName: source.name,
+                current: completed,
+                total,
+              });
+            })
+            .finally(() => {
+              activeTasks--;
+              completedTasks++;
+              activeMemoryBytes = Math.max(
+                0,
+                activeMemoryBytes - estimatedMemoryBytes,
+              );
+              launchMore();
+              finishIfDone();
+            });
+        }
+
+        finishIfDone();
+      };
+
+      launchMore();
+    });
+  }
+
+  createLayerParseTasks(layerSources) {
+    return layerSources.map((source, index) => ({
+      source,
+      index,
+      estimatedMemoryBytes: estimateLayerParseMemoryBytes(source),
+      scheduled: false,
+    }));
+  }
+
+  pickNextLayerParseTask(
+    parseTasks,
+    { activeTasks, activeMemoryBytes },
+  ) {
+    const candidates = parseTasks.filter((task) => !task.scheduled);
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    const budgetBytes = getParseMemoryBudgetBytes();
+    const availableBytes = budgetBytes - activeMemoryBytes;
+    const fittingCandidates = candidates.filter(
+      (task) => task.estimatedMemoryBytes <= availableBytes,
+    );
+
+    if (fittingCandidates.length > 0) {
+      return fittingCandidates.sort(
+        (a, b) => b.estimatedMemoryBytes - a.estimatedMemoryBytes,
+      )[0];
+    }
+
+    if (activeTasks > 0) {
+      return null;
+    }
+
+    return candidates.sort(
+      (a, b) => a.estimatedMemoryBytes - b.estimatedMemoryBytes,
+    )[0];
+  }
+
+  createLayerLoadProgress(total) {
+    return {
+      total,
+      completedLayers: 0,
+    };
+  }
+
+  markLayerLoadComplete(progress) {
+    if (!progress) {
       return 0;
     }
 
-    const totalProgress = readProgresses.reduce(
-      (sum, progress) => sum + clampProgress(progress),
-      0,
+    progress.completedLayers = Math.min(
+      progress.total,
+      (progress.completedLayers ?? 0) + 1,
     );
-
-    return totalProgress / readProgresses.length;
+    return progress.completedLayers;
   }
 
-  getCompletedReadCount(readProgresses) {
-    return readProgresses.filter((progress) => progress >= 1).length;
+  createParseWorkerPool(layerCount) {
+    const workerCount = getParseWorkerCount(layerCount);
+    if (workerCount === 0) {
+      return null;
+    }
+
+    try {
+      return new GerberParseWorkerPool(workerCount);
+    } catch (error) {
+      console.warn("[Parse] Failed to create parse workers:", error);
+      this.addDiagnostic(
+        "warning",
+        "Parallel parsing unavailable",
+        getErrorMessage(error),
+      );
+      return null;
+    }
   }
 
-  async readLayerSource(source, { index, total, title, readProgresses }) {
+  async parseLayerContent(content, offset, parseWorkerPool) {
+    const normalizedOffset = normalizeLayerOffset(offset);
+
+    if (parseWorkerPool) {
+      return parseWorkerPool.parse(content, normalizedOffset);
+    }
+
+    if (typeof this.wasmModule?.parse_gerber_layer !== "function") {
+      throw new Error("Parallel parsing requires an updated WASM module");
+    }
+
+    this.reserveWasmInputCapacity(content);
+    return this.wasmModule.parse_gerber_layer(
+      content,
+      normalizedOffset.x,
+      normalizedOffset.y,
+    );
+  }
+
+  async readAndParseLayerSource(
+    source,
+    { index, total, title, progress, parseWorkerPool },
+  ) {
     const { name, readText } = source;
 
     try {
@@ -1258,47 +1635,59 @@ export class GerberViewer {
         title,
         stage: "Reading",
         fileName: name,
-        current: this.getCompletedReadCount(readProgresses),
+        current: progress.completedLayers,
         total,
-        progress: this.getAggregateReadProgress(readProgresses) * 0.5,
       });
 
-      const content = await readText((readProgress) => {
-        readProgresses[index] = clampProgress(readProgress);
+      const content = await readText(() => {
         this.updateLoadingModal({
           stage: "Reading",
           fileName: name,
-          current: this.getCompletedReadCount(readProgresses),
+          current: progress.completedLayers,
           total,
-          progress: this.getAggregateReadProgress(readProgresses) * 0.5,
         });
       });
 
-      readProgresses[index] = 1;
       this.updateLoadingModal({
         stage: "Reading",
         fileName: name,
-        current: this.getCompletedReadCount(readProgresses),
+        current: progress.completedLayers,
         total,
-        progress: this.getAggregateReadProgress(readProgresses) * 0.5,
+      });
+
+      this.updateLoadingModal({
+        stage: "Parsing",
+        fileName: name,
+        current: progress.completedLayers,
+        total,
+      });
+      const parsedLayer = await this.parseLayerContent(
+        content,
+        source.offset,
+        parseWorkerPool,
+      );
+      this.updateLoadingModal({
+        stage: "Parsing",
+        fileName: name,
+        current: progress.completedLayers,
+        total,
       });
 
       return {
         ok: true,
         index,
         name,
-        content,
+        parsedLayer,
+        sourceContent: content,
         offset: source.offset,
       };
     } catch (error) {
-      readProgresses[index] = 1;
       this.handleLayerLoadError(name, error);
       this.updateLoadingModal({
         stage: "Skipped",
         fileName: name,
-        current: this.getCompletedReadCount(readProgresses),
+        current: progress.completedLayers,
         total,
-        progress: this.getAggregateReadProgress(readProgresses) * 0.5,
       });
       return {
         ok: false,
@@ -1308,44 +1697,43 @@ export class GerberViewer {
     }
   }
 
-  async addBufferedLayerSource(
-    readResult,
-    { title = "Loading files", total = 1 } = {},
+  async loadLayerSourceSerially(
+    source,
+    { index = 0, total = 1, title = "Loading files" } = {},
   ) {
-    const index = readResult.index ?? 0;
-    const name = readResult.name;
-
-    if (!readResult.ok) {
-      this.updateLoadingModal({
-        title,
-        stage: "Skipped",
-        fileName: name,
-        current: index + 1,
-        total,
-        progress: 0.5 + this.getLayerLoadProgress(index, total, 1) * 0.5,
-      });
-      return false;
-    }
+    const { name, readText } = source;
 
     try {
       this.updateLoadingModal({
         title,
-        stage: "Parsing",
+        stage: "Reading",
         fileName: name,
-        current: index + 1,
+        current: index,
         total,
-        progress: 0.5 + this.getLayerLoadProgress(index, total, 0) * 0.5,
       });
 
-      await this.addLayer(name, readResult.content, {
-        offset: readResult.offset,
+      const content = await readText(() => {
+        this.updateLoadingModal({
+          stage: "Reading",
+          fileName: name,
+          current: index,
+          total,
+        });
       });
+
+      this.updateLoadingModal({
+        stage: "Parsing",
+        fileName: name,
+        current: index,
+        total,
+      });
+
+      await this.addLayer(name, content, { offset: source.offset });
       this.updateLoadingModal({
         stage: "Loaded",
         fileName: name,
         current: index + 1,
         total,
-        progress: 0.5 + this.getLayerLoadProgress(index, total, 1) * 0.5,
       });
       return true;
     } catch (error) {
@@ -1355,9 +1743,68 @@ export class GerberViewer {
         fileName: name,
         current: index + 1,
         total,
-        progress: 0.5 + this.getLayerLoadProgress(index, total, 1) * 0.5,
       });
       return false;
+    }
+  }
+
+  async addParsedLayerSource(
+    parseResult,
+    { title = "Loading files", total = 1, progress = null } = {},
+  ) {
+    const index = parseResult.index ?? 0;
+    const name = parseResult.name;
+
+    if (!parseResult.ok) {
+      const completed = this.markLayerLoadComplete(progress);
+      this.updateLoadingModal({
+        title,
+        stage: "Skipped",
+        fileName: name,
+        current: completed,
+        total,
+      });
+      return null;
+    }
+
+    try {
+      this.updateLoadingModal({
+        title,
+        stage: "Rendering",
+        fileName: name,
+        current: progress?.completedLayers ?? index,
+        total,
+      });
+
+      const layerRecord = await this.createParsedLayerRecord(
+        name,
+        parseResult.parsedLayer,
+        {
+          offset: parseResult.offset,
+          sourceContent: parseResult.sourceContent,
+        },
+      );
+      const completed = this.markLayerLoadComplete(progress);
+      this.updateLoadingModal({
+        stage: "Loaded",
+        fileName: name,
+        current: completed,
+        total,
+      });
+      return layerRecord;
+    } catch (error) {
+      const completed = this.markLayerLoadComplete(progress);
+      this.handleLayerLoadError(name, error);
+      this.updateLoadingModal({
+        stage: "Skipped",
+        fileName: name,
+        current: completed,
+        total,
+      });
+      return null;
+    } finally {
+      parseResult.parsedLayer = null;
+      parseResult.sourceContent = null;
     }
   }
 
@@ -1491,6 +1938,53 @@ export class GerberViewer {
     this.notifications.hide();
   }
 
+  createLayerMetadata(name, layerId, options = {}) {
+    if (layerId === undefined || layerId === null) {
+      throw new Error("Failed to get layer ID from WASM processor");
+    }
+
+    const bounds = this.wasmProcessor.get_layer_boundary(layerId);
+    return {
+      id: options.id ?? null,
+      layerId: layerId,
+      name: name,
+      visible: options.visible ?? true,
+      color: options.color ? [...options.color] : null,
+      sourceContent: options.sourceContent,
+      offset: normalizeLayerOffset(options.offset),
+      bounds: {
+        minX: bounds.min_x,
+        maxX: bounds.max_x,
+        minY: bounds.min_y,
+        maxY: bounds.max_y,
+      },
+    };
+  }
+
+  commitLayerMetadata(layer, { updateUiState = true } = {}) {
+    if (!layer.id) {
+      layer.id = `layer-${this.nextLayerDomId++}`;
+    }
+    if (layer.color) {
+      layer.color = [...layer.color];
+    } else {
+      layer.color = [
+        ...this.colorPalette[this.nextColorIndex % this.colorPalette.length],
+      ];
+      this.nextColorIndex++;
+    }
+    this.layers.push(layer);
+    if (updateUiState) {
+      this.updateUiState();
+    }
+    return layer;
+  }
+
+  addLayerMetadata(name, layerId, options = {}) {
+    const layer = this.createLayerMetadata(name, layerId, options);
+    return this.commitLayerMetadata(layer);
+  }
+
   async addLayer(name, content, options = {}) {
     try {
       if (!this.wasmProcessor || this.isWebGlContextLost) {
@@ -1509,38 +2003,11 @@ export class GerberViewer {
       const layerId = hasLayerOffset(offset)
         ? this.wasmProcessor.add_layer_with_offset(content, offset.x, offset.y)
         : this.wasmProcessor.add_layer(content);
-      if (layerId === undefined || layerId === null) {
-        throw new Error("Failed to get layer ID from WASM processor");
-      }
-
-      // Get this layer's boundary from WASM
-      const bounds = this.wasmProcessor.get_layer_boundary(layerId);
-
-      const color = options.color
-        ? [...options.color]
-        : this.colorPalette[this.nextColorIndex % this.colorPalette.length];
-      if (!options.color) {
-        this.nextColorIndex++;
-      }
-
-      const layer = {
-        id: options.id ?? `layer-${this.nextLayerDomId++}`,
-        layerId: layerId, // WASM layer_id
-        name: name,
-        visible: options.visible ?? true,
-        color: color,
+      this.addLayerMetadata(name, layerId, {
+        ...options,
         sourceContent: options.sourceContent ?? content,
         offset,
-        bounds: {
-          minX: bounds.min_x,
-          maxX: bounds.max_x,
-          minY: bounds.min_y,
-          maxY: bounds.max_y,
-        },
-      };
-
-      this.layers.push(layer);
-      this.updateUiState();
+      });
     } catch (error) {
       if (isNoGeometryError(getErrorMessage(error))) {
         console.warn(`[Layer] Skipped layer ${name}:`, error);
@@ -1552,6 +2019,38 @@ export class GerberViewer {
       }
 
       console.error(`[Layer] Failed to add layer ${name}:`, error);
+      throw error;
+    }
+  }
+
+  async addParsedLayer(name, parsedLayer, options = {}) {
+    const layer = await this.createParsedLayerRecord(name, parsedLayer, options);
+    return this.commitLayerMetadata(layer);
+  }
+
+  async createParsedLayerRecord(name, parsedLayer, options = {}) {
+    try {
+      if (!this.wasmProcessor || this.isWebGlContextLost) {
+        throw new Error("WebGL renderer is not available");
+      }
+
+      if (typeof this.wasmProcessor.add_parsed_layer !== "function") {
+        throw new Error("Parsed layer rendering requires an updated WASM module");
+      }
+
+      const layerId = this.wasmProcessor.add_parsed_layer(parsedLayer);
+      return this.createLayerMetadata(name, layerId, options);
+    } catch (error) {
+      if (isNoGeometryError(getErrorMessage(error))) {
+        console.warn(`[Layer] Skipped layer ${name}:`, error);
+        throw error;
+      }
+
+      if (isFatalWasmRuntimeError(error) && !options.skipFatalRecovery) {
+        await this.recoverWasmProcessorAfterFatalError(name, error);
+      }
+
+      console.error(`[Layer] Failed to add parsed layer ${name}:`, error);
       throw error;
     }
   }

--- a/js/main.js
+++ b/js/main.js
@@ -349,6 +349,7 @@ export class GerberViewer {
     this.isWebGlContextLost = false;
     this.isRestoringWebGlContext = false;
     this.isRecoveringWasmProcessor = false;
+    this.wasmRecoveryPromise = null;
     this.isInitialUrlLoading = Boolean(getInitialSourceUrl());
     this.isLoadingLayers = false;
     this.loadingWorkspaceStatus = "Loading files";
@@ -1986,8 +1987,18 @@ export class GerberViewer {
     }
   }
 
+  async waitForWasmProcessorRecovery() {
+    if (this.isRecoveringWasmProcessor && this.wasmRecoveryPromise) {
+      await this.wasmRecoveryPromise;
+    }
+  }
+
   async recoverWasmProcessorAfterFatalError(failedLayerName, error) {
-    if (this.isRecoveringWasmProcessor || this.isWebGlContextLost) {
+    if (this.isRecoveringWasmProcessor) {
+      await this.waitForWasmProcessorRecovery();
+      return;
+    }
+    if (this.isWebGlContextLost) {
       return;
     }
 
@@ -2003,7 +2014,11 @@ export class GerberViewer {
     const viewState = this.captureCanvasViewState();
     const nextLayerDomId = this.nextLayerDomId;
     const nextColorIndex = this.nextColorIndex;
+    let finishRecovery = null;
 
+    this.wasmRecoveryPromise = new Promise((resolve) => {
+      finishRecovery = resolve;
+    });
     this.isRecoveringWasmProcessor = true;
     this.addDiagnostic(
       "warning",
@@ -2045,6 +2060,8 @@ export class GerberViewer {
     } finally {
       this.clearRecoveredPendingLayerRecords(recoveredPendingLayerIds);
       this.isRecoveringWasmProcessor = false;
+      finishRecovery?.();
+      this.wasmRecoveryPromise = null;
       this.updateUiState();
     }
   }
@@ -2119,6 +2136,9 @@ export class GerberViewer {
 
   async addLayer(name, content, options = {}) {
     try {
+      if (!options.skipFatalRecovery) {
+        await this.waitForWasmProcessorRecovery();
+      }
       if (!this.wasmProcessor || this.isWebGlContextLost) {
         throw new Error("WebGL renderer is not available");
       }
@@ -2162,6 +2182,9 @@ export class GerberViewer {
 
   async createParsedLayerRecord(name, parsedLayer, options = {}) {
     try {
+      if (!options.skipFatalRecovery) {
+        await this.waitForWasmProcessorRecovery();
+      }
       if (!this.wasmProcessor || this.isWebGlContextLost) {
         throw new Error("WebGL renderer is not available");
       }

--- a/js/main.js
+++ b/js/main.js
@@ -44,8 +44,10 @@ const MIN_PARSE_TASK_MEMORY_BYTES = 32 * BYTES_PER_MIB;
 const DEFAULT_PARSE_MEMORY_BUDGET_BYTES = 512 * BYTES_PER_MIB;
 const MIN_PARSE_MEMORY_BUDGET_BYTES = 128 * BYTES_PER_MIB;
 const MAX_PARSE_MEMORY_BUDGET_BYTES = 1536 * BYTES_PER_MIB;
-const PARSE_MEMORY_ESTIMATE_MULTIPLIER = 8;
+const PARSE_MEMORY_ESTIMATE_MULTIPLIER = 16;
 const PARSE_MEMORY_HEADROOM_RATIO = 0.5;
+const RECYCLE_PARSE_WORKER_MEMORY_BYTES = 256 * BYTES_PER_MIB;
+const RECYCLE_PARSE_WORKER_GROWTH_BYTES = 128 * BYTES_PER_MIB;
 
 function getUtf8ByteLength(value) {
   let bytes = 0;
@@ -163,23 +165,33 @@ class GerberParseWorkerPool {
     this.activeTasks = new Map();
     this.nextTaskId = 0;
     this.isDisposed = false;
+    this.workerUrl = new URL("./gerber-parse-worker.js", import.meta.url);
 
-    const workerUrl = new URL("./gerber-parse-worker.js", import.meta.url);
     for (let index = 0; index < workerCount; index++) {
-      const worker = new Worker(workerUrl, { type: "module" });
-      worker.addEventListener("message", (event) =>
-        this.handleWorkerMessage(worker, event),
-      );
-      worker.addEventListener("error", (event) =>
-        this.handleWorkerError(worker, event),
-      );
-      this.workers.push(worker);
-      this.idleWorkers.push(worker);
+      this.addIdleWorker();
     }
   }
 
   get size() {
     return this.workers.length;
+  }
+
+  createWorker() {
+    const worker = new Worker(this.workerUrl, { type: "module" });
+    worker.addEventListener("message", (event) =>
+      this.handleWorkerMessage(worker, event),
+    );
+    worker.addEventListener("error", (event) =>
+      this.handleWorkerError(worker, event),
+    );
+    return worker;
+  }
+
+  addIdleWorker() {
+    const worker = this.createWorker();
+    this.workers.push(worker);
+    this.idleWorkers.push(worker);
+    return worker;
   }
 
   parse(content, offset) {
@@ -217,17 +229,48 @@ class GerberParseWorkerPool {
     }
 
     this.activeTasks.delete(worker);
-    if (!this.isDisposed) {
-      this.idleWorkers.push(worker);
-    }
+    const shouldRecycle = this.shouldRecycleWorker(event.data?.workerMemory);
 
     if (event.data.ok) {
       task.resolve(event.data.parsedLayer);
     } else {
-      task.reject(new Error(event.data.error || "Failed to parse Gerber layer"));
+      const error = new Error(event.data.error || "Failed to parse Gerber layer");
+      task.reject(error);
+    }
+
+    if (!this.isDisposed) {
+      if (shouldRecycle) {
+        this.recycleWorker(worker);
+      } else {
+        this.idleWorkers.push(worker);
+      }
     }
 
     this.pump();
+  }
+
+  shouldRecycleWorker(memory) {
+    const beforeBytes = Number(memory?.beforeBytes);
+    const afterBytes = Number(memory?.afterBytes);
+    if (!Number.isFinite(afterBytes)) {
+      return false;
+    }
+
+    const growthBytes = Number.isFinite(beforeBytes)
+      ? Math.max(0, afterBytes - beforeBytes)
+      : 0;
+    return (
+      afterBytes >= RECYCLE_PARSE_WORKER_MEMORY_BYTES ||
+      growthBytes >= RECYCLE_PARSE_WORKER_GROWTH_BYTES
+    );
+  }
+
+  recycleWorker(worker) {
+    worker.terminate();
+    this.workers = this.workers.filter((item) => item !== worker);
+    if (!this.isDisposed) {
+      this.addIdleWorker();
+    }
   }
 
   handleWorkerError(worker, event) {
@@ -1369,7 +1412,6 @@ export class GerberViewer {
     const concurrency = parseWorkerPool.size;
     const progress = this.createLayerLoadProgress(total);
     const parseTasks = this.createLayerParseTasks(layerSources);
-
     this.showLoadingModal({
       title,
       stage: "Reading",
@@ -1436,7 +1478,14 @@ export class GerberViewer {
 
   runLayerParsePipeline(
     layerSources,
-    { title, total, concurrency, progress, parseWorkerPool, parseTasks },
+    {
+      title,
+      total,
+      concurrency,
+      progress,
+      parseWorkerPool,
+      parseTasks,
+    },
   ) {
     const results = Array(total).fill(false);
     const layerRecords = Array(total).fill(null);
@@ -1626,7 +1675,13 @@ export class GerberViewer {
 
   async readAndParseLayerSource(
     source,
-    { index, total, title, progress, parseWorkerPool },
+    {
+      index,
+      total,
+      title,
+      progress,
+      parseWorkerPool,
+    },
   ) {
     const { name, readText } = source;
 
@@ -1647,7 +1702,6 @@ export class GerberViewer {
           total,
         });
       });
-
       this.updateLoadingModal({
         stage: "Reading",
         fileName: name,
@@ -1750,7 +1804,11 @@ export class GerberViewer {
 
   async addParsedLayerSource(
     parseResult,
-    { title = "Loading files", total = 1, progress = null } = {},
+    {
+      title = "Loading files",
+      total = 1,
+      progress = null,
+    } = {},
   ) {
     const index = parseResult.index ?? 0;
     const name = parseResult.name;
@@ -2034,11 +2092,14 @@ export class GerberViewer {
         throw new Error("WebGL renderer is not available");
       }
 
-      if (typeof this.wasmProcessor.add_parsed_layer !== "function") {
+      let layerId;
+      if (typeof this.wasmProcessor.add_render_payload === "function") {
+        layerId = this.wasmProcessor.add_render_payload(parsedLayer);
+      } else if (typeof this.wasmProcessor.add_parsed_layer === "function") {
+        layerId = this.wasmProcessor.add_parsed_layer(parsedLayer);
+      } else {
         throw new Error("Parsed layer rendering requires an updated WASM module");
       }
-
-      const layerId = this.wasmProcessor.add_parsed_layer(parsedLayer);
       return this.createLayerMetadata(name, layerId, options);
     } catch (error) {
       if (isNoGeometryError(getErrorMessage(error))) {

--- a/js/main.js
+++ b/js/main.js
@@ -60,6 +60,17 @@ function isParseWorkerUnavailableError(error) {
   return error instanceof ParseWorkerUnavailableError;
 }
 
+function isParseWorkerCapabilityErrorMessage(message) {
+  const normalizedMessage = String(message ?? "").toLowerCase();
+  return (
+    normalizedMessage.includes("parse_gerber_layer") ||
+    normalizedMessage.includes("parse worker api") ||
+    normalizedMessage.includes("parse worker requires an updated wasm module") ||
+    normalizedMessage.includes("failed to fetch dynamically imported module") ||
+    normalizedMessage.includes("wasm_gerber_processor")
+  );
+}
+
 function getUtf8ByteLength(value) {
   let bytes = 0;
 
@@ -179,8 +190,17 @@ class GerberParseWorkerPool {
     this.unavailableError = null;
     this.workerUrl = new URL("./gerber-parse-worker.js", import.meta.url);
 
-    for (let index = 0; index < workerCount; index++) {
-      this.addIdleWorker();
+    try {
+      for (let index = 0; index < workerCount; index++) {
+        this.addIdleWorker();
+      }
+    } catch (error) {
+      for (const worker of this.workers) {
+        worker.terminate();
+      }
+      this.workers = [];
+      this.idleWorkers = [];
+      throw error;
     }
   }
 
@@ -204,6 +224,30 @@ class GerberParseWorkerPool {
     this.workers.push(worker);
     this.idleWorkers.push(worker);
     return worker;
+  }
+
+  rejectRemainingTasksAsUnavailable(error) {
+    const unavailableError =
+      error instanceof ParseWorkerUnavailableError
+        ? error
+        : new ParseWorkerUnavailableError(getErrorMessage(error));
+    this.unavailableError = unavailableError;
+
+    for (const queuedTask of this.queue) {
+      queuedTask.reject(unavailableError);
+    }
+    this.queue = [];
+
+    for (const activeTask of this.activeTasks.values()) {
+      activeTask.reject(unavailableError);
+    }
+    this.activeTasks.clear();
+
+    for (const worker of this.workers) {
+      worker.terminate();
+    }
+    this.workers = [];
+    this.idleWorkers = [];
   }
 
   parse(content, offset) {
@@ -249,8 +293,18 @@ class GerberParseWorkerPool {
     if (event.data.ok) {
       task.resolve(event.data.parsedLayer);
     } else {
-      const error = new Error(event.data.error || "Failed to parse Gerber layer");
-      task.reject(error);
+      const errorMessage = event.data.error || "Failed to parse Gerber layer";
+      if (
+        event.data.workerUnavailable ||
+        isParseWorkerCapabilityErrorMessage(errorMessage)
+      ) {
+        const error = new ParseWorkerUnavailableError(errorMessage);
+        task.reject(error);
+        this.rejectRemainingTasksAsUnavailable(error);
+        return;
+      }
+
+      task.reject(new Error(errorMessage));
     }
 
     if (!this.isDisposed) {
@@ -2053,6 +2107,7 @@ export class GerberViewer {
   }
 
   collectPendingLayerRecoveryIds() {
+    this.preparePendingLayerRecordsForRecovery();
     return new Set(
       (this.pendingLayerRecordsForRecovery ?? [])
         .filter((layer) => layer && typeof layer.sourceContent === "string")

--- a/js/main.js
+++ b/js/main.js
@@ -273,11 +273,21 @@ class GerberParseWorkerPool {
       const worker = this.idleWorkers.pop();
       const task = this.queue.shift();
       this.activeTasks.set(worker, task);
-      worker.postMessage({
-        id: task.id,
-        content: task.content,
-        offset: task.offset,
-      });
+      try {
+        worker.postMessage({
+          id: task.id,
+          content: task.content,
+          offset: task.offset,
+        });
+      } catch (error) {
+        this.activeTasks.delete(worker);
+        const unavailableError = new ParseWorkerUnavailableError(
+          `Failed to send parse task to worker: ${getErrorMessage(error)}`,
+        );
+        task.reject(unavailableError);
+        this.rejectRemainingTasksAsUnavailable(unavailableError);
+        return;
+      }
     }
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -49,6 +49,17 @@ const PARSE_MEMORY_HEADROOM_RATIO = 0.5;
 const RECYCLE_PARSE_WORKER_MEMORY_BYTES = 256 * BYTES_PER_MIB;
 const RECYCLE_PARSE_WORKER_GROWTH_BYTES = 128 * BYTES_PER_MIB;
 
+class ParseWorkerUnavailableError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ParseWorkerUnavailableError";
+  }
+}
+
+function isParseWorkerUnavailableError(error) {
+  return error instanceof ParseWorkerUnavailableError;
+}
+
 function getUtf8ByteLength(value) {
   let bytes = 0;
 
@@ -165,6 +176,7 @@ class GerberParseWorkerPool {
     this.activeTasks = new Map();
     this.nextTaskId = 0;
     this.isDisposed = false;
+    this.unavailableError = null;
     this.workerUrl = new URL("./gerber-parse-worker.js", import.meta.url);
 
     for (let index = 0; index < workerCount; index++) {
@@ -199,7 +211,10 @@ class GerberParseWorkerPool {
       return Promise.reject(new Error("Parse worker pool has been disposed"));
     }
     if (this.workers.length === 0) {
-      return Promise.reject(new Error("No parse workers are available"));
+      return Promise.reject(
+        this.unavailableError ??
+          new ParseWorkerUnavailableError("No parse workers are available"),
+      );
     }
 
     const id = this.nextTaskId++;
@@ -277,11 +292,11 @@ class GerberParseWorkerPool {
       this.addIdleWorker();
     } catch (error) {
       if (this.workers.length === 0) {
-        const message = getErrorMessage(error);
+        this.unavailableError = new ParseWorkerUnavailableError(
+          `Failed to recreate parse worker: ${getErrorMessage(error)}`,
+        );
         for (const queuedTask of this.queue) {
-          queuedTask.reject(
-            new Error(`Failed to recreate parse worker: ${message}`),
-          );
+          queuedTask.reject(this.unavailableError);
         }
         this.queue = [];
       }
@@ -294,13 +309,23 @@ class GerberParseWorkerPool {
     worker.terminate();
     this.workers = this.workers.filter((item) => item !== worker);
     this.idleWorkers = this.idleWorkers.filter((item) => item !== worker);
+    const isUnavailable = this.workers.length === 0;
+    if (isUnavailable) {
+      this.unavailableError = new ParseWorkerUnavailableError(
+        event.message || "No parse workers are available",
+      );
+    }
 
     if (task) {
-      task.reject(new Error(event.message || "Gerber parse worker failed"));
+      task.reject(
+        isUnavailable
+          ? this.unavailableError
+          : new Error(event.message || "Gerber parse worker failed"),
+      );
     }
-    if (this.workers.length === 0) {
+    if (isUnavailable) {
       for (const queuedTask of this.queue) {
-        queuedTask.reject(new Error("No parse workers are available"));
+        queuedTask.reject(this.unavailableError);
       }
       this.queue = [];
     }
@@ -1445,6 +1470,18 @@ export class GerberViewer {
         parseWorkerPool,
         parseTasks,
       });
+    } catch (error) {
+      if (!isParseWorkerUnavailableError(error)) {
+        throw error;
+      }
+
+      parseWorkerPool.dispose();
+      this.addDiagnostic(
+        "warning",
+        "Parallel parsing unavailable",
+        `${getErrorMessage(error)} Falling back to serial parsing.`,
+      );
+      return this.loadLayerSourcesSerially(layerSources, { title, total });
     } finally {
       parseWorkerPool?.dispose();
     }
@@ -1514,7 +1551,51 @@ export class GerberViewer {
     let activeMemoryBytes = 0;
     let isResolved = false;
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      const restorePendingLayerRecords = () => {
+        if (this.pendingLayerRecordsForRecovery === layerRecords) {
+          this.pendingLayerRecordsForRecovery = previousPendingLayerRecords;
+        }
+      };
+
+      const discardLayerRecord = (layerRecord) => {
+        if (
+          !layerRecord ||
+          layerRecord.layerId === undefined ||
+          layerRecord.layerId === null ||
+          typeof this.wasmProcessor?.remove_layer !== "function"
+        ) {
+          return;
+        }
+
+        try {
+          this.wasmProcessor.remove_layer(layerRecord.layerId);
+        } catch (error) {
+          console.warn(
+            `[Layer] Failed to discard pending layer ${layerRecord.name}:`,
+            error,
+          );
+        }
+      };
+
+      const discardPendingLayerRecords = () => {
+        for (let index = 0; index < layerRecords.length; index++) {
+          discardLayerRecord(layerRecords[index]);
+          layerRecords[index] = null;
+        }
+      };
+
+      const abortWithWorkerFallback = (error) => {
+        if (isResolved) {
+          return;
+        }
+
+        isResolved = true;
+        discardPendingLayerRecords();
+        restorePendingLayerRecords();
+        reject(error);
+      };
+
       const finishIfDone = () => {
         if (isResolved || completedTasks < total) {
           return;
@@ -1525,14 +1606,13 @@ export class GerberViewer {
         for (let index = 0; index < layerRecords.length; index++) {
           const layerRecord = layerRecords[index];
           if (layerRecord) {
+            this.prepareLayerMetadata(layerRecord);
             this.commitLayerMetadata(layerRecord, { updateUiState: false });
             layerRecords[index] = null;
             didCommitLayer = true;
           }
         }
-        if (this.pendingLayerRecordsForRecovery === layerRecords) {
-          this.pendingLayerRecordsForRecovery = previousPendingLayerRecords;
-        }
+        restorePendingLayerRecords();
         if (didCommitLayer) {
           this.updateUiState();
         }
@@ -1566,13 +1646,23 @@ export class GerberViewer {
                 total,
                 progress,
               });
+              if (isResolved) {
+                discardLayerRecord(layerRecord);
+                return;
+              }
               if (layerRecord) {
-                this.prepareLayerMetadata(layerRecord);
                 layerRecords[index] = layerRecord;
                 results[index] = true;
               }
             })
             .catch((error) => {
+              if (isParseWorkerUnavailableError(error)) {
+                abortWithWorkerFallback(error);
+                return;
+              }
+              if (isResolved) {
+                return;
+              }
               const completed = this.markLayerLoadComplete(progress);
               this.handleLayerLoadError(source.name, error);
               this.updateLoadingModal({
@@ -1590,6 +1680,9 @@ export class GerberViewer {
                 0,
                 activeMemoryBytes - estimatedMemoryBytes,
               );
+              if (isResolved) {
+                return;
+              }
               launchMore();
               finishIfDone();
             });
@@ -1761,6 +1854,9 @@ export class GerberViewer {
         offset: source.offset,
       };
     } catch (error) {
+      if (isParseWorkerUnavailableError(error)) {
+        throw error;
+      }
       this.handleLayerLoadError(name, error);
       this.updateLoadingModal({
         stage: "Skipped",
@@ -1930,7 +2026,16 @@ export class GerberViewer {
     };
   }
 
+  preparePendingLayerRecordsForRecovery() {
+    for (const layer of this.pendingLayerRecordsForRecovery ?? []) {
+      if (layer && typeof layer.sourceContent === "string") {
+        this.prepareLayerMetadata(layer);
+      }
+    }
+  }
+
   snapshotLayersForRecovery() {
+    this.preparePendingLayerRecordsForRecovery();
     const committedSnapshots = this.layers.map((layer) =>
       this.createLayerRecoverySnapshot(layer),
     );
@@ -2176,6 +2281,12 @@ export class GerberViewer {
   }
 
   async addParsedLayer(name, parsedLayer, options = {}) {
+    if (typeof options.sourceContent !== "string") {
+      throw new Error(
+        "addParsedLayer requires options.sourceContent for renderer recovery",
+      );
+    }
+
     const layer = await this.createParsedLayerRecord(name, parsedLayer, options);
     return this.commitLayerMetadata(layer);
   }

--- a/js/main.js
+++ b/js/main.js
@@ -268,8 +268,23 @@ class GerberParseWorkerPool {
   recycleWorker(worker) {
     worker.terminate();
     this.workers = this.workers.filter((item) => item !== worker);
-    if (!this.isDisposed) {
+
+    if (this.isDisposed) {
+      return;
+    }
+
+    try {
       this.addIdleWorker();
+    } catch (error) {
+      if (this.workers.length === 0) {
+        const message = getErrorMessage(error);
+        for (const queuedTask of this.queue) {
+          queuedTask.reject(
+            new Error(`Failed to recreate parse worker: ${message}`),
+          );
+        }
+        this.queue = [];
+      }
     }
   }
 
@@ -343,6 +358,7 @@ export class GerberViewer {
     this.nextLayerDomId = 0;
     this.draggedLayerId = null;
     this.layerDropIndex = null;
+    this.pendingLayerRecordsForRecovery = null;
 
     // Camera
     this.camera = {
@@ -1489,6 +1505,8 @@ export class GerberViewer {
   ) {
     const results = Array(total).fill(false);
     const layerRecords = Array(total).fill(null);
+    const previousPendingLayerRecords = this.pendingLayerRecordsForRecovery;
+    this.pendingLayerRecordsForRecovery = layerRecords;
     let activeTasks = 0;
     let scheduledTasks = 0;
     let completedTasks = 0;
@@ -1503,11 +1521,16 @@ export class GerberViewer {
 
         isResolved = true;
         let didCommitLayer = false;
-        for (const layerRecord of layerRecords) {
+        for (let index = 0; index < layerRecords.length; index++) {
+          const layerRecord = layerRecords[index];
           if (layerRecord) {
             this.commitLayerMetadata(layerRecord, { updateUiState: false });
+            layerRecords[index] = null;
             didCommitLayer = true;
           }
+        }
+        if (this.pendingLayerRecordsForRecovery === layerRecords) {
+          this.pendingLayerRecordsForRecovery = previousPendingLayerRecords;
         }
         if (didCommitLayer) {
           this.updateUiState();
@@ -1543,6 +1566,7 @@ export class GerberViewer {
                 progress,
               });
               if (layerRecord) {
+                this.prepareLayerMetadata(layerRecord);
                 layerRecords[index] = layerRecord;
                 results[index] = true;
               }
@@ -1894,15 +1918,57 @@ export class GerberViewer {
     }
   }
 
-  snapshotLayersForRecovery() {
-    return this.layers.map((layer) => ({
+  createLayerRecoverySnapshot(layer) {
+    return {
       id: layer.id,
       name: layer.name,
       visible: layer.visible,
-      color: [...layer.color],
+      color: layer.color ? [...layer.color] : null,
       sourceContent: layer.sourceContent,
       offset: { ...normalizeLayerOffset(layer.offset) },
-    }));
+    };
+  }
+
+  snapshotLayersForRecovery() {
+    const committedSnapshots = this.layers.map((layer) =>
+      this.createLayerRecoverySnapshot(layer),
+    );
+    const committedIds = new Set(this.layers.map((layer) => layer.id));
+    const pendingSnapshots = (this.pendingLayerRecordsForRecovery ?? [])
+      .filter(
+        (layer) =>
+          layer &&
+          !committedIds.has(layer.id) &&
+          typeof layer.sourceContent === "string",
+      )
+      .map((layer) => this.createLayerRecoverySnapshot(layer));
+
+    return [...committedSnapshots, ...pendingSnapshots];
+  }
+
+  collectPendingLayerRecoveryIds() {
+    return new Set(
+      (this.pendingLayerRecordsForRecovery ?? [])
+        .filter((layer) => layer && typeof layer.sourceContent === "string")
+        .map((layer) => layer.id),
+    );
+  }
+
+  clearRecoveredPendingLayerRecords(recoveredLayerIds) {
+    if (!this.pendingLayerRecordsForRecovery || recoveredLayerIds.size === 0) {
+      return;
+    }
+
+    for (
+      let index = 0;
+      index < this.pendingLayerRecordsForRecovery.length;
+      index++
+    ) {
+      const layer = this.pendingLayerRecordsForRecovery[index];
+      if (layer && recoveredLayerIds.has(layer.id)) {
+        this.pendingLayerRecordsForRecovery[index] = null;
+      }
+    }
   }
 
   disposeWasmProcessor() {
@@ -1925,10 +1991,12 @@ export class GerberViewer {
       return;
     }
 
+    const recoveredPendingLayerIds = this.collectPendingLayerRecoveryIds();
     const layerSnapshot = this.snapshotLayersForRecovery();
     if (layerSnapshot.length === 0) {
       this.disposeWasmProcessor();
       this.createWebGlProcessor();
+      this.clearRecoveredPendingLayerRecords(recoveredPendingLayerIds);
       return;
     }
 
@@ -1975,6 +2043,7 @@ export class GerberViewer {
       this.renderLayerList();
       this.render();
     } finally {
+      this.clearRecoveredPendingLayerRecords(recoveredPendingLayerIds);
       this.isRecoveringWasmProcessor = false;
       this.updateUiState();
     }
@@ -2020,6 +2089,15 @@ export class GerberViewer {
   }
 
   commitLayerMetadata(layer, { updateUiState = true } = {}) {
+    this.prepareLayerMetadata(layer);
+    this.layers.push(layer);
+    if (updateUiState) {
+      this.updateUiState();
+    }
+    return layer;
+  }
+
+  prepareLayerMetadata(layer) {
     if (!layer.id) {
       layer.id = `layer-${this.nextLayerDomId++}`;
     }
@@ -2030,10 +2108,6 @@ export class GerberViewer {
         ...this.colorPalette[this.nextColorIndex % this.colorPalette.length],
       ];
       this.nextColorIndex++;
-    }
-    this.layers.push(layer);
-    if (updateUiState) {
-      this.updateUiState();
     }
     return layer;
   }

--- a/js/main.js
+++ b/js/main.js
@@ -142,12 +142,12 @@ export class GerberViewer {
 
     // Colors
     this.colorPalette = [
-      [1.0, 0.0, 0.0], // Red
       [0.0, 1.0, 0.0], // Green
       [0.0, 0.0, 1.0], // Blue
       [1.0, 1.0, 0.0], // Yellow
       [1.0, 0.0, 1.0], // Magenta
       [0.0, 1.0, 1.0], // Cyan
+      [1.0, 0.0, 0.0], // Red
     ];
     this.nextColorIndex = 0;
 
@@ -1094,7 +1094,7 @@ export class GerberViewer {
         return;
       }
 
-      const results = await this.loadLayerSourcesSequentially(layerSources, {
+      const results = await this.loadLayerSources(layerSources, {
         title: "Loading remote file",
       });
       const loadedCount = results.filter(Boolean).length;
@@ -1152,7 +1152,7 @@ export class GerberViewer {
         const layerSources = await this.collectLayerSources(validFiles);
 
         if (layerSources.length > 0) {
-          const results = await this.loadLayerSourcesSequentially(layerSources, {
+          const results = await this.loadLayerSources(layerSources, {
             title: "Loading files",
           });
           const loadedCount = results.filter(Boolean).length;
@@ -1175,26 +1175,33 @@ export class GerberViewer {
     this.fileInput.value = "";
   }
 
-  async loadLayerSourcesSequentially(layerSources, { title = "Loading files" } = {}) {
-    const results = [];
+  async loadLayerSources(layerSources, { title = "Loading files" } = {}) {
     const total = layerSources.length;
+    const readProgresses = Array(total).fill(0);
 
     this.showLoadingModal({
       title,
-      stage: "Processing",
+      stage: "Reading",
       current: 0,
       total,
       progress: 0,
     });
 
-    for (const [index, source] of layerSources.entries()) {
-      results.push(
-        await this.loadLayerSource(source.name, source.readText, {
+    const readResults = await Promise.all(
+      layerSources.map((source, index) =>
+        this.readLayerSource(source, {
           index,
           total,
           title,
-          offset: source.offset,
+          readProgresses,
         }),
+      ),
+    );
+
+    const results = [];
+    for (const readResult of readResults) {
+      results.push(
+        await this.addBufferedLayerSource(readResult, { title, total }),
       );
     }
 
@@ -1226,46 +1233,119 @@ export class GerberViewer {
     });
   }
 
-  async loadLayerSource(
-    name,
-    readText,
-    { index = 0, total = 1, title = "Loading files", offset } = {},
-  ) {
+  getAggregateReadProgress(readProgresses) {
+    if (readProgresses.length === 0) {
+      return 0;
+    }
+
+    const totalProgress = readProgresses.reduce(
+      (sum, progress) => sum + clampProgress(progress),
+      0,
+    );
+
+    return totalProgress / readProgresses.length;
+  }
+
+  getCompletedReadCount(readProgresses) {
+    return readProgresses.filter((progress) => progress >= 1).length;
+  }
+
+  async readLayerSource(source, { index, total, title, readProgresses }) {
+    const { name, readText } = source;
+
     try {
       this.updateLoadingModal({
         title,
         stage: "Reading",
         fileName: name,
-        current: index + 1,
+        current: this.getCompletedReadCount(readProgresses),
         total,
-        progress: this.getLayerLoadProgress(index, total, 0),
+        progress: this.getAggregateReadProgress(readProgresses) * 0.5,
       });
 
       const content = await readText((readProgress) => {
+        readProgresses[index] = clampProgress(readProgress);
         this.updateLoadingModal({
           stage: "Reading",
           fileName: name,
-          current: index + 1,
+          current: this.getCompletedReadCount(readProgresses),
           total,
-          progress: this.getLayerLoadProgress(index, total, readProgress * 0.45),
+          progress: this.getAggregateReadProgress(readProgresses) * 0.5,
         });
       });
 
+      readProgresses[index] = 1;
       this.updateLoadingModal({
+        stage: "Reading",
+        fileName: name,
+        current: this.getCompletedReadCount(readProgresses),
+        total,
+        progress: this.getAggregateReadProgress(readProgresses) * 0.5,
+      });
+
+      return {
+        ok: true,
+        index,
+        name,
+        content,
+        offset: source.offset,
+      };
+    } catch (error) {
+      readProgresses[index] = 1;
+      this.handleLayerLoadError(name, error);
+      this.updateLoadingModal({
+        stage: "Skipped",
+        fileName: name,
+        current: this.getCompletedReadCount(readProgresses),
+        total,
+        progress: this.getAggregateReadProgress(readProgresses) * 0.5,
+      });
+      return {
+        ok: false,
+        index,
+        name,
+      };
+    }
+  }
+
+  async addBufferedLayerSource(
+    readResult,
+    { title = "Loading files", total = 1 } = {},
+  ) {
+    const index = readResult.index ?? 0;
+    const name = readResult.name;
+
+    if (!readResult.ok) {
+      this.updateLoadingModal({
+        title,
+        stage: "Skipped",
+        fileName: name,
+        current: index + 1,
+        total,
+        progress: 0.5 + this.getLayerLoadProgress(index, total, 1) * 0.5,
+      });
+      return false;
+    }
+
+    try {
+      this.updateLoadingModal({
+        title,
         stage: "Parsing",
         fileName: name,
         current: index + 1,
         total,
-        progress: this.getLayerLoadProgress(index, total, 0.55),
+        progress: 0.5 + this.getLayerLoadProgress(index, total, 0) * 0.5,
       });
 
-      await this.addLayer(name, content, { offset });
+      await this.addLayer(name, readResult.content, {
+        offset: readResult.offset,
+      });
       this.updateLoadingModal({
         stage: "Loaded",
         fileName: name,
         current: index + 1,
         total,
-        progress: this.getLayerLoadProgress(index, total, 1),
+        progress: 0.5 + this.getLayerLoadProgress(index, total, 1) * 0.5,
       });
       return true;
     } catch (error) {
@@ -1275,7 +1355,7 @@ export class GerberViewer {
         fileName: name,
         current: index + 1,
         total,
-        progress: this.getLayerLoadProgress(index, total, 1),
+        progress: 0.5 + this.getLayerLoadProgress(index, total, 1) * 0.5,
       });
       return false;
     }

--- a/js/source-loader.js
+++ b/js/source-loader.js
@@ -84,6 +84,7 @@ export async function collectLayerSources(files, callbacks = {}) {
 
     layerSources.push({
       name: file.name,
+      sizeBytes: file.size,
       readText: (onProgress) => readFileText(file, onProgress),
     });
   }
@@ -98,16 +99,35 @@ export function repeatLayerSources(layerSources, repeat, { offset = {} } = {}) {
 
   const repeatOffset = normalizeLayerOffset(offset);
 
-  return layerSources.flatMap((source) =>
-    Array.from({ length: repeat }, (_, index) => ({
+  return layerSources.flatMap((source) => {
+    const readText = createSharedTextReader(source.readText);
+    return Array.from({ length: repeat }, (_, index) => ({
       name: `${source.name} #${index + 1}`,
-      readText: source.readText,
+      sizeBytes: source.sizeBytes,
+      readText,
       offset: addLayerOffsets(source.offset, {
         x: repeatOffset.x * index,
         y: repeatOffset.y * index,
       }),
-    })),
-  );
+    }));
+  });
+}
+
+function createSharedTextReader(readText) {
+  let textPromise = null;
+
+  return (onProgress = () => {}) => {
+    if (!textPromise) {
+      textPromise = readText(onProgress);
+    } else {
+      textPromise.then(
+        () => onProgress(1),
+        () => onProgress(1),
+      );
+    }
+
+    return textPromise;
+  };
 }
 
 function readFileText(file, onProgress = () => {}) {
@@ -210,6 +230,7 @@ async function collectZipLayerSources(
 
     return entries.map((entry) => ({
       name: getBaseFileName(entry.name),
+      sizeBytes: getZipEntrySizeBytes(entry),
       readText: (onProgress = () => {}) =>
         entry.async("string", (metadata) => {
           onProgress(Math.min(metadata.percent / 100, 1));
@@ -219,4 +240,11 @@ async function collectZipLayerSources(
     onArchiveError(file.name, error);
     return [];
   }
+}
+
+function getZipEntrySizeBytes(entry) {
+  const size = Number(
+    entry._data?.uncompressedSize ?? entry._data?.compressedSize,
+  );
+  return Number.isFinite(size) && size > 0 ? size : null;
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -4,7 +4,7 @@ mod shape;
 
 use crate::parser::parse_gerber;
 use crate::renderer::Renderer;
-use crate::shape::{Boundary, GerberData};
+use crate::shape::{gerber_data_layers_from_js, gerber_data_layers_to_js, Boundary, GerberData};
 use wasm_bindgen::prelude::*;
 use web_sys::WebGl2RenderingContext;
 
@@ -45,6 +45,47 @@ pub fn reserve_input_capacity(byte_count: usize) -> Result<(), JsValue> {
     Ok(())
 }
 
+fn parse_layer_data(
+    content: &str,
+    offset_x: f32,
+    offset_y: f32,
+) -> Result<Vec<GerberData>, JsValue> {
+    if !offset_x.is_finite() || !offset_y.is_finite() {
+        return Err(JsValue::from_str("Layer offset must be finite"));
+    }
+
+    let mut gerber_data_layers = parse_gerber(content)?;
+
+    if offset_x != 0.0 || offset_y != 0.0 {
+        for layer in &mut gerber_data_layers {
+            layer.translate(offset_x, offset_y);
+        }
+    }
+
+    let non_empty_layers: Vec<_> = gerber_data_layers
+        .into_iter()
+        .filter(|layer| layer.has_geometry())
+        .collect();
+
+    if non_empty_layers.is_empty() {
+        return Err(JsValue::from_str(
+            "File does not contain valid Gerber data (no geometry found)",
+        ));
+    }
+
+    Ok(non_empty_layers)
+}
+
+#[wasm_bindgen]
+pub fn parse_gerber_layer(
+    content: String,
+    offset_x: f32,
+    offset_y: f32,
+) -> Result<JsValue, JsValue> {
+    let gerber_data_layers = parse_layer_data(&content, offset_x, offset_y)?;
+    gerber_data_layers_to_js(&gerber_data_layers)
+}
+
 /// Main Gerber processor with stateful WebGL renderer
 #[wasm_bindgen]
 #[derive(Default)]
@@ -55,7 +96,6 @@ pub struct GerberProcessor {
 
 impl GerberProcessor {
     fn add_parsed_layers(&mut self, gerber_data_layers: Vec<GerberData>) -> Result<u32, JsValue> {
-        // Filter out empty layers (layers with no geometry)
         let non_empty_layers: Vec<_> = gerber_data_layers
             .into_iter()
             .filter(|layer| layer.has_geometry())
@@ -129,8 +169,7 @@ impl GerberProcessor {
     /// # Returns
     /// * Layer ID (u32) for tracking this layer
     pub fn add_layer(&mut self, content: String) -> Result<u32, JsValue> {
-        // Parse Gerber content to get Vec<GerberData> (one per polarity layer)
-        let gerber_data_layers = parse_gerber(&content)?;
+        let gerber_data_layers = parse_layer_data(&content, 0.0, 0.0)?;
         self.add_parsed_layers(gerber_data_layers)
     }
 
@@ -149,19 +188,13 @@ impl GerberProcessor {
         offset_x: f32,
         offset_y: f32,
     ) -> Result<u32, JsValue> {
-        if !offset_x.is_finite() || !offset_y.is_finite() {
-            return Err(JsValue::from_str("Layer offset must be finite"));
-        }
+        let gerber_data_layers = parse_layer_data(&content, offset_x, offset_y)?;
+        self.add_parsed_layers(gerber_data_layers)
+    }
 
-        if offset_x == 0.0 && offset_y == 0.0 {
-            return self.add_layer(content);
-        }
-
-        let mut gerber_data_layers = parse_gerber(&content)?;
-        for layer in &mut gerber_data_layers {
-            layer.translate(offset_x, offset_y);
-        }
-
+    /// Add a layer from geometry parsed in a worker or another WASM instance.
+    pub fn add_parsed_layer(&mut self, parsed_layer: JsValue) -> Result<u32, JsValue> {
+        let gerber_data_layers = gerber_data_layers_from_js(&parsed_layer)?;
         self.add_parsed_layers(gerber_data_layers)
     }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -198,6 +198,17 @@ impl GerberProcessor {
         self.add_parsed_layers(gerber_data_layers)
     }
 
+    /// Add a worker-produced render payload directly to WebGL buffers.
+    pub fn add_render_payload(&mut self, render_payload: JsValue) -> Result<u32, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            Ok(renderer.add_layer_from_render_payload(&render_payload)? as u32)
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
     /// Remove a layer from the renderer
     ///
     /// # Arguments

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -13,7 +13,7 @@ use shader::{
 use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Thermals, TriangleTemplateInstances, Triangles,
 };
-use js_sys::Float32Array;
+use js_sys::{Array, Float32Array, Reflect};
 use wasm_bindgen::prelude::*;
 use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlTexture};
 
@@ -109,6 +109,695 @@ impl Renderer {
             self.layer_count += 1;
             Ok(self.layers.len() - 1)
         }
+    }
+
+    /// Add a layer from a worker-produced render payload without rebuilding
+    /// CPU-side GerberData geometry in the main WASM instance.
+    pub fn add_layer_from_render_payload(&mut self, payload: &JsValue) -> Result<usize, JsValue> {
+        let (width, height) = self.get_canvas_size()?;
+        let sublayers = Array::from(&Self::js_property(payload, "sublayers")?);
+        if sublayers.length() == 0 {
+            return Err(JsValue::from_str("Layer does not contain any sublayers"));
+        }
+
+        let mut min_x = f32::INFINITY;
+        let mut max_x = f32::NEG_INFINITY;
+        let mut min_y = f32::INFINITY;
+        let mut max_y = f32::NEG_INFINITY;
+        let mut gerber_data = Vec::with_capacity(sublayers.length() as usize);
+        let mut buffer_caches = Vec::with_capacity(sublayers.length() as usize);
+
+        for sublayer in sublayers.iter() {
+            let boundary = Boundary::new(
+                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "minX")?,
+                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "maxX")?,
+                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "minY")?,
+                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "maxY")?,
+            );
+            Self::validate_finite_value("boundary.min_x", boundary.min_x)?;
+            Self::validate_finite_value("boundary.max_x", boundary.max_x)?;
+            Self::validate_finite_value("boundary.min_y", boundary.min_y)?;
+            Self::validate_finite_value("boundary.max_y", boundary.max_y)?;
+
+            min_x = min_x.min(boundary.min_x);
+            max_x = max_x.max(boundary.max_x);
+            min_y = min_y.min(boundary.min_y);
+            max_y = max_y.max(boundary.max_y);
+
+            let mut buffer_cache = BufferCache::default();
+            let template_count =
+                self.populate_buffer_cache_from_render_payload(&mut buffer_cache, &sublayer)?;
+            buffer_caches.push(buffer_cache);
+            gerber_data.push(Self::placeholder_gerber_data(
+                boundary,
+                Self::js_bool_property(&sublayer, "isNegative"),
+                template_count,
+            ));
+        }
+
+        if !min_x.is_finite() || !max_x.is_finite() || !min_y.is_finite() || !max_y.is_finite() {
+            return Err(JsValue::from_str("Layer boundary is not finite"));
+        }
+
+        let layer_metadata = LayerMetadata {
+            gerber_data,
+            fbo: Self::create_fbo(&self.gl, width, height)?,
+            buffer_caches,
+            boundary: Boundary::new(min_x, max_x, min_y, max_y),
+            fbo_dirty: true,
+            fbo_transform: None,
+            cpu_geometry_released: true,
+        };
+
+        if let Some(free_slot) = self.layers.iter().position(|layer| layer.is_none()) {
+            self.layers[free_slot] = Some(layer_metadata);
+            self.layer_count += 1;
+            Ok(free_slot)
+        } else {
+            self.layers.push(Some(layer_metadata));
+            self.layer_count += 1;
+            Ok(self.layers.len() - 1)
+        }
+    }
+
+    fn placeholder_gerber_data(
+        boundary: Boundary,
+        is_negative: bool,
+        template_count: usize,
+    ) -> GerberData {
+        GerberData::new(
+            Triangles::new(Vec::new(), Vec::new(), Vec::new(), Vec::new()),
+            (0..template_count)
+                .map(|_| TriangleTemplateInstances::new(Vec::new(), Vec::new(), Vec::new()))
+                .collect(),
+            Circles::new(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+            Arcs::new(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+            Thermals::new(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+            boundary,
+            is_negative,
+        )
+    }
+
+    fn populate_buffer_cache_from_render_payload(
+        &self,
+        buffer_cache: &mut BufferCache,
+        sublayer: &JsValue,
+    ) -> Result<usize, JsValue> {
+        self.populate_triangle_cache_from_payload(buffer_cache, sublayer)?;
+        let template_count =
+            self.populate_triangle_template_cache_from_payload(buffer_cache, sublayer)?;
+        self.populate_circle_cache_from_payload(buffer_cache, sublayer)?;
+        self.populate_arc_cache_from_payload(buffer_cache, sublayer)?;
+        self.populate_thermal_cache_from_payload(buffer_cache, sublayer)?;
+        Ok(template_count)
+    }
+
+    fn populate_triangle_cache_from_payload(
+        &self,
+        buffer_cache: &mut BufferCache,
+        sublayer: &JsValue,
+    ) -> Result<(), JsValue> {
+        let triangles = Self::js_property(sublayer, "triangles")?;
+        let vertices = Self::js_f32_array(&triangles, "vertices")?;
+        if vertices.length() == 0 {
+            return Ok(());
+        }
+
+        let vertex_count = Self::validate_triangle_vertex_array("triangle vertices", &vertices)?;
+        let vao = self
+            .gl
+            .create_vertex_array()
+            .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+        self.gl.bind_vertex_array(Some(&vao));
+        let vertex_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &vertices,
+            &self.programs.triangle,
+            "position",
+            2,
+            0,
+        )?;
+
+        let hole_radius = Self::js_f32_array(&triangles, "holeRadius")?;
+        if hole_radius.length() == 0 {
+            Self::use_constant_vertex_attrib_1f(
+                &self.gl,
+                &self.programs.triangle,
+                "hole_x_instance",
+                0.0,
+            )?;
+            Self::use_constant_vertex_attrib_1f(
+                &self.gl,
+                &self.programs.triangle,
+                "hole_y_instance",
+                0.0,
+            )?;
+            Self::use_constant_vertex_attrib_1f(
+                &self.gl,
+                &self.programs.triangle,
+                "hole_radius_instance",
+                0.0,
+            )?;
+        } else {
+            let hole_x = Self::js_f32_array(&triangles, "holeX")?;
+            let hole_y = Self::js_f32_array(&triangles, "holeY")?;
+            Self::validate_js_array_len("triangle hole_x", &hole_x, vertex_count as u32)?;
+            Self::validate_js_array_len("triangle hole_y", &hole_y, vertex_count as u32)?;
+            Self::validate_js_array_len("triangle hole_radius", &hole_radius, vertex_count as u32)?;
+            buffer_cache.triangle_hole_x_buffer = Some(Self::create_attrib_buffer_from_js_array(
+                &self.gl,
+                &hole_x,
+                &self.programs.triangle,
+                "hole_x_instance",
+                1,
+                0,
+            )?);
+            buffer_cache.triangle_hole_y_buffer = Some(Self::create_attrib_buffer_from_js_array(
+                &self.gl,
+                &hole_y,
+                &self.programs.triangle,
+                "hole_y_instance",
+                1,
+                0,
+            )?);
+            buffer_cache.triangle_hole_radius_buffer =
+                Some(Self::create_attrib_buffer_from_js_array(
+                    &self.gl,
+                    &hole_radius,
+                    &self.programs.triangle,
+                    "hole_radius_instance",
+                    1,
+                    0,
+                )?);
+        }
+
+        self.gl.bind_vertex_array(None);
+        buffer_cache.triangle_vao = Some(vao);
+        buffer_cache.triangle_vertex_count = vertex_count;
+        buffer_cache.triangle_vertex_buffer = Some(vertex_buffer);
+        Ok(())
+    }
+
+    fn populate_triangle_template_cache_from_payload(
+        &self,
+        buffer_cache: &mut BufferCache,
+        sublayer: &JsValue,
+    ) -> Result<usize, JsValue> {
+        let templates = Array::from(&Self::js_property(sublayer, "triangleTemplates")?);
+        let template_count = templates.length() as usize;
+        buffer_cache
+            .triangle_template_caches
+            .resize_with(template_count, TriangleTemplateBufferCache::default);
+
+        for (template_idx, template) in templates.iter().enumerate() {
+            let vertices = Self::js_f32_array(&template, "vertices")?;
+            let instance_x = Self::js_f32_array(&template, "instanceX")?;
+            let instance_y = Self::js_f32_array(&template, "instanceY")?;
+            if vertices.length() == 0 || instance_x.length() == 0 {
+                continue;
+            }
+
+            let vertex_count =
+                Self::validate_triangle_vertex_array("triangle template vertices", &vertices)?;
+            let instance_count =
+                Self::validate_instance_array("triangle template instances", &instance_x)?;
+            Self::validate_js_array_len(
+                "triangle template instance_y",
+                &instance_y,
+                instance_count as u32,
+            )?;
+
+            let vao = self
+                .gl
+                .create_vertex_array()
+                .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+            self.gl.bind_vertex_array(Some(&vao));
+            let vertex_buffer = Self::create_attrib_buffer_from_js_array(
+                &self.gl,
+                &vertices,
+                &self.programs.triangle_template,
+                "position",
+                2,
+                0,
+            )?;
+            let instance_x_buffer = Self::create_attrib_buffer_from_js_array(
+                &self.gl,
+                &instance_x,
+                &self.programs.triangle_template,
+                "instance_x",
+                1,
+                1,
+            )?;
+            let instance_y_buffer = Self::create_attrib_buffer_from_js_array(
+                &self.gl,
+                &instance_y,
+                &self.programs.triangle_template,
+                "instance_y",
+                1,
+                1,
+            )?;
+            self.gl.bind_vertex_array(None);
+
+            let template_cache = &mut buffer_cache.triangle_template_caches[template_idx];
+            template_cache.vao = Some(vao);
+            template_cache.vertex_count = vertex_count;
+            template_cache.instance_count = instance_count;
+            template_cache.vertex_buffer = Some(vertex_buffer);
+            template_cache.instance_x_buffer = Some(instance_x_buffer);
+            template_cache.instance_y_buffer = Some(instance_y_buffer);
+        }
+
+        Ok(template_count)
+    }
+
+    fn populate_circle_cache_from_payload(
+        &self,
+        buffer_cache: &mut BufferCache,
+        sublayer: &JsValue,
+    ) -> Result<(), JsValue> {
+        let circles = Self::js_property(sublayer, "circles")?;
+        let x = Self::js_f32_array(&circles, "x")?;
+        if x.length() == 0 {
+            return Ok(());
+        }
+
+        let y = Self::js_f32_array(&circles, "y")?;
+        let radius = Self::js_f32_array(&circles, "radius")?;
+        let instance_count = Self::validate_instance_array("circle", &x)?;
+        Self::validate_js_array_len("circle y", &y, instance_count as u32)?;
+        Self::validate_js_array_len("circle radius", &radius, instance_count as u32)?;
+
+        let vao = self
+            .gl
+            .create_vertex_array()
+            .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+        self.gl.bind_vertex_array(Some(&vao));
+        self.bind_quad_position(&self.programs.circle)?;
+        let center_x_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &x,
+            &self.programs.circle,
+            "center_x_instance",
+            1,
+            1,
+        )?;
+        let center_y_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &y,
+            &self.programs.circle,
+            "center_y_instance",
+            1,
+            1,
+        )?;
+        let radius_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &radius,
+            &self.programs.circle,
+            "radius_instance",
+            1,
+            1,
+        )?;
+
+        let hole_radius = Self::js_f32_array(&circles, "holeRadius")?;
+        if hole_radius.length() == 0 {
+            Self::use_constant_vertex_attrib_1f(
+                &self.gl,
+                &self.programs.circle,
+                "hole_x_instance",
+                0.0,
+            )?;
+            Self::use_constant_vertex_attrib_1f(
+                &self.gl,
+                &self.programs.circle,
+                "hole_y_instance",
+                0.0,
+            )?;
+            Self::use_constant_vertex_attrib_1f(
+                &self.gl,
+                &self.programs.circle,
+                "hole_radius_instance",
+                0.0,
+            )?;
+        } else {
+            let hole_x = Self::js_f32_array(&circles, "holeX")?;
+            let hole_y = Self::js_f32_array(&circles, "holeY")?;
+            Self::validate_js_array_len("circle hole_x", &hole_x, instance_count as u32)?;
+            Self::validate_js_array_len("circle hole_y", &hole_y, instance_count as u32)?;
+            Self::validate_js_array_len("circle hole_radius", &hole_radius, instance_count as u32)?;
+            buffer_cache.circle_hole_x_buffer = Some(Self::create_attrib_buffer_from_js_array(
+                &self.gl,
+                &hole_x,
+                &self.programs.circle,
+                "hole_x_instance",
+                1,
+                1,
+            )?);
+            buffer_cache.circle_hole_y_buffer = Some(Self::create_attrib_buffer_from_js_array(
+                &self.gl,
+                &hole_y,
+                &self.programs.circle,
+                "hole_y_instance",
+                1,
+                1,
+            )?);
+            buffer_cache.circle_hole_radius_buffer =
+                Some(Self::create_attrib_buffer_from_js_array(
+                    &self.gl,
+                    &hole_radius,
+                    &self.programs.circle,
+                    "hole_radius_instance",
+                    1,
+                    1,
+                )?);
+        }
+
+        self.gl.bind_vertex_array(None);
+        buffer_cache.circle_vao = Some(vao);
+        buffer_cache.circle_instance_count = instance_count;
+        buffer_cache.circle_center_x_buffer = Some(center_x_buffer);
+        buffer_cache.circle_center_y_buffer = Some(center_y_buffer);
+        buffer_cache.circle_radius_buffer = Some(radius_buffer);
+        Ok(())
+    }
+
+    fn populate_arc_cache_from_payload(
+        &self,
+        buffer_cache: &mut BufferCache,
+        sublayer: &JsValue,
+    ) -> Result<(), JsValue> {
+        let arcs = Self::js_property(sublayer, "arcs")?;
+        let x = Self::js_f32_array(&arcs, "x")?;
+        if x.length() == 0 {
+            return Ok(());
+        }
+
+        let y = Self::js_f32_array(&arcs, "y")?;
+        let radius = Self::js_f32_array(&arcs, "radius")?;
+        let start_angle = Self::js_f32_array(&arcs, "startAngle")?;
+        let sweep_angle = Self::js_f32_array(&arcs, "sweepAngle")?;
+        let thickness = Self::js_f32_array(&arcs, "thickness")?;
+        let instance_count = Self::validate_instance_array("arc", &x)?;
+        Self::validate_js_array_len("arc y", &y, instance_count as u32)?;
+        Self::validate_js_array_len("arc radius", &radius, instance_count as u32)?;
+        Self::validate_js_array_len("arc start_angle", &start_angle, instance_count as u32)?;
+        Self::validate_js_array_len("arc sweep_angle", &sweep_angle, instance_count as u32)?;
+        Self::validate_js_array_len("arc thickness", &thickness, instance_count as u32)?;
+
+        let vao = self
+            .gl
+            .create_vertex_array()
+            .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+        self.gl.bind_vertex_array(Some(&vao));
+        self.bind_quad_position(&self.programs.arc)?;
+        let center_x_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &x,
+            &self.programs.arc,
+            "center_x_instance",
+            1,
+            1,
+        )?;
+        let center_y_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &y,
+            &self.programs.arc,
+            "center_y_instance",
+            1,
+            1,
+        )?;
+        let radius_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &radius,
+            &self.programs.arc,
+            "radius_instance",
+            1,
+            1,
+        )?;
+        let start_angle_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &start_angle,
+            &self.programs.arc,
+            "startAngle_instance",
+            1,
+            1,
+        )?;
+        let sweep_angle_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &sweep_angle,
+            &self.programs.arc,
+            "sweepAngle_instance",
+            1,
+            1,
+        )?;
+        let thickness_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &thickness,
+            &self.programs.arc,
+            "thickness_instance",
+            1,
+            1,
+        )?;
+
+        self.gl.bind_vertex_array(None);
+        buffer_cache.arc_vao = Some(vao);
+        buffer_cache.arc_instance_count = instance_count;
+        buffer_cache.arc_center_x_buffer = Some(center_x_buffer);
+        buffer_cache.arc_center_y_buffer = Some(center_y_buffer);
+        buffer_cache.arc_radius_buffer = Some(radius_buffer);
+        buffer_cache.arc_start_angle_buffer = Some(start_angle_buffer);
+        buffer_cache.arc_sweep_angle_buffer = Some(sweep_angle_buffer);
+        buffer_cache.arc_thickness_buffer = Some(thickness_buffer);
+        Ok(())
+    }
+
+    fn populate_thermal_cache_from_payload(
+        &self,
+        buffer_cache: &mut BufferCache,
+        sublayer: &JsValue,
+    ) -> Result<(), JsValue> {
+        let thermals = Self::js_property(sublayer, "thermals")?;
+        let x = Self::js_f32_array(&thermals, "x")?;
+        if x.length() == 0 {
+            return Ok(());
+        }
+
+        let y = Self::js_f32_array(&thermals, "y")?;
+        let outer_diameter = Self::js_f32_array(&thermals, "outerDiameter")?;
+        let inner_diameter = Self::js_f32_array(&thermals, "innerDiameter")?;
+        let gap_thickness = Self::js_f32_array(&thermals, "gapThickness")?;
+        let rotation = Self::js_f32_array(&thermals, "rotation")?;
+        let instance_count = Self::validate_instance_array("thermal", &x)?;
+        Self::validate_js_array_len("thermal y", &y, instance_count as u32)?;
+        Self::validate_js_array_len(
+            "thermal outer_diameter",
+            &outer_diameter,
+            instance_count as u32,
+        )?;
+        Self::validate_js_array_len(
+            "thermal inner_diameter",
+            &inner_diameter,
+            instance_count as u32,
+        )?;
+        Self::validate_js_array_len(
+            "thermal gap_thickness",
+            &gap_thickness,
+            instance_count as u32,
+        )?;
+        Self::validate_js_array_len("thermal rotation", &rotation, instance_count as u32)?;
+
+        let vao = self
+            .gl
+            .create_vertex_array()
+            .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+        self.gl.bind_vertex_array(Some(&vao));
+        self.bind_quad_position(&self.programs.thermal)?;
+        let center_x_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &x,
+            &self.programs.thermal,
+            "center_x_instance",
+            1,
+            1,
+        )?;
+        let center_y_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &y,
+            &self.programs.thermal,
+            "center_y_instance",
+            1,
+            1,
+        )?;
+        let outer_diameter_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &outer_diameter,
+            &self.programs.thermal,
+            "outer_diameter_instance",
+            1,
+            1,
+        )?;
+        let inner_diameter_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &inner_diameter,
+            &self.programs.thermal,
+            "inner_diameter_instance",
+            1,
+            1,
+        )?;
+        let gap_thickness_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &gap_thickness,
+            &self.programs.thermal,
+            "gap_thickness_instance",
+            1,
+            1,
+        )?;
+        let rotation_buffer = Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &rotation,
+            &self.programs.thermal,
+            "rotation_instance",
+            1,
+            1,
+        )?;
+
+        self.gl.bind_vertex_array(None);
+        buffer_cache.thermal_vao = Some(vao);
+        buffer_cache.thermal_instance_count = instance_count;
+        buffer_cache.thermal_center_x_buffer = Some(center_x_buffer);
+        buffer_cache.thermal_center_y_buffer = Some(center_y_buffer);
+        buffer_cache.thermal_outer_diameter_buffer = Some(outer_diameter_buffer);
+        buffer_cache.thermal_inner_diameter_buffer = Some(inner_diameter_buffer);
+        buffer_cache.thermal_gap_thickness_buffer = Some(gap_thickness_buffer);
+        buffer_cache.thermal_rotation_buffer = Some(rotation_buffer);
+        Ok(())
+    }
+
+    fn create_attrib_buffer_from_js_array(
+        gl: &WebGl2RenderingContext,
+        data: &Float32Array,
+        program: &ShaderProgram,
+        attr_name: &str,
+        components: i32,
+        divisor: u32,
+    ) -> Result<WebGlBuffer, JsValue> {
+        let buffer = gl
+            .create_buffer()
+            .ok_or_else(|| JsValue::from_str("Failed to create buffer"))?;
+        gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
+        gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, data, STATIC_DRAW);
+        let loc = Self::shader_attribute(program, attr_name)?;
+        gl.enable_vertex_attrib_array(loc);
+        gl.vertex_attrib_pointer_with_i32(loc, components, FLOAT, false, 0, 0);
+        gl.vertex_attrib_divisor(loc, divisor);
+        Ok(buffer)
+    }
+
+    fn bind_quad_position(&self, program: &ShaderProgram) -> Result<(), JsValue> {
+        self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
+        let position_loc = Self::shader_attribute(program, "position")?;
+        self.gl.enable_vertex_attrib_array(position_loc);
+        self.gl
+            .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
+        Ok(())
+    }
+
+    fn validate_triangle_vertex_array(label: &str, values: &Float32Array) -> Result<i32, JsValue> {
+        if !values.length().is_multiple_of(2) {
+            return Err(JsValue::from_str(&format!(
+                "{} buffer has an odd number of coordinates",
+                label
+            )));
+        }
+        let vertex_count = values.length() / 2;
+        if !vertex_count.is_multiple_of(3) {
+            return Err(JsValue::from_str(&format!(
+                "{} count is not divisible by 3",
+                label
+            )));
+        }
+        if vertex_count > i32::MAX as u32 {
+            return Err(JsValue::from_str(&format!(
+                "{} count exceeds WebGL draw limits",
+                label
+            )));
+        }
+        Ok(vertex_count as i32)
+    }
+
+    fn validate_instance_array(label: &str, values: &Float32Array) -> Result<i32, JsValue> {
+        if values.length() > i32::MAX as u32 {
+            return Err(JsValue::from_str(&format!(
+                "{} count exceeds WebGL draw limits",
+                label
+            )));
+        }
+        Ok(values.length() as i32)
+    }
+
+    fn validate_js_array_len(
+        label: &str,
+        values: &Float32Array,
+        expected: u32,
+    ) -> Result<(), JsValue> {
+        if values.length() != expected {
+            return Err(JsValue::from_str(&format!(
+                "{} length mismatch: expected {}, got {}",
+                label,
+                expected,
+                values.length()
+            )));
+        }
+        Ok(())
+    }
+
+    fn js_property(value: &JsValue, key: &str) -> Result<JsValue, JsValue> {
+        let property = Reflect::get(value, &JsValue::from_str(key))
+            .map_err(|_| JsValue::from_str(&format!("Missing render payload field `{key}`")))?;
+        if property.is_undefined() || property.is_null() {
+            return Err(JsValue::from_str(&format!(
+                "Missing render payload field `{key}`"
+            )));
+        }
+        Ok(property)
+    }
+
+    fn js_f32_array(value: &JsValue, key: &str) -> Result<Float32Array, JsValue> {
+        Ok(Float32Array::new(&Self::js_property(value, key)?))
+    }
+
+    fn js_f32_property(value: &JsValue, key: &str) -> Result<f32, JsValue> {
+        let number = Self::js_property(value, key)?.as_f64().ok_or_else(|| {
+            JsValue::from_str(&format!("Render payload field `{key}` is not numeric"))
+        })?;
+        Ok(number as f32)
+    }
+
+    fn js_bool_property(value: &JsValue, key: &str) -> bool {
+        Self::js_property(value, key)
+            .ok()
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
     }
 
     fn validate_gerber_data_layers(gerber_data: &[GerberData]) -> Result<(), JsValue> {

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -145,8 +145,18 @@ impl Renderer {
             max_y = max_y.max(boundary.max_y);
 
             let mut buffer_cache = BufferCache::default();
-            let template_count =
-                self.populate_buffer_cache_from_render_payload(&mut buffer_cache, &sublayer)?;
+            let template_count = match self
+                .populate_buffer_cache_from_render_payload(&mut buffer_cache, &sublayer)
+            {
+                Ok(template_count) => template_count,
+                Err(error) => {
+                    Self::delete_buffer_cache(&self.gl, buffer_cache);
+                    for cache in buffer_caches.drain(..) {
+                        Self::delete_buffer_cache(&self.gl, cache);
+                    }
+                    return Err(error);
+                }
+            };
             buffer_caches.push(buffer_cache);
             gerber_data.push(Self::placeholder_gerber_data(
                 boundary,
@@ -159,9 +169,19 @@ impl Renderer {
             return Err(JsValue::from_str("Layer boundary is not finite"));
         }
 
+        let fbo = match Self::create_fbo(&self.gl, width, height) {
+            Ok(fbo) => fbo,
+            Err(error) => {
+                for cache in buffer_caches.drain(..) {
+                    Self::delete_buffer_cache(&self.gl, cache);
+                }
+                return Err(error);
+            }
+        };
+
         let layer_metadata = LayerMetadata {
             gerber_data,
-            fbo: Self::create_fbo(&self.gl, width, height)?,
+            fbo,
             buffer_caches,
             boundary: Boundary::new(min_x, max_x, min_y, max_y),
             fbo_dirty: true,

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -14,7 +14,7 @@ use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Thermals, TriangleTemplateInstances, Triangles,
 };
 use js_sys::{Array, Float32Array, Reflect};
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{prelude::*, JsCast};
 use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlTexture};
 
 /// Metadata for a single user layer (may contain multiple polarity sublayers)
@@ -273,6 +273,7 @@ impl Renderer {
         }
 
         let vertex_count = Self::validate_triangle_vertex_array("triangle vertices", &vertices)?;
+        Self::validate_js_finite_array("triangle vertices", &vertices)?;
         let vao = self
             .gl
             .create_vertex_array()
@@ -316,6 +317,9 @@ impl Renderer {
             Self::validate_js_array_len("triangle hole_x", &hole_x, vertex_count as u32)?;
             Self::validate_js_array_len("triangle hole_y", &hole_y, vertex_count as u32)?;
             Self::validate_js_array_len("triangle hole_radius", &hole_radius, vertex_count as u32)?;
+            Self::validate_js_finite_array("triangle hole_x", &hole_x)?;
+            Self::validate_js_finite_array("triangle hole_y", &hole_y)?;
+            Self::validate_js_non_negative_array("triangle hole_radius", &hole_radius)?;
             buffer_cache.triangle_hole_x_buffer = Some(Self::create_attrib_buffer_from_js_array(
                 &self.gl,
                 &hole_x,
@@ -375,6 +379,9 @@ impl Renderer {
                 &instance_y,
                 instance_count as u32,
             )?;
+            Self::validate_js_finite_array("triangle template vertices", &vertices)?;
+            Self::validate_js_finite_array("triangle template instance_x", &instance_x)?;
+            Self::validate_js_finite_array("triangle template instance_y", &instance_y)?;
 
             let vao = self
                 .gl
@@ -434,6 +441,9 @@ impl Renderer {
         let instance_count = Self::validate_instance_array("circle", &x)?;
         Self::validate_js_array_len("circle y", &y, instance_count as u32)?;
         Self::validate_js_array_len("circle radius", &radius, instance_count as u32)?;
+        Self::validate_js_finite_array("circle x", &x)?;
+        Self::validate_js_finite_array("circle y", &y)?;
+        Self::validate_js_non_negative_array("circle radius", &radius)?;
 
         let vao = self
             .gl
@@ -497,6 +507,9 @@ impl Renderer {
             Self::validate_js_array_len("circle hole_x", &hole_x, instance_count as u32)?;
             Self::validate_js_array_len("circle hole_y", &hole_y, instance_count as u32)?;
             Self::validate_js_array_len("circle hole_radius", &hole_radius, instance_count as u32)?;
+            Self::validate_js_finite_array("circle hole_x", &hole_x)?;
+            Self::validate_js_finite_array("circle hole_y", &hole_y)?;
+            Self::validate_js_non_negative_array("circle hole_radius", &hole_radius)?;
             buffer_cache.circle_hole_x_buffer = Some(Self::create_attrib_buffer_from_js_array(
                 &self.gl,
                 &hole_x,
@@ -550,6 +563,12 @@ impl Renderer {
         Self::validate_js_array_len("arc start_angle", &start_angle, instance_count as u32)?;
         Self::validate_js_array_len("arc sweep_angle", &sweep_angle, instance_count as u32)?;
         Self::validate_js_array_len("arc thickness", &thickness, instance_count as u32)?;
+        Self::validate_js_finite_array("arc x", &x)?;
+        Self::validate_js_finite_array("arc y", &y)?;
+        Self::validate_js_non_negative_array("arc radius", &radius)?;
+        Self::validate_js_finite_array("arc start_angle", &start_angle)?;
+        Self::validate_js_finite_array("arc sweep_angle", &sweep_angle)?;
+        Self::validate_js_non_negative_array("arc thickness", &thickness)?;
 
         let vao = self
             .gl
@@ -652,6 +671,12 @@ impl Renderer {
             instance_count as u32,
         )?;
         Self::validate_js_array_len("thermal rotation", &rotation, instance_count as u32)?;
+        Self::validate_js_finite_array("thermal x", &x)?;
+        Self::validate_js_finite_array("thermal y", &y)?;
+        Self::validate_js_non_negative_array("thermal outer_diameter", &outer_diameter)?;
+        Self::validate_js_non_negative_array("thermal inner_diameter", &inner_diameter)?;
+        Self::validate_js_non_negative_array("thermal gap_thickness", &gap_thickness)?;
+        Self::validate_js_finite_array("thermal rotation", &rotation)?;
 
         let vao = self
             .gl
@@ -816,7 +841,13 @@ impl Renderer {
     }
 
     fn js_f32_array(value: &JsValue, key: &str) -> Result<Float32Array, JsValue> {
-        Ok(Float32Array::new(&Self::js_property(value, key)?))
+        Self::js_property(value, key)?
+            .dyn_into::<Float32Array>()
+            .map_err(|_| {
+                JsValue::from_str(&format!(
+                    "Render payload field `{key}` must be a Float32Array"
+                ))
+            })
     }
 
     fn js_f32_property(value: &JsValue, key: &str) -> Result<f32, JsValue> {
@@ -1095,6 +1126,27 @@ impl Renderer {
     fn validate_finite_value(label: &str, value: f32) -> Result<(), JsValue> {
         if !value.is_finite() {
             return Err(JsValue::from_str(&format!("{} is not finite", label)));
+        }
+        Ok(())
+    }
+
+    fn validate_js_finite_array(label: &str, values: &Float32Array) -> Result<(), JsValue> {
+        for index in 0..values.length() {
+            Self::validate_finite_value(label, values.get_index(index))?;
+        }
+        Ok(())
+    }
+
+    fn validate_js_non_negative_array(label: &str, values: &Float32Array) -> Result<(), JsValue> {
+        for index in 0..values.length() {
+            let value = values.get_index(index);
+            Self::validate_finite_value(label, value)?;
+            if value < 0.0 {
+                return Err(JsValue::from_str(&format!(
+                    "{} contains a negative value",
+                    label
+                )));
+            }
         }
         Ok(())
     }

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -128,16 +128,13 @@ impl Renderer {
         let mut buffer_caches = Vec::with_capacity(sublayers.length() as usize);
 
         for sublayer in sublayers.iter() {
-            let boundary = Boundary::new(
-                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "minX")?,
-                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "maxX")?,
-                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "minY")?,
-                Self::js_f32_property(&Self::js_property(&sublayer, "boundary")?, "maxY")?,
-            );
-            Self::validate_finite_value("boundary.min_x", boundary.min_x)?;
-            Self::validate_finite_value("boundary.max_x", boundary.max_x)?;
-            Self::validate_finite_value("boundary.min_y", boundary.min_y)?;
-            Self::validate_finite_value("boundary.max_y", boundary.max_y)?;
+            let boundary = match Self::decode_render_payload_boundary(&sublayer) {
+                Ok(boundary) => boundary,
+                Err(error) => {
+                    Self::delete_buffer_caches(&self.gl, &mut buffer_caches);
+                    return Err(error);
+                }
+            };
 
             min_x = min_x.min(boundary.min_x);
             max_x = max_x.max(boundary.max_x);
@@ -151,9 +148,7 @@ impl Renderer {
                 Ok(template_count) => template_count,
                 Err(error) => {
                     Self::delete_buffer_cache(&self.gl, buffer_cache);
-                    for cache in buffer_caches.drain(..) {
-                        Self::delete_buffer_cache(&self.gl, cache);
-                    }
+                    Self::delete_buffer_caches(&self.gl, &mut buffer_caches);
                     return Err(error);
                 }
             };
@@ -172,9 +167,7 @@ impl Renderer {
         let fbo = match Self::create_fbo(&self.gl, width, height) {
             Ok(fbo) => fbo,
             Err(error) => {
-                for cache in buffer_caches.drain(..) {
-                    Self::delete_buffer_cache(&self.gl, cache);
-                }
+                Self::delete_buffer_caches(&self.gl, &mut buffer_caches);
                 return Err(error);
             }
         };
@@ -198,6 +191,21 @@ impl Renderer {
             self.layer_count += 1;
             Ok(self.layers.len() - 1)
         }
+    }
+
+    fn decode_render_payload_boundary(sublayer: &JsValue) -> Result<Boundary, JsValue> {
+        let boundary_payload = Self::js_property(sublayer, "boundary")?;
+        let boundary = Boundary::new(
+            Self::js_f32_property(&boundary_payload, "minX")?,
+            Self::js_f32_property(&boundary_payload, "maxX")?,
+            Self::js_f32_property(&boundary_payload, "minY")?,
+            Self::js_f32_property(&boundary_payload, "maxY")?,
+        );
+        Self::validate_finite_value("boundary.min_x", boundary.min_x)?;
+        Self::validate_finite_value("boundary.max_x", boundary.max_x)?;
+        Self::validate_finite_value("boundary.min_y", boundary.min_y)?;
+        Self::validate_finite_value("boundary.max_y", boundary.max_y)?;
+        Ok(boundary)
     }
 
     fn placeholder_gerber_data(
@@ -270,6 +278,8 @@ impl Renderer {
             .create_vertex_array()
             .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
         self.gl.bind_vertex_array(Some(&vao));
+        buffer_cache.triangle_vao = Some(vao);
+        buffer_cache.triangle_vertex_count = vertex_count;
         let vertex_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &vertices,
@@ -278,6 +288,7 @@ impl Renderer {
             2,
             0,
         )?;
+        buffer_cache.triangle_vertex_buffer = Some(vertex_buffer);
 
         let hole_radius = Self::js_f32_array(&triangles, "holeRadius")?;
         if hole_radius.length() == 0 {
@@ -333,9 +344,6 @@ impl Renderer {
         }
 
         self.gl.bind_vertex_array(None);
-        buffer_cache.triangle_vao = Some(vao);
-        buffer_cache.triangle_vertex_count = vertex_count;
-        buffer_cache.triangle_vertex_buffer = Some(vertex_buffer);
         Ok(())
     }
 
@@ -373,6 +381,10 @@ impl Renderer {
                 .create_vertex_array()
                 .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
             self.gl.bind_vertex_array(Some(&vao));
+            let template_cache = &mut buffer_cache.triangle_template_caches[template_idx];
+            template_cache.vao = Some(vao);
+            template_cache.vertex_count = vertex_count;
+            template_cache.instance_count = instance_count;
             let vertex_buffer = Self::create_attrib_buffer_from_js_array(
                 &self.gl,
                 &vertices,
@@ -381,6 +393,7 @@ impl Renderer {
                 2,
                 0,
             )?;
+            template_cache.vertex_buffer = Some(vertex_buffer);
             let instance_x_buffer = Self::create_attrib_buffer_from_js_array(
                 &self.gl,
                 &instance_x,
@@ -389,6 +402,7 @@ impl Renderer {
                 1,
                 1,
             )?;
+            template_cache.instance_x_buffer = Some(instance_x_buffer);
             let instance_y_buffer = Self::create_attrib_buffer_from_js_array(
                 &self.gl,
                 &instance_y,
@@ -397,15 +411,8 @@ impl Renderer {
                 1,
                 1,
             )?;
-            self.gl.bind_vertex_array(None);
-
-            let template_cache = &mut buffer_cache.triangle_template_caches[template_idx];
-            template_cache.vao = Some(vao);
-            template_cache.vertex_count = vertex_count;
-            template_cache.instance_count = instance_count;
-            template_cache.vertex_buffer = Some(vertex_buffer);
-            template_cache.instance_x_buffer = Some(instance_x_buffer);
             template_cache.instance_y_buffer = Some(instance_y_buffer);
+            self.gl.bind_vertex_array(None);
         }
 
         Ok(template_count)
@@ -433,6 +440,8 @@ impl Renderer {
             .create_vertex_array()
             .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
         self.gl.bind_vertex_array(Some(&vao));
+        buffer_cache.circle_vao = Some(vao);
+        buffer_cache.circle_instance_count = instance_count;
         self.bind_quad_position(&self.programs.circle)?;
         let center_x_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
@@ -442,6 +451,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.circle_center_x_buffer = Some(center_x_buffer);
         let center_y_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &y,
@@ -450,6 +460,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.circle_center_y_buffer = Some(center_y_buffer);
         let radius_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &radius,
@@ -458,6 +469,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.circle_radius_buffer = Some(radius_buffer);
 
         let hole_radius = Self::js_f32_array(&circles, "holeRadius")?;
         if hole_radius.length() == 0 {
@@ -513,11 +525,6 @@ impl Renderer {
         }
 
         self.gl.bind_vertex_array(None);
-        buffer_cache.circle_vao = Some(vao);
-        buffer_cache.circle_instance_count = instance_count;
-        buffer_cache.circle_center_x_buffer = Some(center_x_buffer);
-        buffer_cache.circle_center_y_buffer = Some(center_y_buffer);
-        buffer_cache.circle_radius_buffer = Some(radius_buffer);
         Ok(())
     }
 
@@ -549,6 +556,8 @@ impl Renderer {
             .create_vertex_array()
             .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
         self.gl.bind_vertex_array(Some(&vao));
+        buffer_cache.arc_vao = Some(vao);
+        buffer_cache.arc_instance_count = instance_count;
         self.bind_quad_position(&self.programs.arc)?;
         let center_x_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
@@ -558,6 +567,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.arc_center_x_buffer = Some(center_x_buffer);
         let center_y_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &y,
@@ -566,6 +576,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.arc_center_y_buffer = Some(center_y_buffer);
         let radius_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &radius,
@@ -574,6 +585,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.arc_radius_buffer = Some(radius_buffer);
         let start_angle_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &start_angle,
@@ -582,6 +594,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.arc_start_angle_buffer = Some(start_angle_buffer);
         let sweep_angle_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &sweep_angle,
@@ -590,6 +603,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.arc_sweep_angle_buffer = Some(sweep_angle_buffer);
         let thickness_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &thickness,
@@ -598,16 +612,9 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.arc_thickness_buffer = Some(thickness_buffer);
 
         self.gl.bind_vertex_array(None);
-        buffer_cache.arc_vao = Some(vao);
-        buffer_cache.arc_instance_count = instance_count;
-        buffer_cache.arc_center_x_buffer = Some(center_x_buffer);
-        buffer_cache.arc_center_y_buffer = Some(center_y_buffer);
-        buffer_cache.arc_radius_buffer = Some(radius_buffer);
-        buffer_cache.arc_start_angle_buffer = Some(start_angle_buffer);
-        buffer_cache.arc_sweep_angle_buffer = Some(sweep_angle_buffer);
-        buffer_cache.arc_thickness_buffer = Some(thickness_buffer);
         Ok(())
     }
 
@@ -651,6 +658,8 @@ impl Renderer {
             .create_vertex_array()
             .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
         self.gl.bind_vertex_array(Some(&vao));
+        buffer_cache.thermal_vao = Some(vao);
+        buffer_cache.thermal_instance_count = instance_count;
         self.bind_quad_position(&self.programs.thermal)?;
         let center_x_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
@@ -660,6 +669,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.thermal_center_x_buffer = Some(center_x_buffer);
         let center_y_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &y,
@@ -668,6 +678,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.thermal_center_y_buffer = Some(center_y_buffer);
         let outer_diameter_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &outer_diameter,
@@ -676,6 +687,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.thermal_outer_diameter_buffer = Some(outer_diameter_buffer);
         let inner_diameter_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &inner_diameter,
@@ -684,6 +696,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.thermal_inner_diameter_buffer = Some(inner_diameter_buffer);
         let gap_thickness_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &gap_thickness,
@@ -692,6 +705,7 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.thermal_gap_thickness_buffer = Some(gap_thickness_buffer);
         let rotation_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &rotation,
@@ -700,16 +714,9 @@ impl Renderer {
             1,
             1,
         )?;
+        buffer_cache.thermal_rotation_buffer = Some(rotation_buffer);
 
         self.gl.bind_vertex_array(None);
-        buffer_cache.thermal_vao = Some(vao);
-        buffer_cache.thermal_instance_count = instance_count;
-        buffer_cache.thermal_center_x_buffer = Some(center_x_buffer);
-        buffer_cache.thermal_center_y_buffer = Some(center_y_buffer);
-        buffer_cache.thermal_outer_diameter_buffer = Some(outer_diameter_buffer);
-        buffer_cache.thermal_inner_diameter_buffer = Some(inner_diameter_buffer);
-        buffer_cache.thermal_gap_thickness_buffer = Some(gap_thickness_buffer);
-        buffer_cache.thermal_rotation_buffer = Some(rotation_buffer);
         Ok(())
     }
 
@@ -726,7 +733,13 @@ impl Renderer {
             .ok_or_else(|| JsValue::from_str("Failed to create buffer"))?;
         gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
         gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, data, STATIC_DRAW);
-        let loc = Self::shader_attribute(program, attr_name)?;
+        let loc = match Self::shader_attribute(program, attr_name) {
+            Ok(loc) => loc,
+            Err(error) => {
+                gl.delete_buffer(Some(&buffer));
+                return Err(error);
+            }
+        };
         gl.enable_vertex_attrib_array(loc);
         gl.vertex_attrib_pointer_with_i32(loc, components, FLOAT, false, 0, 0);
         gl.vertex_attrib_divisor(loc, divisor);
@@ -1139,6 +1152,12 @@ impl Renderer {
         gl.delete_program(Some(&programs.arc.program));
         gl.delete_program(Some(&programs.thermal.program));
         gl.delete_program(Some(&programs.texture.program));
+    }
+
+    fn delete_buffer_caches(gl: &WebGl2RenderingContext, caches: &mut Vec<BufferCache>) {
+        for cache in caches.drain(..) {
+            Self::delete_buffer_cache(gl, cache);
+        }
     }
 
     fn delete_buffer_cache(gl: &WebGl2RenderingContext, cache: BufferCache) {

--- a/wasm/src/shape.rs
+++ b/wasm/src/shape.rs
@@ -1,4 +1,40 @@
+use js_sys::{Array, Float32Array, Object, Reflect};
 use wasm_bindgen::prelude::*;
+
+fn set_property(object: &Object, key: &str, value: &JsValue) -> Result<(), JsValue> {
+    Reflect::set(object, &JsValue::from_str(key), value)
+        .map(|_| ())
+        .map_err(|_| JsValue::from_str(&format!("Failed to set parsed layer field `{key}`")))
+}
+
+fn get_property(value: &JsValue, key: &str) -> Result<JsValue, JsValue> {
+    Reflect::get(value, &JsValue::from_str(key))
+        .map_err(|_| JsValue::from_str(&format!("Missing parsed layer field `{key}`")))
+}
+
+fn f32_array_to_js(values: &[f32]) -> JsValue {
+    let array = Float32Array::new_with_length(values.len() as u32);
+    array.copy_from(values);
+    array.into()
+}
+
+fn f32_array_from_js(value: &JsValue, key: &str) -> Result<Vec<f32>, JsValue> {
+    Ok(Float32Array::new(&get_property(value, key)?).to_vec())
+}
+
+fn f32_property_from_js(value: &JsValue, key: &str) -> Result<f32, JsValue> {
+    let number = get_property(value, key)?
+        .as_f64()
+        .ok_or_else(|| JsValue::from_str(&format!("Parsed layer field `{key}` is not numeric")))?;
+    let value = number as f32;
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(JsValue::from_str(&format!(
+            "Parsed layer field `{key}` must be finite"
+        )))
+    }
+}
 
 fn translate_point_pairs(values: &mut [f32], dx: f32, dy: f32) {
     for point in values.chunks_exact_mut(2) {
@@ -51,6 +87,24 @@ impl Triangles {
         translate_point_pairs(&mut self.vertices, dx, dy);
         translate_components(&mut self.hole_x, &mut self.hole_y, dx, dy);
     }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "vertices", &f32_array_to_js(&self.vertices))?;
+        set_property(&object, "holeX", &f32_array_to_js(&self.hole_x))?;
+        set_property(&object, "holeY", &f32_array_to_js(&self.hole_y))?;
+        set_property(&object, "holeRadius", &f32_array_to_js(&self.hole_radius))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<Triangles, JsValue> {
+        Ok(Triangles::new(
+            f32_array_from_js(value, "vertices")?,
+            f32_array_from_js(value, "holeX")?,
+            f32_array_from_js(value, "holeY")?,
+            f32_array_from_js(value, "holeRadius")?,
+        ))
+    }
 }
 
 /// Triangle mesh template rendered at many flash positions.
@@ -81,6 +135,22 @@ impl TriangleTemplateInstances {
 
     pub(crate) fn translate(&mut self, dx: f32, dy: f32) {
         translate_components(&mut self.instance_x, &mut self.instance_y, dx, dy);
+    }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "vertices", &f32_array_to_js(&self.vertices))?;
+        set_property(&object, "instanceX", &f32_array_to_js(&self.instance_x))?;
+        set_property(&object, "instanceY", &f32_array_to_js(&self.instance_y))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<TriangleTemplateInstances, JsValue> {
+        Ok(TriangleTemplateInstances::new(
+            f32_array_from_js(value, "vertices")?,
+            f32_array_from_js(value, "instanceX")?,
+            f32_array_from_js(value, "instanceY")?,
+        ))
     }
 }
 
@@ -126,6 +196,28 @@ impl Circles {
         translate_components(&mut self.x, &mut self.y, dx, dy);
         translate_components(&mut self.hole_x, &mut self.hole_y, dx, dy);
     }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "x", &f32_array_to_js(&self.x))?;
+        set_property(&object, "y", &f32_array_to_js(&self.y))?;
+        set_property(&object, "radius", &f32_array_to_js(&self.radius))?;
+        set_property(&object, "holeX", &f32_array_to_js(&self.hole_x))?;
+        set_property(&object, "holeY", &f32_array_to_js(&self.hole_y))?;
+        set_property(&object, "holeRadius", &f32_array_to_js(&self.hole_radius))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<Circles, JsValue> {
+        Ok(Circles::new(
+            f32_array_from_js(value, "x")?,
+            f32_array_from_js(value, "y")?,
+            f32_array_from_js(value, "radius")?,
+            f32_array_from_js(value, "holeX")?,
+            f32_array_from_js(value, "holeY")?,
+            f32_array_from_js(value, "holeRadius")?,
+        ))
+    }
 }
 
 /// Arc primitive data structure
@@ -169,6 +261,28 @@ impl Arcs {
     pub(crate) fn translate(&mut self, dx: f32, dy: f32) {
         translate_components(&mut self.x, &mut self.y, dx, dy);
     }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "x", &f32_array_to_js(&self.x))?;
+        set_property(&object, "y", &f32_array_to_js(&self.y))?;
+        set_property(&object, "radius", &f32_array_to_js(&self.radius))?;
+        set_property(&object, "startAngle", &f32_array_to_js(&self.start_angle))?;
+        set_property(&object, "sweepAngle", &f32_array_to_js(&self.sweep_angle))?;
+        set_property(&object, "thickness", &f32_array_to_js(&self.thickness))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<Arcs, JsValue> {
+        Ok(Arcs::new(
+            f32_array_from_js(value, "x")?,
+            f32_array_from_js(value, "y")?,
+            f32_array_from_js(value, "radius")?,
+            f32_array_from_js(value, "startAngle")?,
+            f32_array_from_js(value, "sweepAngle")?,
+            f32_array_from_js(value, "thickness")?,
+        ))
+    }
 }
 
 /// Thermal primitive data structure
@@ -211,6 +325,40 @@ impl Thermals {
 
     pub(crate) fn translate(&mut self, dx: f32, dy: f32) {
         translate_components(&mut self.x, &mut self.y, dx, dy);
+    }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "x", &f32_array_to_js(&self.x))?;
+        set_property(&object, "y", &f32_array_to_js(&self.y))?;
+        set_property(
+            &object,
+            "outerDiameter",
+            &f32_array_to_js(&self.outer_diameter),
+        )?;
+        set_property(
+            &object,
+            "innerDiameter",
+            &f32_array_to_js(&self.inner_diameter),
+        )?;
+        set_property(
+            &object,
+            "gapThickness",
+            &f32_array_to_js(&self.gap_thickness),
+        )?;
+        set_property(&object, "rotation", &f32_array_to_js(&self.rotation))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<Thermals, JsValue> {
+        Ok(Thermals::new(
+            f32_array_from_js(value, "x")?,
+            f32_array_from_js(value, "y")?,
+            f32_array_from_js(value, "outerDiameter")?,
+            f32_array_from_js(value, "innerDiameter")?,
+            f32_array_from_js(value, "gapThickness")?,
+            f32_array_from_js(value, "rotation")?,
+        ))
     }
 }
 
@@ -260,6 +408,24 @@ impl Boundary {
         self.max_x += dx;
         self.min_y += dy;
         self.max_y += dy;
+    }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "minX", &JsValue::from_f64(self.min_x as f64))?;
+        set_property(&object, "maxX", &JsValue::from_f64(self.max_x as f64))?;
+        set_property(&object, "minY", &JsValue::from_f64(self.min_y as f64))?;
+        set_property(&object, "maxY", &JsValue::from_f64(self.max_y as f64))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<Boundary, JsValue> {
+        Ok(Boundary::new(
+            f32_property_from_js(value, "minX")?,
+            f32_property_from_js(value, "maxX")?,
+            f32_property_from_js(value, "minY")?,
+            f32_property_from_js(value, "maxY")?,
+        ))
     }
 }
 
@@ -317,4 +483,62 @@ impl GerberData {
         self.thermals.translate(dx, dy);
         self.boundary.translate(dx, dy);
     }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        let templates = Array::new();
+        for template in &self.triangle_templates {
+            templates.push(&template.to_js()?);
+        }
+
+        set_property(&object, "triangles", &self.triangles.to_js()?)?;
+        set_property(&object, "triangleTemplates", &templates.into())?;
+        set_property(&object, "circles", &self.circles.to_js()?)?;
+        set_property(&object, "arcs", &self.arcs.to_js()?)?;
+        set_property(&object, "thermals", &self.thermals.to_js()?)?;
+        set_property(&object, "boundary", &self.boundary.to_js()?)?;
+        set_property(&object, "isNegative", &JsValue::from_bool(self.is_negative))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<GerberData, JsValue> {
+        let template_values = Array::from(&get_property(value, "triangleTemplates")?);
+        let mut triangle_templates = Vec::with_capacity(template_values.length() as usize);
+        for template_value in template_values.iter() {
+            triangle_templates.push(TriangleTemplateInstances::from_js(&template_value)?);
+        }
+
+        Ok(GerberData::new(
+            Triangles::from_js(&get_property(value, "triangles")?)?,
+            triangle_templates,
+            Circles::from_js(&get_property(value, "circles")?)?,
+            Arcs::from_js(&get_property(value, "arcs")?)?,
+            Thermals::from_js(&get_property(value, "thermals")?)?,
+            Boundary::from_js(&get_property(value, "boundary")?)?,
+            get_property(value, "isNegative")?
+                .as_bool()
+                .unwrap_or(false),
+        ))
+    }
+}
+
+pub(crate) fn gerber_data_layers_to_js(layers: &[GerberData]) -> Result<JsValue, JsValue> {
+    let object = Object::new();
+    let sublayers = Array::new();
+    for layer in layers {
+        sublayers.push(&layer.to_js()?);
+    }
+
+    set_property(&object, "sublayers", &sublayers.into())?;
+    Ok(object.into())
+}
+
+pub(crate) fn gerber_data_layers_from_js(value: &JsValue) -> Result<Vec<GerberData>, JsValue> {
+    let sublayer_values = Array::from(&get_property(value, "sublayers")?);
+    let mut layers = Vec::with_capacity(sublayer_values.length() as usize);
+    for sublayer_value in sublayer_values.iter() {
+        layers.push(GerberData::from_js(&sublayer_value)?);
+    }
+
+    Ok(layers)
 }


### PR DESCRIPTION
## Summary
- remove temporary Gerber benchmark console/JSON logging
- recycle parse workers after large WASM memory growth and use a more conservative parse memory estimate
- add a flat render-payload path so worker parsed buffers upload directly to WebGL without rebuilding main-WASM GerberData geometry

## Tests
- node --check js/main.js
- node --check js/gerber-parse-worker.js
- cargo test --manifest-path wasm/Cargo.toml
- wasm-pack build wasm --target web --out-dir pkg --release