### PR TITLE
Add instanced minimum line width rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,6 +296,40 @@
                       </div>
                     </div>
                   </div>
+                  <div class="option-outline">
+                    <div class="option-row">
+                      <span>Minimum Line Width</span>
+                      <div class="segmented-control three-up" role="radiogroup" aria-label="Minimum line width">
+                        <label>
+                          <input
+                            type="radio"
+                            id="minimum-visibility-off"
+                            name="minimum-visibility"
+                            value="0"
+                          />
+                          <span>Off</span>
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            id="minimum-visibility-1"
+                            name="minimum-visibility"
+                            value="1"
+                          />
+                          <span>1px</span>
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            id="minimum-visibility-2"
+                            name="minimum-visibility"
+                            value="2"
+                          />
+                          <span>2px</span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
                 </section>
 
                 <section class="options-section filter-form">

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -97,6 +97,18 @@ export function getViewerElements(documentRef = document) {
     arcQualityLowInput: requireElement(documentRef, "arc-quality-low"),
     arcQualityNormalInput: requireElement(documentRef, "arc-quality-normal"),
     arcQualityHighInput: requireElement(documentRef, "arc-quality-high"),
+    minimumVisibilityOffInput: requireElement(
+      documentRef,
+      "minimum-visibility-off",
+    ),
+    minimumVisibility1Input: requireElement(
+      documentRef,
+      "minimum-visibility-1",
+    ),
+    minimumVisibility2Input: requireElement(
+      documentRef,
+      "minimum-visibility-2",
+    ),
     topFilterInput: requireElement(documentRef, "top-filter-input"),
     bottomFilterInput: requireElement(documentRef, "bottom-filter-input"),
     filterSaveBtn: requireElement(documentRef, "filter-save-btn"),

--- a/js/main.js
+++ b/js/main.js
@@ -54,6 +54,7 @@ const ARC_TESSELLATION_QUALITY_LEVELS = {
   normal: 1,
   high: 2,
 };
+const MINIMUM_FEATURE_PIXEL_VALUES = new Set([0, 1, 2]);
 
 class ParseWorkerUnavailableError extends Error {
   constructor(message) {
@@ -512,6 +513,9 @@ export class GerberViewer {
     );
     this.arcTessellationQuality =
       this.viewerOptionsStore.get("arcTessellationQuality") ?? "normal";
+    this.minimumFeaturePixels = Number(
+      this.viewerOptionsStore.get("minimumFeaturePixels") ?? 0,
+    );
     this.drawerController = new DrawerController({
       drawer: this.drawer,
       resizeHandle: this.resizeHandle,
@@ -549,6 +553,7 @@ export class GerberViewer {
       getWasmProcessor: () => this.wasmProcessor,
       getLayers: () => this.layers,
       getParseOptions: () => this.getParseOptions(),
+      getRenderOptions: () => this.getRenderOptions(),
       getRenderState: (rect) => ({
         viewScaleX: this.getViewScaleX(),
         viewScaleY: this.getViewScaleY(),
@@ -642,6 +647,10 @@ export class GerberViewer {
 
     if (typeof processor?.set_arc_tessellation_quality === "function") {
       processor.set_arc_tessellation_quality(this.getArcTessellationQualityLevel());
+    }
+
+    if (typeof processor?.set_minimum_feature_pixels === "function") {
+      processor.set_minimum_feature_pixels(this.minimumFeaturePixels);
     }
   }
 
@@ -879,6 +888,14 @@ export class GerberViewer {
       });
     }
 
+    for (const input of this.getMinimumVisibilityInputs()) {
+      input.addEventListener("change", () => {
+        if (input.checked) {
+          this.setMinimumFeaturePixels(Number(input.value));
+        }
+      });
+    }
+
     this.topFilterInput.addEventListener("input", () => {
       this.updateLayerFilter("top", this.topFilterInput.value);
     });
@@ -1056,6 +1073,12 @@ export class GerberViewer {
     };
   }
 
+  getRenderOptions() {
+    return {
+      minimumFeaturePixels: this.minimumFeaturePixels,
+    };
+  }
+
   getArcTessellationQualityLevel() {
     return ARC_TESSELLATION_QUALITY_LEVELS[this.arcTessellationQuality] ?? 1;
   }
@@ -1068,6 +1091,14 @@ export class GerberViewer {
     ];
   }
 
+  getMinimumVisibilityInputs() {
+    return [
+      this.minimumVisibilityOffInput,
+      this.minimumVisibility1Input,
+      this.minimumVisibility2Input,
+    ];
+  }
+
   syncOptionControls() {
     this.regionArcExactInput.checked = this.preserveArcRegions;
     this.regionArcApproximateInput.checked = !this.preserveArcRegions;
@@ -1075,6 +1106,11 @@ export class GerberViewer {
     for (const input of this.getArcQualityInputs()) {
       input.checked = input.value === this.arcTessellationQuality;
       input.disabled = this.preserveArcRegions || this.isRendererBusy();
+    }
+
+    for (const input of this.getMinimumVisibilityInputs()) {
+      input.checked = Number(input.value) === this.minimumFeaturePixels;
+      input.disabled = this.isRendererBusy();
     }
   }
 
@@ -1183,6 +1219,46 @@ export class GerberViewer {
       );
       this.configureWasmProcessorOptions(this.wasmProcessor);
       this.showError(`Failed to apply arc quality option: ${getErrorMessage(error)}`);
+    } finally {
+      this.updateUiState();
+    }
+  }
+
+  setMinimumFeaturePixels(pixels) {
+    if (!MINIMUM_FEATURE_PIXEL_VALUES.has(pixels)) {
+      this.syncOptionControls();
+      return;
+    }
+    if (pixels === this.minimumFeaturePixels) {
+      return;
+    }
+    if (this.isRendererBusy()) {
+      this.syncOptionControls();
+      return;
+    }
+
+    const previousPixels = this.minimumFeaturePixels;
+    this.minimumFeaturePixels = pixels;
+    this.syncOptionControls();
+    this.viewerOptionsStore.set(
+      "minimumFeaturePixels",
+      this.minimumFeaturePixels,
+    );
+
+    try {
+      if (typeof this.wasmProcessor?.set_minimum_feature_pixels === "function") {
+        this.wasmProcessor.set_minimum_feature_pixels(this.minimumFeaturePixels);
+      }
+      this.render();
+    } catch (error) {
+      this.minimumFeaturePixels = previousPixels;
+      this.syncOptionControls();
+      this.viewerOptionsStore.set(
+        "minimumFeaturePixels",
+        this.minimumFeaturePixels,
+      );
+      this.configureWasmProcessorOptions(this.wasmProcessor);
+      this.showError(`Failed to apply minimum line width: ${getErrorMessage(error)}`);
     } finally {
       this.updateUiState();
     }
@@ -1349,6 +1425,9 @@ export class GerberViewer {
     this.regionArcApproximateInput.disabled = rendererBusy;
     for (const input of this.getArcQualityInputs()) {
       input.disabled = rendererBusy || this.preserveArcRegions;
+    }
+    for (const input of this.getMinimumVisibilityInputs()) {
+      input.disabled = rendererBusy;
     }
 
     this.visibleLayerCount.textContent = `${visibleLayers} / ${totalLayers}`;

--- a/js/screenshot-exporter.js
+++ b/js/screenshot-exporter.js
@@ -35,6 +35,7 @@ export class ScreenshotExporter {
     getWasmProcessor,
     getLayers,
     getParseOptions,
+    getRenderOptions,
     getRenderState,
     isWebGlUnavailable,
     drawMeasurements,
@@ -58,6 +59,7 @@ export class ScreenshotExporter {
     this.getWasmProcessor = getWasmProcessor;
     this.getLayers = getLayers;
     this.getParseOptions = getParseOptions;
+    this.getRenderOptions = getRenderOptions;
     this.getRenderState = getRenderState;
     this.isWebGlUnavailable = isWebGlUnavailable;
     this.drawMeasurements = drawMeasurements;
@@ -345,6 +347,12 @@ export class ScreenshotExporter {
       Number(parseOptions.arcTessellationQuality ?? 1) !== 1
     ) {
       throw new Error("Arc tessellation quality requires an updated WASM module.");
+    }
+    const renderOptions = this.getRenderOptions?.() ?? {};
+    if (typeof processor.set_minimum_feature_pixels === "function") {
+      processor.set_minimum_feature_pixels(
+        Number(renderOptions.minimumFeaturePixels ?? 0),
+      );
     }
 
     const activeLayerIds = [];

--- a/js/viewer-options.js
+++ b/js/viewer-options.js
@@ -1,9 +1,11 @@
 const DEFAULT_VIEWER_OPTIONS = {
   preserveArcRegions: true,
   arcTessellationQuality: "normal",
+  minimumFeaturePixels: 0,
 };
 
 const ARC_TESSELLATION_QUALITIES = new Set(["low", "normal", "high"]);
+const MINIMUM_FEATURE_PIXELS = new Set([0, 1, 2]);
 
 function createMemoryStorage() {
   const values = new Map();
@@ -54,6 +56,11 @@ export class ViewerOptionsStore {
         )
           ? stored.arcTessellationQuality
           : DEFAULT_VIEWER_OPTIONS.arcTessellationQuality,
+        minimumFeaturePixels: MINIMUM_FEATURE_PIXELS.has(
+          stored.minimumFeaturePixels,
+        )
+          ? stored.minimumFeaturePixels
+          : DEFAULT_VIEWER_OPTIONS.minimumFeaturePixels,
       };
     } catch {
       return this.getDefaults();

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -117,6 +117,7 @@ pub struct GerberProcessor {
     renderer: Option<Renderer>,
     preserve_arc_regions: bool,
     arc_tessellation_quality: u32,
+    minimum_feature_pixels: f32,
 }
 
 impl Default for GerberProcessor {
@@ -126,6 +127,7 @@ impl Default for GerberProcessor {
             renderer: None,
             preserve_arc_regions: true,
             arc_tessellation_quality: 1,
+            minimum_feature_pixels: 0.0,
         }
     }
 }
@@ -176,7 +178,9 @@ impl GerberProcessor {
     /// * `"init_done"` signal on success
     pub fn init(&mut self, gl: WebGl2RenderingContext) -> Result<String, JsValue> {
         // Create renderer with WebGL context (initially no layers)
-        self.renderer = Some(Renderer::new(gl.clone())?);
+        let mut renderer = Renderer::new(gl.clone())?;
+        renderer.set_minimum_feature_pixels(self.minimum_feature_pixels);
+        self.renderer = Some(renderer);
         self.gl = Some(gl);
         Ok("init_done".to_string())
     }
@@ -196,6 +200,23 @@ impl GerberProcessor {
         self.arc_tessellation_quality = arc_tessellation_quality.min(2);
     }
 
+    /// Configure minimum display size for tiny rendered features.
+    ///
+    /// `0.0` disables the adjustment. Current implementation applies to
+    /// triangle mesh bodies and circle flashes, which covers standard line
+    /// draws represented as two cap flashes plus two body triangles.
+    pub fn set_minimum_feature_pixels(&mut self, pixels: f32) {
+        self.minimum_feature_pixels = if pixels.is_finite() {
+            pixels.clamp(0.0, 8.0)
+        } else {
+            0.0
+        };
+
+        if let Some(renderer) = &mut self.renderer {
+            renderer.set_minimum_feature_pixels(self.minimum_feature_pixels);
+        }
+    }
+
     /// Recreate WebGL-owned resources after browser context restoration.
     ///
     /// This can recreate GPU resources only while parsed geometry is still retained.
@@ -205,7 +226,9 @@ impl GerberProcessor {
         if let Some(renderer) = &mut self.renderer {
             renderer.restore_context(gl.clone())?;
         } else {
-            self.renderer = Some(Renderer::new(gl.clone())?);
+            let mut renderer = Renderer::new(gl.clone())?;
+            renderer.set_minimum_feature_pixels(self.minimum_feature_pixels);
+            self.renderer = Some(renderer);
         }
 
         self.gl = Some(gl);

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -16,7 +16,7 @@ use state::{
 
 use self::geometry::{parse_graphic_command, Primitive, RegionContour};
 use crate::shape::{
-    Arcs, Boundary, Circles, GerberData, PathRegions, Thermals, TriangleTemplateInstances,
+    Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
     Triangles,
 };
 use std::collections::HashMap;
@@ -44,6 +44,7 @@ struct PrimitiveBufferCounts {
     triangles: usize,
     has_triangle_holes: bool,
     triangle_template_instance_counts: HashMap<usize, usize>,
+    lines: usize,
     circles: usize,
     has_circle_holes: bool,
     arcs: usize,
@@ -63,6 +64,7 @@ impl PrimitiveBufferCounts {
             }
             Primitive::Arc { .. } => self.arcs += 1,
             Primitive::Thermal { .. } => self.thermals += 1,
+            Primitive::Line { .. } => self.lines += 1,
             Primitive::TriangleTemplateFlash { template, .. } => {
                 let key = std::rc::Rc::as_ptr(template) as usize;
                 *self
@@ -103,6 +105,7 @@ fn primitive_has_hole(primitive: &Primitive) -> bool {
         }
         Primitive::Arc { .. }
         | Primitive::Thermal { .. }
+        | Primitive::Line { .. }
         | Primitive::TriangleTemplateFlash { .. } => false,
     }
 }
@@ -122,6 +125,11 @@ struct PrimitiveOutputBuffers {
     triangle_templates: Vec<TriangleTemplateOutputBuffers>,
     triangle_template_indices: HashMap<usize, usize>,
     triangle_template_instance_counts: HashMap<usize, usize>,
+    lines_start_x: Vec<f32>,
+    lines_start_y: Vec<f32>,
+    lines_end_x: Vec<f32>,
+    lines_end_y: Vec<f32>,
+    lines_width: Vec<f32>,
     has_circle_holes: bool,
     circles_x: Vec<f32>,
     circles_y: Vec<f32>,
@@ -157,6 +165,11 @@ impl PrimitiveOutputBuffers {
             triangle_templates: Vec::new(),
             triangle_template_indices: HashMap::new(),
             triangle_template_instance_counts: counts.triangle_template_instance_counts.clone(),
+            lines_start_x: Vec::new(),
+            lines_start_y: Vec::new(),
+            lines_end_x: Vec::new(),
+            lines_end_y: Vec::new(),
+            lines_width: Vec::new(),
             has_circle_holes: counts.has_circle_holes,
             circles_x: Vec::new(),
             circles_y: Vec::new(),
@@ -215,6 +228,20 @@ impl PrimitiveOutputBuffers {
                     "Gerber layer is too large to render: not enough memory for triangle template index map",
                 )
             })?;
+
+        try_reserve_exact(
+            &mut buffers.lines_start_x,
+            counts.lines,
+            "line start X buffer",
+        )?;
+        try_reserve_exact(
+            &mut buffers.lines_start_y,
+            counts.lines,
+            "line start Y buffer",
+        )?;
+        try_reserve_exact(&mut buffers.lines_end_x, counts.lines, "line end X buffer")?;
+        try_reserve_exact(&mut buffers.lines_end_y, counts.lines, "line end Y buffer")?;
+        try_reserve_exact(&mut buffers.lines_width, counts.lines, "line width buffer")?;
 
         try_reserve_exact(&mut buffers.circles_x, counts.circles, "circle X buffer")?;
         try_reserve_exact(&mut buffers.circles_y, counts.circles, "circle Y buffer")?;
@@ -345,6 +372,20 @@ impl PrimitiveOutputBuffers {
                 self.arcs_sweep_angle.push(end_angle - start_angle);
                 self.arcs_thickness.push(thickness * TO_MM);
             }
+            Primitive::Line {
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+                width,
+                ..
+            } => {
+                self.lines_start_x.push(start_x * TO_MM);
+                self.lines_start_y.push(start_y * TO_MM);
+                self.lines_end_x.push(end_x * TO_MM);
+                self.lines_end_y.push(end_y * TO_MM);
+                self.lines_width.push(width * TO_MM);
+            }
             Primitive::Thermal {
                 x,
                 y,
@@ -434,6 +475,13 @@ impl PrimitiveOutputBuffers {
                 self.triangle_hole_radius,
             ),
             triangle_templates,
+            Lines::new(
+                self.lines_start_x,
+                self.lines_start_y,
+                self.lines_end_x,
+                self.lines_end_y,
+                self.lines_width,
+            ),
             Circles::new(
                 self.circles_x,
                 self.circles_y,
@@ -470,6 +518,7 @@ impl PrimitiveOutputBuffers {
                 .triangle_templates
                 .iter()
                 .any(|template| !template.vertices.is_empty() && !template.instance_x.is_empty())
+            || !self.lines_start_x.is_empty()
             || !self.circles_x.is_empty()
             || !self.arcs_x.is_empty()
             || !self.thermals_x.is_empty()
@@ -514,6 +563,18 @@ impl PrimitiveOutputBuffers {
                 min_y = min_y.min(template_min_y + y);
                 max_y = max_y.max(template_max_y + y);
             }
+        }
+
+        for i in 0..self.lines_start_x.len() {
+            let sx = self.lines_start_x[i];
+            let sy = self.lines_start_y[i];
+            let ex = self.lines_end_x[i];
+            let ey = self.lines_end_y[i];
+            let half_width = self.lines_width[i] * 0.5;
+            min_x = min_x.min(sx.min(ex) - half_width);
+            max_x = max_x.max(sx.max(ex) + half_width);
+            min_y = min_y.min(sy.min(ey) - half_width);
+            max_y = max_y.max(sy.max(ey) + half_width);
         }
 
         for i in 0..self.circles_x.len() {

--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -407,6 +407,7 @@ pub fn parse_aperture(
         Primitive::Triangle { exposure, .. } => *exposure < 0.5,
         Primitive::Arc { exposure, .. } => *exposure < 0.5,
         Primitive::Thermal { exposure, .. } => *exposure < 0.5,
+        Primitive::Line { exposure, .. } => *exposure < 0.5,
         Primitive::TriangleTemplateFlash { .. } => false,
     });
     aperture.triangle_template = build_triangle_template(&aperture.primitives);

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -146,6 +146,14 @@ pub enum Primitive {
         x: f32,
         y: f32,
     },
+    Line {
+        start_x: f32,
+        start_y: f32,
+        end_x: f32,
+        end_y: f32,
+        width: f32,
+        exposure: f32,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -303,6 +311,20 @@ pub fn scale_primitive(primitive: &mut Primitive, scale: f32) {
             *x *= scale;
             *y *= scale;
         }
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+            ..
+        } => {
+            *start_x *= scale;
+            *start_y *= scale;
+            *end_x *= scale;
+            *end_y *= scale;
+            *width *= scale;
+        }
     }
 }
 
@@ -404,6 +426,22 @@ pub fn mirror_primitive(primitive: &mut Primitive, mirror_x: bool, mirror_y: boo
                 *y = -*y;
             }
         }
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            ..
+        } => {
+            if mirror_x {
+                *start_x = -*start_x;
+                *end_x = -*end_x;
+            }
+            if mirror_y {
+                *start_y = -*start_y;
+                *end_y = -*end_y;
+            }
+        }
     }
 }
 
@@ -484,6 +522,22 @@ pub fn rotate_primitive(primitive: &mut Primitive, angle: f32) {
             *x = center[0];
             *y = center[1];
         }
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            ..
+        } => {
+            let mut start = [*start_x, *start_y];
+            let mut end = [*end_x, *end_y];
+            rotate_point(&mut start, angle, 0.0, 0.0);
+            rotate_point(&mut end, angle, 0.0, 0.0);
+            *start_x = start[0];
+            *start_y = start[1];
+            *end_x = end[0];
+            *end_y = end[1];
+        }
     }
 }
 
@@ -530,7 +584,30 @@ pub fn triangulate_outline(vertices: &[[f32; 2]], exposure: f32) -> Result<Vec<P
     }
 }
 
-/// Split line into two triangles (including width)
+/// Store a stroked straight line body for instanced rendering.
+pub fn line_to_body(
+    start_x: f32,
+    start_y: f32,
+    end_x: f32,
+    end_y: f32,
+    width: f32,
+    exposure: f32,
+) -> Option<Primitive> {
+    if width <= 0.0 || points_coincide(start_x, start_y, end_x, end_y) {
+        return None;
+    }
+
+    Some(Primitive::Line {
+        start_x,
+        start_y,
+        end_x,
+        end_y,
+        width,
+        exposure,
+    })
+}
+
+/// Split a macro line primitive into two triangles.
 pub fn line_to_triangles(
     start_x: f32,
     start_y: f32,
@@ -539,7 +616,6 @@ pub fn line_to_triangles(
     width: f32,
     exposure: f32,
 ) -> Vec<Primitive> {
-    // Line direction vector
     let dx = end_x - start_x;
     let dy = end_y - start_y;
     let len = (dx * dx + dy * dy).sqrt();
@@ -548,18 +624,15 @@ pub fn line_to_triangles(
         return Vec::new();
     }
 
-    // Perpendicular vector (width direction)
     let half_width = width / 2.0;
     let perp_x = -dy / len * half_width;
     let perp_y = dx / len * half_width;
 
-    // 4 vertices on both sides of the line
     let v1 = [start_x + perp_x, start_y + perp_y];
     let v2 = [start_x - perp_x, start_y - perp_y];
     let v3 = [end_x + perp_x, end_y + perp_y];
     let v4 = [end_x - perp_x, end_y - perp_y];
 
-    // Two triangles: (v1, v2, v3), (v2, v4, v3)
     vec![
         Primitive::Triangle {
             vertices: [v1, v2, v3],
@@ -650,6 +723,30 @@ pub fn primitive_to_polygon(primitive: &Primitive) -> Vec<[f32; 2]> {
             .chunks_exact(2)
             .map(|point| [point[0] + *x, point[1] + *y])
             .collect(),
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+            ..
+        } => {
+            let dx = end_x - start_x;
+            let dy = end_y - start_y;
+            let len = (dx * dx + dy * dy).sqrt();
+            if len <= f32::EPSILON {
+                return Vec::new();
+            }
+            let half_width = width * 0.5;
+            let perp_x = -dy / len * half_width;
+            let perp_y = dx / len * half_width;
+            vec![
+                [start_x + perp_x, start_y + perp_y],
+                [end_x + perp_x, end_y + perp_y],
+                [end_x - perp_x, end_y - perp_y],
+                [start_x - perp_x, start_y - perp_y],
+            ]
+        }
     }
 }
 
@@ -856,6 +953,21 @@ pub fn offset_primitive_by(primitive: &Primitive, dx: f32, dy: f32) -> Primitive
             x: x + dx,
             y: y + dy,
         },
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+            exposure,
+        } => Primitive::Line {
+            start_x: start_x + dx,
+            start_y: start_y + dy,
+            end_x: end_x + dx,
+            end_y: end_y + dy,
+            width: *width,
+            exposure: *exposure,
+        },
     }
 }
 
@@ -953,6 +1065,7 @@ fn flash_aperture_no_sr(
                     Primitive::Triangle { exposure, .. } => *exposure,
                     Primitive::Arc { exposure, .. } => *exposure,
                     Primitive::Thermal { exposure, .. } => *exposure,
+                    Primitive::Line { exposure, .. } => *exposure,
                     Primitive::TriangleTemplateFlash { .. } => 1.0,
                 };
                 // Wrap polygon in shape format (single contour)
@@ -1021,6 +1134,18 @@ fn flash_aperture_no_sr(
                 Primitive::TriangleTemplateFlash { x: tx, y: ty, .. } => {
                     *tx += x;
                     *ty += y;
+                }
+                Primitive::Line {
+                    start_x,
+                    start_y,
+                    end_x,
+                    end_y,
+                    ..
+                } => {
+                    *start_x += x;
+                    *start_y += y;
+                    *end_x += x;
+                    *end_y += y;
                 }
             }
             primitives.push(new_primitive);
@@ -1246,17 +1371,15 @@ pub fn execute_interpolation(
                             state.layer_rotation,
                         )?;
 
-                        // Convert vector line with width of aperture diameter to triangle
+                        // Store line body separately from the two round cap flashes so
+                        // the renderer can keep it instanced and clamp screen thickness.
                         let diameter = aperture.radius * 2.0 * state.layer_scale;
-                        let line_triangles = line_to_triangles(
-                            sr_start_x, sr_start_y, sr_end_x, sr_end_y, diameter, 1.0,
-                        );
-                        try_reserve_primitives(
-                            primitives,
-                            line_triangles.len(),
-                            "linear interpolation",
-                        )?;
-                        primitives.extend(line_triangles);
+                        if let Some(line) =
+                            line_to_body(sr_start_x, sr_start_y, sr_end_x, sr_end_y, diameter, 1.0)
+                        {
+                            try_reserve_primitives(primitives, 1, "linear interpolation")?;
+                            primitives.push(line);
+                        }
 
                         // Flash aperture at end point (no SR since we're already in SR loop)
                         flash_aperture_no_sr(

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1379,7 +1379,31 @@ M02*",
     assert_eq!(layer.circles.x.len(), 2);
     assert!(has_circle_at(&layer.circles, 0.0, 0.0, 0.5));
     assert!(has_circle_at(&layer.circles, 1.0, 0.0, 0.5));
-    assert!(!layer.triangles.vertices.is_empty());
+    assert!(layer.triangles.vertices.is_empty());
+    assert_eq!(layer.lines.start_x, vec![0.0]);
+    assert_eq!(layer.lines.start_y, vec![0.0]);
+    assert_eq!(layer.lines.end_x, vec![1.0]);
+    assert_eq!(layer.lines.end_y, vec![0.0]);
+    assert_eq!(layer.lines.width, vec![1.0]);
+}
+
+#[test]
+fn zero_width_solid_circle_draw_does_not_create_line_body() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,0.0*%
+D10*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+M02*",
+    )
+    .expect("zero-width solid circle D01 should parse");
+    let layer = &layers[0];
+
+    assert!(layer.lines.start_x.is_empty());
+    assert!(layer.triangles.vertices.is_empty());
 }
 
 #[test]
@@ -1400,6 +1424,7 @@ M02*",
     assert_eq!(layer.circles.x.len(), 1);
     assert!(has_circle_at(&layer.circles, 0.0, 0.0, 0.5));
     assert!(layer.triangles.vertices.is_empty());
+    assert!(layer.lines.start_x.is_empty());
 }
 
 #[test]

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -12,7 +12,7 @@ use shader::{
 };
 
 use crate::shape::{
-    Arcs, Boundary, Circles, GerberData, PathRegions, Thermals, TriangleTemplateInstances,
+    Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
     Triangles,
 };
 use js_sys::{Array, Float32Array, Reflect, Uint32Array};
@@ -39,6 +39,7 @@ pub struct Renderer {
     programs: ShaderPrograms,
     camera: Camera,
     quad_buffer: WebGlBuffer, // Shared quad buffer for all layers
+    minimum_feature_pixels: f32,
 }
 
 impl Renderer {
@@ -57,7 +58,27 @@ impl Renderer {
             programs,
             camera: Camera::new(),
             quad_buffer,
+            minimum_feature_pixels: 0.0,
         })
+    }
+
+    /// Configure a display-space minimum feature size in CSS/device pixels.
+    ///
+    /// This is applied in the WebGL shaders and only affects rendering. Parsed
+    /// geometry and layer bounds remain unchanged.
+    pub fn set_minimum_feature_pixels(&mut self, pixels: f32) {
+        let next_pixels = if pixels.is_finite() {
+            pixels.clamp(0.0, 8.0)
+        } else {
+            0.0
+        };
+
+        if (self.minimum_feature_pixels - next_pixels).abs() <= f32::EPSILON {
+            return;
+        }
+
+        self.minimum_feature_pixels = next_pixels;
+        self.mark_all_layers_dirty();
     }
 
     /// Add a new layer with parsed Gerber data
@@ -231,6 +252,7 @@ impl Renderer {
             (0..template_count)
                 .map(|_| TriangleTemplateInstances::new(Vec::new(), Vec::new(), Vec::new()))
                 .collect(),
+            Lines::new(Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new()),
             Circles::new(
                 Vec::new(),
                 Vec::new(),
@@ -269,6 +291,7 @@ impl Renderer {
         self.populate_triangle_cache_from_payload(buffer_cache, sublayer)?;
         let template_count =
             self.populate_triangle_template_cache_from_payload(buffer_cache, sublayer)?;
+        self.populate_line_cache_from_payload(buffer_cache, sublayer)?;
         self.populate_circle_cache_from_payload(buffer_cache, sublayer)?;
         self.populate_arc_cache_from_payload(buffer_cache, sublayer)?;
         self.populate_thermal_cache_from_payload(buffer_cache, sublayer)?;
@@ -438,6 +461,85 @@ impl Renderer {
         }
 
         Ok(template_count)
+    }
+
+    fn populate_line_cache_from_payload(
+        &self,
+        buffer_cache: &mut BufferCache,
+        sublayer: &JsValue,
+    ) -> Result<(), JsValue> {
+        let lines = Self::js_property(sublayer, "lines")?;
+        let start_x = Self::js_f32_array(&lines, "startX")?;
+        if start_x.length() == 0 {
+            return Ok(());
+        }
+
+        let instance_count = Self::validate_instance_array("line instances", &start_x)?;
+        let start_y = Self::js_f32_array(&lines, "startY")?;
+        let end_x = Self::js_f32_array(&lines, "endX")?;
+        let end_y = Self::js_f32_array(&lines, "endY")?;
+        let width = Self::js_f32_array(&lines, "width")?;
+        Self::validate_js_array_len("line start_y", &start_y, instance_count as u32)?;
+        Self::validate_js_array_len("line end_x", &end_x, instance_count as u32)?;
+        Self::validate_js_array_len("line end_y", &end_y, instance_count as u32)?;
+        Self::validate_js_array_len("line width", &width, instance_count as u32)?;
+        Self::validate_js_finite_array("line start_x", &start_x)?;
+        Self::validate_js_finite_array("line start_y", &start_y)?;
+        Self::validate_js_finite_array("line end_x", &end_x)?;
+        Self::validate_js_finite_array("line end_y", &end_y)?;
+        Self::validate_js_non_negative_array("line width", &width)?;
+
+        let vao = self
+            .gl
+            .create_vertex_array()
+            .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+        self.gl.bind_vertex_array(Some(&vao));
+        buffer_cache.line_vao = Some(vao);
+        buffer_cache.line_instance_count = instance_count;
+        self.bind_quad_position(&self.programs.line)?;
+        buffer_cache.line_start_x_buffer = Some(Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &start_x,
+            &self.programs.line,
+            "start_x_instance",
+            1,
+            1,
+        )?);
+        buffer_cache.line_start_y_buffer = Some(Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &start_y,
+            &self.programs.line,
+            "start_y_instance",
+            1,
+            1,
+        )?);
+        buffer_cache.line_end_x_buffer = Some(Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &end_x,
+            &self.programs.line,
+            "end_x_instance",
+            1,
+            1,
+        )?);
+        buffer_cache.line_end_y_buffer = Some(Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &end_y,
+            &self.programs.line,
+            "end_y_instance",
+            1,
+            1,
+        )?);
+        buffer_cache.line_width_buffer = Some(Self::create_attrib_buffer_from_js_array(
+            &self.gl,
+            &width,
+            &self.programs.line,
+            "width_instance",
+            1,
+            1,
+        )?);
+
+        self.gl.bind_vertex_array(None);
+        Ok(())
     }
 
     fn populate_circle_cache_from_payload(
@@ -1019,6 +1121,24 @@ impl Renderer {
         Ok(vertex_count as i32)
     }
 
+    fn set_view_feature_uniforms(
+        &self,
+        program: &ShaderProgram,
+        viewport_width: u32,
+        viewport_height: u32,
+    ) {
+        if let Some(loc) = program.uniforms.get("viewport_size") {
+            self.gl.uniform2f(
+                Some(loc),
+                viewport_width.max(1) as f32,
+                viewport_height.max(1) as f32,
+            );
+        }
+        if let Some(loc) = program.uniforms.get("minimum_feature_pixels") {
+            self.gl.uniform1f(Some(loc), self.minimum_feature_pixels);
+        }
+    }
+
     fn validate_instance_array(label: &str, values: &Float32Array) -> Result<i32, JsValue> {
         if values.length() > i32::MAX as u32 {
             return Err(JsValue::from_str(&format!(
@@ -1105,6 +1225,7 @@ impl Renderer {
     fn validate_gerber_data(data: &GerberData, sublayer_idx: usize) -> Result<(), JsValue> {
         Self::validate_triangle_data(&data.triangles, sublayer_idx)?;
         Self::validate_triangle_template_data(&data.triangle_templates, sublayer_idx)?;
+        Self::validate_line_data(&data.lines, sublayer_idx)?;
         Self::validate_circle_data(&data.circles, sublayer_idx)?;
         Self::validate_arc_data(&data.arcs, sublayer_idx)?;
         Self::validate_thermal_data(&data.thermals, sublayer_idx)?;
@@ -1207,6 +1328,21 @@ impl Renderer {
             }
         }
 
+        Ok(())
+    }
+
+    fn validate_line_data(lines: &Lines, sublayer_idx: usize) -> Result<(), JsValue> {
+        let count = lines.start_x.len();
+        Self::validate_instance_count("line", sublayer_idx, count)?;
+        Self::validate_len("line start_y", sublayer_idx, lines.start_y.len(), count)?;
+        Self::validate_len("line end_x", sublayer_idx, lines.end_x.len(), count)?;
+        Self::validate_len("line end_y", sublayer_idx, lines.end_y.len(), count)?;
+        Self::validate_len("line width", sublayer_idx, lines.width.len(), count)?;
+        Self::validate_finite_slice("line start_x", &lines.start_x)?;
+        Self::validate_finite_slice("line start_y", &lines.start_y)?;
+        Self::validate_finite_slice("line end_x", &lines.end_x)?;
+        Self::validate_finite_slice("line end_y", &lines.end_y)?;
+        Self::validate_non_negative_slice("line width", &lines.width)?;
         Ok(())
     }
 
@@ -1514,6 +1650,13 @@ impl Renderer {
         (0..count).map(|_| BufferCache::default()).collect()
     }
 
+    fn mark_all_layers_dirty(&mut self) {
+        for layer in self.layers.iter_mut().flatten() {
+            layer.fbo_dirty = true;
+            layer.fbo_transform = None;
+        }
+    }
+
     fn delete_layer_gpu_resources(gl: &WebGl2RenderingContext, layer: LayerMetadata) {
         Self::delete_fbo(gl, layer.fbo);
 
@@ -1533,6 +1676,7 @@ impl Renderer {
     fn delete_shader_programs(gl: &WebGl2RenderingContext, programs: &ShaderPrograms) {
         gl.delete_program(Some(&programs.triangle.program));
         gl.delete_program(Some(&programs.triangle_template.program));
+        gl.delete_program(Some(&programs.line.program));
         gl.delete_program(Some(&programs.circle.program));
         gl.delete_program(Some(&programs.arc.program));
         gl.delete_program(Some(&programs.thermal.program));
@@ -1576,6 +1720,25 @@ impl Renderer {
             if let Some(buf) = template_cache.instance_y_buffer {
                 gl.delete_buffer(Some(&buf));
             }
+        }
+
+        if let Some(vao) = cache.line_vao {
+            gl.delete_vertex_array(Some(&vao));
+        }
+        if let Some(buf) = cache.line_start_x_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.line_start_y_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.line_end_x_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.line_end_y_buffer {
+            gl.delete_buffer(Some(&buf));
+        }
+        if let Some(buf) = cache.line_width_buffer {
+            gl.delete_buffer(Some(&buf));
         }
 
         if let Some(vao) = cache.circle_vao {
@@ -2225,6 +2388,118 @@ impl Renderer {
                 .draw_arrays_instanced(TRIANGLES, 0, vertex_count, instance_count);
             self.gl.bind_vertex_array(None);
         }
+
+        Ok(())
+    }
+
+    /// Draw instanced straight line bodies.
+    fn draw_instanced_lines(
+        &mut self,
+        transform: &[f32; 9],
+        color: &[f32; 4],
+        layer_id: usize,
+        sublayer_idx: usize,
+        viewport_width: u32,
+        viewport_height: u32,
+    ) -> Result<(), JsValue> {
+        let program = &self.programs.line;
+        self.gl.use_program(Some(&program.program));
+
+        let instance_count = {
+            let layer = self.layers[layer_id]
+                .as_mut()
+                .ok_or_else(|| JsValue::from_str("Layer not found"))?;
+
+            if layer.buffer_caches[sublayer_idx].line_vao.is_none() {
+                let lines = &layer.gerber_data[sublayer_idx].lines;
+                if lines.start_x.is_empty() {
+                    return Ok(());
+                }
+                let instance_count = lines.start_x.len() as i32;
+
+                let vao = self
+                    .gl
+                    .create_vertex_array()
+                    .ok_or_else(|| JsValue::from_str("Failed to create VAO"))?;
+                self.gl.bind_vertex_array(Some(&vao));
+                self.gl.bind_buffer(ARRAY_BUFFER, Some(&self.quad_buffer));
+                let position_loc = Self::shader_attribute(program, "position")?;
+                self.gl.enable_vertex_attrib_array(position_loc);
+                self.gl
+                    .vertex_attrib_pointer_with_i32(position_loc, 2, FLOAT, false, 0, 0);
+
+                let start_x_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &lines.start_x,
+                    program,
+                    "start_x_instance",
+                    1,
+                )?;
+                let start_y_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &lines.start_y,
+                    program,
+                    "start_y_instance",
+                    1,
+                )?;
+                let end_x_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &lines.end_x,
+                    program,
+                    "end_x_instance",
+                    1,
+                )?;
+                let end_y_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &lines.end_y,
+                    program,
+                    "end_y_instance",
+                    1,
+                )?;
+                let width_buffer = Self::create_instance_buffer(
+                    &self.gl,
+                    &lines.width,
+                    program,
+                    "width_instance",
+                    1,
+                )?;
+
+                self.gl.bind_vertex_array(None);
+
+                let buffer_cache = &mut layer.buffer_caches[sublayer_idx];
+                buffer_cache.line_vao = Some(vao);
+                buffer_cache.line_instance_count = instance_count;
+                buffer_cache.line_start_x_buffer = Some(start_x_buffer);
+                buffer_cache.line_start_y_buffer = Some(start_y_buffer);
+                buffer_cache.line_end_x_buffer = Some(end_x_buffer);
+                buffer_cache.line_end_y_buffer = Some(end_y_buffer);
+                buffer_cache.line_width_buffer = Some(width_buffer);
+                layer.gerber_data[sublayer_idx].lines.release_cpu_geometry();
+                layer.cpu_geometry_released = true;
+            }
+
+            layer.buffer_caches[sublayer_idx].line_instance_count
+        };
+        if instance_count == 0 {
+            return Ok(());
+        }
+
+        let layer = self.get_layer(layer_id)?;
+        let buffer_cache = &layer.buffer_caches[sublayer_idx];
+        self.gl.bind_vertex_array(buffer_cache.line_vao.as_ref());
+
+        if let Some(loc) = program.uniforms.get("transform") {
+            self.gl
+                .uniform_matrix3fv_with_f32_array(Some(loc), false, transform);
+        }
+        if let Some(loc) = program.uniforms.get("color") {
+            self.gl.uniform4fv_with_f32_array(Some(loc), color);
+        }
+        self.set_view_feature_uniforms(program, viewport_width, viewport_height);
+
+        self.gl
+            .draw_arrays_instanced(TRIANGLES, 0, 6, instance_count);
+        self.gl.bind_vertex_array(None);
 
         Ok(())
     }
@@ -2929,6 +3204,8 @@ impl Renderer {
         &mut self,
         layer_id: usize,
         transform: &[f32; 9],
+        viewport_width: u32,
+        viewport_height: u32,
     ) -> Result<(), JsValue> {
         if layer_id >= self.layers.len() || self.layers[layer_id].is_none() {
             return Ok(());
@@ -2962,6 +3239,14 @@ impl Renderer {
                 &white_color,
                 layer_id,
                 sublayer_idx,
+            )?;
+            self.draw_instanced_lines(
+                transform,
+                &white_color,
+                layer_id,
+                sublayer_idx,
+                viewport_width,
+                viewport_height,
             )?;
             self.draw_instanced_circles(transform, &white_color, layer_id, sublayer_idx)?;
             self.draw_instanced_arcs(transform, &white_color, layer_id, sublayer_idx)?;
@@ -3096,7 +3381,7 @@ impl Renderer {
                 self.gl.clear(COLOR_BUFFER_BIT);
 
                 // Render layer geometry (with polarity blending handled internally)
-                self.render_layer_geometry(layer_idx, &transform)?;
+                self.render_layer_geometry(layer_idx, &transform, width, height)?;
 
                 if let Some(layer) = &mut self.layers[layer_idx] {
                     layer.fbo_dirty = false;

--- a/wasm/src/renderer/buffer.rs
+++ b/wasm/src/renderer/buffer.rs
@@ -32,6 +32,15 @@ pub struct BufferCache {
     pub triangle_hole_radius_buffer: Option<WebGlBuffer>,
     pub triangle_template_caches: Vec<TriangleTemplateBufferCache>,
 
+    // Lines cache
+    pub line_vao: Option<WebGlVertexArrayObject>,
+    pub line_instance_count: i32,
+    pub line_start_x_buffer: Option<WebGlBuffer>,
+    pub line_start_y_buffer: Option<WebGlBuffer>,
+    pub line_end_x_buffer: Option<WebGlBuffer>,
+    pub line_end_y_buffer: Option<WebGlBuffer>,
+    pub line_width_buffer: Option<WebGlBuffer>,
+
     // Circles cache
     pub circle_vao: Option<WebGlVertexArrayObject>,
     pub circle_instance_count: i32,

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -58,6 +58,64 @@ void main() {
 }
 "#;
 
+pub const LINE_VERTEX_SHADER: &str = r#"#version 300 es
+precision highp float;
+in vec2 position;
+in float start_x_instance;
+in float start_y_instance;
+in float end_x_instance;
+in float end_y_instance;
+in float width_instance;
+uniform mat3 transform;
+uniform vec2 viewport_size;
+uniform float minimum_feature_pixels;
+
+vec2 clipToPixel(vec2 clipPosition) {
+    return clipPosition * viewport_size * 0.5;
+}
+
+vec2 pixelToClip(vec2 pixelPosition) {
+    return pixelPosition / max(viewport_size * 0.5, vec2(1.0));
+}
+
+void main() {
+    vec2 start = vec2(start_x_instance, start_y_instance);
+    vec2 end = vec2(end_x_instance, end_y_instance);
+    vec3 startClip = transform * vec3(start, 1.0);
+    vec3 endClip = transform * vec3(end, 1.0);
+    vec2 startPixels = clipToPixel(startClip.xy);
+    vec2 endPixels = clipToPixel(endClip.xy);
+
+    vec2 linePixels = endPixels - startPixels;
+    float lineLength = length(linePixels);
+    vec2 direction = lineLength > 0.000001 ? linePixels / lineLength : vec2(1.0, 0.0);
+    vec2 normal = vec2(-direction.y, direction.x);
+
+    vec2 lineWorld = end - start;
+    float worldLength = length(lineWorld);
+    vec2 worldNormal = worldLength > 0.000001
+        ? vec2(-lineWorld.y, lineWorld.x) / worldLength
+        : vec2(0.0, 1.0);
+    vec2 widthClip = mat2(transform) * worldNormal * width_instance;
+    float halfWidthPixels = length(widthClip * viewport_size * 0.5) * 0.5;
+    halfWidthPixels = max(halfWidthPixels, minimum_feature_pixels * 0.5);
+
+    float t = position.x * 0.5 + 0.5;
+    vec2 centerPixels = mix(startPixels, endPixels, t);
+    vec2 adjustedPixels = centerPixels + normal * position.y * halfWidthPixels;
+    gl_Position = vec4(pixelToClip(adjustedPixels), 0.0, 1.0);
+}
+"#;
+
+pub const LINE_FRAGMENT_SHADER: &str = r#"#version 300 es
+precision highp float;
+uniform lowp vec4 color;
+out lowp vec4 fragColor;
+void main() {
+    fragColor = color;
+}
+"#;
+
 pub const TRIANGLE_TEMPLATE_VERTEX_SHADER: &str = r#"#version 300 es
 precision highp float;
 in vec2 position;
@@ -406,6 +464,7 @@ pub struct ShaderProgram {
 pub struct ShaderPrograms {
     pub triangle: ShaderProgram,
     pub triangle_template: ShaderProgram,
+    pub line: ShaderProgram,
     pub circle: ShaderProgram,
     pub arc: ShaderProgram,
     pub thermal: ShaderProgram,
@@ -436,6 +495,26 @@ impl ShaderPrograms {
             TRIANGLE_TEMPLATE_FRAGMENT_SHADER,
             &["position", "instance_x", "instance_y"],
             &["transform", "color"],
+        )?;
+
+        let line = compile_program(
+            gl,
+            LINE_VERTEX_SHADER,
+            LINE_FRAGMENT_SHADER,
+            &[
+                "position",
+                "start_x_instance",
+                "start_y_instance",
+                "end_x_instance",
+                "end_y_instance",
+                "width_instance",
+            ],
+            &[
+                "transform",
+                "color",
+                "viewport_size",
+                "minimum_feature_pixels",
+            ],
         )?;
 
         let circle = compile_program(
@@ -513,6 +592,7 @@ impl ShaderPrograms {
         Ok(ShaderPrograms {
             triangle,
             triangle_template,
+            line,
             circle,
             arc,
             thermal,

--- a/wasm/src/shape.rs
+++ b/wasm/src/shape.rs
@@ -164,6 +164,66 @@ impl TriangleTemplateInstances {
     }
 }
 
+/// Instanced straight line body rendered between two round caps.
+pub struct Lines {
+    pub(crate) start_x: Vec<f32>,
+    pub(crate) start_y: Vec<f32>,
+    pub(crate) end_x: Vec<f32>,
+    pub(crate) end_y: Vec<f32>,
+    pub(crate) width: Vec<f32>,
+}
+
+impl Lines {
+    pub fn new(
+        start_x: Vec<f32>,
+        start_y: Vec<f32>,
+        end_x: Vec<f32>,
+        end_y: Vec<f32>,
+        width: Vec<f32>,
+    ) -> Lines {
+        Lines {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+        }
+    }
+
+    pub(crate) fn release_cpu_geometry(&mut self) {
+        self.start_x = Vec::new();
+        self.start_y = Vec::new();
+        self.end_x = Vec::new();
+        self.end_y = Vec::new();
+        self.width = Vec::new();
+    }
+
+    pub(crate) fn translate(&mut self, dx: f32, dy: f32) {
+        translate_components(&mut self.start_x, &mut self.start_y, dx, dy);
+        translate_components(&mut self.end_x, &mut self.end_y, dx, dy);
+    }
+
+    pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "startX", &f32_array_to_js(&self.start_x))?;
+        set_property(&object, "startY", &f32_array_to_js(&self.start_y))?;
+        set_property(&object, "endX", &f32_array_to_js(&self.end_x))?;
+        set_property(&object, "endY", &f32_array_to_js(&self.end_y))?;
+        set_property(&object, "width", &f32_array_to_js(&self.width))?;
+        Ok(object.into())
+    }
+
+    pub(crate) fn from_js(value: &JsValue) -> Result<Lines, JsValue> {
+        Ok(Lines::new(
+            f32_array_from_js(value, "startX")?,
+            f32_array_from_js(value, "startY")?,
+            f32_array_from_js(value, "endX")?,
+            f32_array_from_js(value, "endY")?,
+            f32_array_from_js(value, "width")?,
+        ))
+    }
+}
+
 /// Circle primitive data structure
 pub struct Circles {
     pub(crate) x: Vec<f32>,
@@ -710,6 +770,7 @@ impl Boundary {
 pub struct GerberData {
     pub(crate) triangles: Triangles,
     pub(crate) triangle_templates: Vec<TriangleTemplateInstances>,
+    pub(crate) lines: Lines,
     pub(crate) circles: Circles,
     pub(crate) arcs: Arcs,
     pub(crate) thermals: Thermals,
@@ -722,6 +783,7 @@ impl GerberData {
     pub fn new(
         triangles: Triangles,
         triangle_templates: Vec<TriangleTemplateInstances>,
+        lines: Lines,
         circles: Circles,
         arcs: Arcs,
         thermals: Thermals,
@@ -732,6 +794,7 @@ impl GerberData {
         GerberData {
             triangles,
             triangle_templates,
+            lines,
             circles,
             arcs,
             thermals,
@@ -748,6 +811,7 @@ impl GerberData {
                 .triangle_templates
                 .iter()
                 .any(|template| !template.vertices.is_empty() && !template.instance_x.is_empty())
+            || !self.lines.start_x.is_empty()
             || !self.circles.x.is_empty()
             || !self.arcs.x.is_empty()
             || !self.thermals.x.is_empty()
@@ -759,6 +823,7 @@ impl GerberData {
         for template in &mut self.triangle_templates {
             template.translate(dx, dy);
         }
+        self.lines.translate(dx, dy);
         self.circles.translate(dx, dy);
         self.arcs.translate(dx, dy);
         self.thermals.translate(dx, dy);
@@ -775,6 +840,7 @@ impl GerberData {
 
         set_property(&object, "triangles", &self.triangles.to_js()?)?;
         set_property(&object, "triangleTemplates", &templates.into())?;
+        set_property(&object, "lines", &self.lines.to_js()?)?;
         set_property(&object, "circles", &self.circles.to_js()?)?;
         set_property(&object, "arcs", &self.arcs.to_js()?)?;
         set_property(&object, "thermals", &self.thermals.to_js()?)?;
@@ -794,6 +860,7 @@ impl GerberData {
         Ok(GerberData::new(
             Triangles::from_js(&get_property(value, "triangles")?)?,
             triangle_templates,
+            Lines::from_js(&get_property(value, "lines")?)?,
             Circles::from_js(&get_property(value, "circles")?)?,
             Arcs::from_js(&get_property(value, "arcs")?)?,
             Thermals::from_js(&get_property(value, "thermals")?)?,


### PR DESCRIPTION
## Summary
- Add a Minimum Line Width rendering option with persisted Off/1px/2px controls
- Store D01 solid-circle line bodies as a dedicated line primitive instead of triangle geometry
- Render line bodies through an instanced WebGL path and apply minimum width only there
- Keep zero-width draws image-free so minimum width does not expose non-image D01 objects

## Conflict Resolution
- Rebased onto `main` after #43 merged.
- Local merge/rebase completed without conflicts.

## Tests
- cargo test --manifest-path wasm/Cargo.toml
- wasm-pack build wasm --target web --out-dir pkg --release
- node --check js/*.js
- git diff --check