### PR TITLE
Apply minimum width to arc strokes

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -203,8 +203,7 @@ impl GerberProcessor {
     /// Configure minimum display size for tiny rendered features.
     ///
     /// `0.0` disables the adjustment. Current implementation applies to
-    /// triangle mesh bodies and circle flashes, which covers standard line
-    /// draws represented as two cap flashes plus two body triangles.
+    /// analytic line and arc strokes in the WebGL renderer.
     pub fn set_minimum_feature_pixels(&mut self, pixels: f32) {
         self.minimum_feature_pixels = if pixels.is_finite() {
             pixels.clamp(0.0, 8.0)

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -2660,6 +2660,8 @@ impl Renderer {
         color: &[f32; 4],
         layer_id: usize,
         sublayer_idx: usize,
+        viewport_width: u32,
+        viewport_height: u32,
     ) -> Result<(), JsValue> {
         let program = &self.programs.arc;
         self.gl.use_program(Some(&program.program));
@@ -2771,6 +2773,7 @@ impl Renderer {
         if let Some(loc) = program.uniforms.get("color") {
             self.gl.uniform4fv_with_f32_array(Some(loc), color);
         }
+        self.set_view_feature_uniforms(program, viewport_width, viewport_height);
 
         // Draw
         self.gl
@@ -3249,7 +3252,14 @@ impl Renderer {
                 viewport_height,
             )?;
             self.draw_instanced_circles(transform, &white_color, layer_id, sublayer_idx)?;
-            self.draw_instanced_arcs(transform, &white_color, layer_id, sublayer_idx)?;
+            self.draw_instanced_arcs(
+                transform,
+                &white_color,
+                layer_id,
+                sublayer_idx,
+                viewport_width,
+                viewport_height,
+            )?;
             self.draw_instanced_thermals(transform, &white_color, layer_id, sublayer_idx)?;
             self.draw_path_regions(transform, &white_color, layer_id, sublayer_idx)?;
         }

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -198,10 +198,22 @@ out highp float vRadius;
 out highp float vStartAngle;
 out highp float vSweepAngle;
 out highp float vThickness;
+
+float weakestPixelsPerWorld() {
+    vec2 pixelScale = viewport_size * 0.5;
+    vec2 axisX = (mat2(transform) * vec2(1.0, 0.0)) * pixelScale;
+    vec2 axisY = (mat2(transform) * vec2(0.0, 1.0)) * pixelScale;
+    float a = dot(axisX, axisX);
+    float b = dot(axisX, axisY);
+    float d = dot(axisY, axisY);
+    float trace = a + d;
+    float discriminant = sqrt(max((a - d) * (a - d) + 4.0 * b * b, 0.0));
+    float weakestScaleSquared = max((trace - discriminant) * 0.5, 0.0);
+    return sqrt(weakestScaleSquared);
+}
+
 void main() {
-    vec2 unitWorldX = vec2(1.0, 0.0);
-    vec2 unitClipX = mat2(transform) * unitWorldX;
-    float pixelsPerWorld = length(unitClipX * viewport_size * 0.5);
+    float pixelsPerWorld = weakestPixelsPerWorld();
     float minimumWorldThickness = minimum_feature_pixels / max(pixelsPerWorld, 0.000001);
     float effectiveThickness = max(thickness_instance, minimumWorldThickness);
     float maxRadius = max(radius_instance + effectiveThickness * 0.5, 0.0);

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -191,13 +191,20 @@ in float startAngle_instance;
 in float sweepAngle_instance;
 in float thickness_instance;
 uniform mat3 transform;
+uniform vec2 viewport_size;
+uniform float minimum_feature_pixels;
 out highp vec2 vPosition;
 out highp float vRadius;
 out highp float vStartAngle;
 out highp float vSweepAngle;
 out highp float vThickness;
 void main() {
-    float maxRadius = max(radius_instance + thickness_instance * 0.5, 0.0);
+    vec2 unitWorldX = vec2(1.0, 0.0);
+    vec2 unitClipX = mat2(transform) * unitWorldX;
+    float pixelsPerWorld = length(unitClipX * viewport_size * 0.5);
+    float minimumWorldThickness = minimum_feature_pixels / max(pixelsPerWorld, 0.000001);
+    float effectiveThickness = max(thickness_instance, minimumWorldThickness);
+    float maxRadius = max(radius_instance + effectiveThickness * 0.5, 0.0);
     vec2 scaledPos = position * maxRadius + vec2(center_x_instance, center_y_instance);
     vec3 transformed = transform * vec3(scaledPos, 1.0);
     gl_Position = vec4(transformed.xy, 0.0, 1.0);
@@ -205,7 +212,7 @@ void main() {
     vRadius = radius_instance;
     vStartAngle = startAngle_instance;
     vSweepAngle = sweepAngle_instance;
-    vThickness = thickness_instance;
+    vThickness = effectiveThickness;
 }
 "#;
 
@@ -241,10 +248,6 @@ void main() {
     float innerRadius = vRadius - vThickness * 0.5;
     float outerRadius = vRadius + vThickness * 0.5;
 
-    if (dist < innerRadius || dist > outerRadius) {
-        discard;
-    }
-
     bool inRange;
     if (vSweepAngle > 0.0) {
         if (endAngle > startAngle) {
@@ -260,7 +263,18 @@ void main() {
         }
     }
 
-    if (!inRange) {
+    bool inArcBody = dist >= innerRadius && dist <= outerRadius && inRange;
+    bool hasCaps = abs(vSweepAngle) < TWO_PI - 0.001;
+    bool inCap = false;
+    if (hasCaps) {
+        float halfThickness = vThickness * 0.5;
+        vec2 startPoint = vec2(cos(vStartAngle), sin(vStartAngle)) * vRadius;
+        vec2 endPoint = vec2(cos(vStartAngle + vSweepAngle), sin(vStartAngle + vSweepAngle)) * vRadius;
+        inCap = length(vPosition - startPoint) <= halfThickness
+            || length(vPosition - endPoint) <= halfThickness;
+    }
+
+    if (!inArcBody && !inCap) {
         discard;
     }
 
@@ -546,7 +560,12 @@ impl ShaderPrograms {
                 "sweepAngle_instance",
                 "thickness_instance",
             ],
-            &["transform", "color"],
+            &[
+                "transform",
+                "color",
+                "viewport_size",
+                "minimum_feature_pixels",
+            ],
         )?;
 
         let thermal = compile_program(


### PR DESCRIPTION
## Summary
- apply the existing minimum feature pixel setting to analytic arc stroke thickness
- pass viewport/minimum-width uniforms to the arc shader
- render rounded arc caps with the effective minimum thickness

## Verification
- cargo test --manifest-path wasm/Cargo.toml
- node --check js/main.js && node --check js/screenshot-exporter.js && node --check js/viewer-options.js
- wasm-pack build wasm --target web --out-dir pkg --release
- git diff --check