### PR TITLE
Optimize renderer memory and repeated aperture flashes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -451,6 +451,7 @@ export class GerberViewer {
     this.isInitialUrlLoading = Boolean(getInitialSourceUrl());
     this.isLoadingLayers = false;
     this.loadingWorkspaceStatus = "Loading files";
+    this.pendingRenderFrame = null;
 
     // Layers
     this.layers = [];
@@ -604,7 +605,7 @@ export class GerberViewer {
     this.updateRulerControls();
     this.updateMeasurementUnitControl();
     this.updateViewFlipControls();
-    this.render();
+    this.requestRender();
     this.loadInitialUrlSource();
   }
 
@@ -732,7 +733,7 @@ export class GerberViewer {
       }
     }
 
-    this.render();
+    this.requestRender();
   }
 
   setupEventListeners() {
@@ -1026,7 +1027,7 @@ export class GerberViewer {
     } finally {
       this.isRestoringWebGlContext = false;
       this.updateUiState();
-      this.render();
+      this.requestRender();
     }
   }
 
@@ -1249,7 +1250,7 @@ export class GerberViewer {
       if (typeof this.wasmProcessor?.set_minimum_feature_pixels === "function") {
         this.wasmProcessor.set_minimum_feature_pixels(this.minimumFeaturePixels);
       }
-      this.render();
+      this.requestRender();
     } catch (error) {
       this.minimumFeaturePixels = previousPixels;
       this.syncOptionControls();
@@ -1368,7 +1369,7 @@ export class GerberViewer {
 
       this.restoreCanvasViewState(viewState);
       this.renderLayerList();
-      this.render();
+      this.requestRender();
     } finally {
       this.hideLoadingModal();
     }
@@ -1620,7 +1621,7 @@ export class GerberViewer {
       this.camera.offsetY = 2 * viewportCenter.y - this.camera.offsetY;
     }
 
-    this.render();
+    this.requestRender();
     this.updateViewFlipControls();
   }
 
@@ -1882,7 +1883,7 @@ export class GerberViewer {
 
       if (loadedCount > 0) {
         this.renderLayerList();
-        this.render();
+        this.requestRender();
         this.fitView();
         this.addDiagnostic("info", "Remote file loaded", `${loadedCount} processed`);
       }
@@ -1939,7 +1940,7 @@ export class GerberViewer {
 
           if (loadedCount > 0) {
             this.renderLayerList();
-            this.render();
+            this.requestRender();
             this.fitView();
             this.addDiagnostic("info", "Files loaded", `${loadedCount} processed`);
           }
@@ -2701,7 +2702,7 @@ export class GerberViewer {
       this.nextColorIndex = nextColorIndex;
       this.restoreCanvasViewState(viewState);
       this.renderLayerList();
-      this.render();
+      this.requestRender();
     } finally {
       this.clearRecoveredPendingLayerRecords(recoveredPendingLayerIds);
       this.isRecoveringWasmProcessor = false;
@@ -2878,6 +2879,17 @@ export class GerberViewer {
     }
   }
 
+  requestRender() {
+    if (this.pendingRenderFrame !== null) {
+      return;
+    }
+
+    this.pendingRenderFrame = requestAnimationFrame(() => {
+      this.pendingRenderFrame = null;
+      this.render();
+    });
+  }
+
   render() {
     if (
       !this.wasmProcessor ||
@@ -2962,7 +2974,7 @@ export class GerberViewer {
     this.camera.offsetY =
       fitView.targetY - fitView.centerY * this.getViewScaleY();
 
-    this.render();
+    this.requestRender();
     this.updateUiState();
   }
 
@@ -3039,7 +3051,7 @@ export class GerberViewer {
       maxZoom: this.maxZoom,
     });
     if (didZoom) {
-      this.render();
+      this.requestRender();
     }
   }
 
@@ -3150,7 +3162,7 @@ export class GerberViewer {
       camera: this.camera,
     });
 
-    this.render();
+    this.requestRender();
   }
 
   // Touch event handlers
@@ -3240,7 +3252,7 @@ export class GerberViewer {
       });
 
       this.lastTouchCenter = currentCenter;
-      this.render();
+      this.requestRender();
     } else if (this.touches.length === 1) {
       if (this.isRulerActive) {
         return;
@@ -3262,7 +3274,7 @@ export class GerberViewer {
       });
 
       this.lastTouchCenter = currentPos;
-      this.render();
+      this.requestRender();
     }
   }
 
@@ -3385,14 +3397,14 @@ export class GerberViewer {
     const b = parseInt(hexColor.substr(5, 2), 16) / 255;
 
     layer.color = [r, g, b];
-    this.render();
+    this.requestRender();
     this.updateUiState();
   }
 
   updateGlobalAlpha(alpha) {
     this.globalAlpha = alpha;
     // Re-render with new alpha
-    this.render();
+    this.requestRender();
   }
 
   deleteLayer(layerId) {
@@ -3418,7 +3430,7 @@ export class GerberViewer {
     }
 
     this.renderLayerList();
-    this.render();
+    this.requestRender();
     this.updateUiState();
   }
 
@@ -3434,7 +3446,7 @@ export class GerberViewer {
       this.nextLayerDomId = 0;
       this.fitViewZoom = null;
       this.renderLayerList();
-      this.render();
+      this.requestRender();
       this.updateUiState();
     } catch (error) {
       console.error("[Layer] Failed to clear all layers:", error);
@@ -3447,7 +3459,7 @@ export class GerberViewer {
       layer.visible = true;
     });
     this.renderLayerList();
-    this.render();
+    this.requestRender();
     this.updateUiState();
   }
 
@@ -3456,7 +3468,7 @@ export class GerberViewer {
       layer.visible = this.layerFilterStore.matches(layer, kind);
     });
     this.renderLayerList();
-    this.render();
+    this.requestRender();
     this.updateUiState();
   }
 
@@ -3465,7 +3477,7 @@ export class GerberViewer {
       layer.visible = false;
     });
     this.renderLayerList();
-    this.render();
+    this.requestRender();
     this.updateUiState();
   }
 
@@ -3533,7 +3545,7 @@ export class GerberViewer {
       const [layer] = this.layers.splice(fromIndex, 1);
       this.layers.splice(toIndex, 0, layer);
       this.renderLayerList();
-      this.render();
+      this.requestRender();
       this.updateUiState();
     }
 
@@ -3584,12 +3596,12 @@ export class GerberViewer {
       onColorChange: (layerId, color) => this.updateLayerColor(layerId, color),
       onVisibilityChange: (layer, visible) => {
         layer.visible = visible;
-        this.render();
+        this.requestRender();
         this.updateUiState();
       },
       onToggleVisibility: (layer) => {
         layer.visible = !layer.visible;
-        this.render();
+        this.requestRender();
         this.updateUiState();
       },
       onDelete: (layerId) => this.deleteLayer(layerId),

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -177,8 +177,10 @@ fn primitive_is_renderable(primitive: &Primitive) -> bool {
             finite_point(*x, *y)
                 && has_positive_extent(*outer_diameter)
                 && inner_diameter.is_finite()
+                && *inner_diameter >= 0.0
                 && *inner_diameter < *outer_diameter
                 && gap_thickness.is_finite()
+                && *gap_thickness >= 0.0
                 && rotation.is_finite()
         }
         Primitive::Line {

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -53,6 +53,10 @@ struct PrimitiveBufferCounts {
 
 impl PrimitiveBufferCounts {
     fn include(&mut self, primitive: &Primitive) {
+        if !primitive_is_renderable(primitive) {
+            return;
+        }
+
         match primitive {
             Primitive::Triangle { hole_radius, .. } => {
                 self.triangles += 1;
@@ -107,6 +111,92 @@ fn primitive_has_hole(primitive: &Primitive) -> bool {
         | Primitive::Thermal { .. }
         | Primitive::Line { .. }
         | Primitive::TriangleTemplateFlash { .. } => false,
+    }
+}
+
+const GEOMETRY_EPSILON: f32 = 1.0e-6;
+
+fn finite_point(x: f32, y: f32) -> bool {
+    x.is_finite() && y.is_finite()
+}
+
+fn has_positive_extent(value: f32) -> bool {
+    value.is_finite() && value > GEOMETRY_EPSILON
+}
+
+fn points_are_distinct(start_x: f32, start_y: f32, end_x: f32, end_y: f32) -> bool {
+    let dx = end_x - start_x;
+    let dy = end_y - start_y;
+    dx.is_finite() && dy.is_finite() && dx * dx + dy * dy > GEOMETRY_EPSILON * GEOMETRY_EPSILON
+}
+
+fn triangle_has_area(vertices: &[[f32; 2]; 3]) -> bool {
+    if !vertices
+        .iter()
+        .all(|point| finite_point(point[0], point[1]))
+    {
+        return false;
+    }
+
+    let area2 = (vertices[1][0] - vertices[0][0]) * (vertices[2][1] - vertices[0][1])
+        - (vertices[2][0] - vertices[0][0]) * (vertices[1][1] - vertices[0][1]);
+    area2.is_finite() && area2.abs() > GEOMETRY_EPSILON * GEOMETRY_EPSILON
+}
+
+fn primitive_is_renderable(primitive: &Primitive) -> bool {
+    match primitive {
+        Primitive::Triangle { vertices, .. } => triangle_has_area(vertices),
+        Primitive::Circle { x, y, radius, .. } => {
+            finite_point(*x, *y) && has_positive_extent(*radius)
+        }
+        Primitive::Arc {
+            x,
+            y,
+            radius,
+            start_angle,
+            end_angle,
+            thickness,
+            ..
+        } => {
+            finite_point(*x, *y)
+                && has_positive_extent(*radius)
+                && has_positive_extent(*thickness)
+                && start_angle.is_finite()
+                && end_angle.is_finite()
+                && (*end_angle - *start_angle).abs() > GEOMETRY_EPSILON
+        }
+        Primitive::Thermal {
+            x,
+            y,
+            outer_diameter,
+            inner_diameter,
+            gap_thickness,
+            rotation,
+            ..
+        } => {
+            finite_point(*x, *y)
+                && has_positive_extent(*outer_diameter)
+                && inner_diameter.is_finite()
+                && *inner_diameter < *outer_diameter
+                && gap_thickness.is_finite()
+                && rotation.is_finite()
+        }
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+            ..
+        } => {
+            finite_point(*start_x, *start_y)
+                && finite_point(*end_x, *end_y)
+                && has_positive_extent(*width)
+                && points_are_distinct(*start_x, *start_y, *end_x, *end_y)
+        }
+        Primitive::TriangleTemplateFlash { template, x, y } => {
+            finite_point(*x, *y) && template.len() >= 6 && template.len().is_multiple_of(6)
+        }
     }
 }
 
@@ -314,6 +404,10 @@ impl PrimitiveOutputBuffers {
     }
 
     fn push_primitive(&mut self, primitive: Primitive) -> Result<(), JsValue> {
+        if !primitive_is_renderable(&primitive) {
+            return Ok(());
+        }
+
         // Unit conversion: aperture.rs already converts to mm using unit_multiplier.
         const TO_MM: f32 = 1.0;
 

--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -2,8 +2,17 @@ use super::aperture_macro::ApertureMacro;
 use super::geometry::{scale_primitive, Primitive};
 use super::state::Polarity;
 use super::PolarityLayer;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct TriangleTemplateTransformKey {
+    layer_scale: u32,
+    mirror_x: bool,
+    mirror_y: bool,
+    layer_rotation: u32,
+}
 
 /// Aperture definition (Circle, Rectangle, Obround, Polygon, or Macro reference)
 #[derive(Clone, Debug)]
@@ -13,6 +22,7 @@ pub struct Aperture {
     pub has_negative: bool,         // true if primitives contain exposure=0
     pub block_layers: Option<Vec<PolarityLayer>>,
     pub triangle_template: Option<Rc<Vec<f32>>>,
+    triangle_template_cache: RefCell<HashMap<TriangleTemplateTransformKey, Rc<Vec<f32>>>>,
     pub is_solid_circle: bool,
 }
 
@@ -24,6 +34,7 @@ impl Aperture {
             has_negative: false,
             block_layers: None,
             triangle_template: None,
+            triangle_template_cache: RefCell::new(HashMap::new()),
             is_solid_circle: false,
         }
     }
@@ -39,8 +50,69 @@ impl Aperture {
             has_negative,
             block_layers: Some(block_layers),
             triangle_template: None,
+            triangle_template_cache: RefCell::new(HashMap::new()),
             is_solid_circle: false,
         }
+    }
+
+    pub(crate) fn triangle_template_for_transform(
+        &self,
+        layer_scale: f32,
+        mirror_x: bool,
+        mirror_y: bool,
+        layer_rotation: f32,
+    ) -> Option<Rc<Vec<f32>>> {
+        let template = self.triangle_template.as_ref()?;
+        if !layer_scale.is_finite() || layer_scale.abs() <= f32::EPSILON {
+            return None;
+        }
+
+        if layer_scale == 1.0 && !mirror_x && !mirror_y && layer_rotation == 0.0 {
+            return Some(Rc::clone(template));
+        }
+
+        let key = TriangleTemplateTransformKey {
+            layer_scale: layer_scale.to_bits(),
+            mirror_x,
+            mirror_y,
+            layer_rotation: layer_rotation.to_bits(),
+        };
+        if let Some(cached_template) = self.triangle_template_cache.borrow().get(&key) {
+            return Some(Rc::clone(cached_template));
+        }
+
+        let cos_r = layer_rotation.cos();
+        let sin_r = layer_rotation.sin();
+        let mut vertices = Vec::new();
+        if vertices.try_reserve(template.len()).is_err() {
+            return None;
+        }
+
+        for point in template.chunks_exact(2) {
+            let mut x = point[0] * layer_scale;
+            let mut y = point[1] * layer_scale;
+            if mirror_x {
+                x = -x;
+            }
+            if mirror_y {
+                y = -y;
+            }
+            vertices.push(x * cos_r - y * sin_r);
+            vertices.push(x * sin_r + y * cos_r);
+        }
+
+        if mirror_x ^ mirror_y {
+            for triangle in vertices.chunks_exact_mut(6) {
+                triangle.swap(2, 4);
+                triangle.swap(3, 5);
+            }
+        }
+
+        let transformed_template = Rc::new(vertices);
+        self.triangle_template_cache
+            .borrow_mut()
+            .insert(key, Rc::clone(&transformed_template));
+        Some(transformed_template)
     }
 }
 

--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -116,12 +116,27 @@ impl Aperture {
     }
 }
 
+fn triangle_vertices_are_renderable(vertices: &[[f32; 2]; 3]) -> bool {
+    if !vertices
+        .iter()
+        .all(|point| point[0].is_finite() && point[1].is_finite())
+    {
+        return false;
+    }
+
+    let area2 = (vertices[1][0] - vertices[0][0]) * (vertices[2][1] - vertices[0][1])
+        - (vertices[2][0] - vertices[0][0]) * (vertices[1][1] - vertices[0][1]);
+    area2.is_finite() && area2.abs() > f32::EPSILON * f32::EPSILON
+}
+
 fn build_triangle_template(primitives: &[Primitive]) -> Option<Rc<Vec<f32>>> {
     if primitives.is_empty() {
         return None;
     }
 
-    let mut vertices = Vec::with_capacity(primitives.len() * 6);
+    let vertex_capacity = primitives.len().checked_mul(6)?;
+    let mut vertices = Vec::new();
+    vertices.try_reserve(vertex_capacity).ok()?;
     for primitive in primitives {
         match primitive {
             Primitive::Triangle {
@@ -129,7 +144,10 @@ fn build_triangle_template(primitives: &[Primitive]) -> Option<Rc<Vec<f32>>> {
                 exposure,
                 hole_radius,
                 ..
-            } if *exposure >= 0.5 && *hole_radius == 0.0 => {
+            } if *exposure >= 0.5
+                && *hole_radius == 0.0
+                && triangle_vertices_are_renderable(triangle) =>
+            {
                 for vertex in triangle {
                     vertices.push(vertex[0]);
                     vertices.push(vertex[1]);

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1291,6 +1291,30 @@ pub fn flash_aperture(
             return Ok(());
         }
 
+        if let Some(template) = aperture.triangle_template_for_transform(
+            state.layer_scale,
+            state.mirror_x,
+            state.mirror_y,
+            state.layer_rotation,
+        ) {
+            let repeat_count = checked_primitive_count(
+                state.sr_x as usize,
+                state.sr_y as usize,
+                "aperture triangle template flash step repeat",
+            )?;
+            try_reserve_primitives(primitives, repeat_count, "aperture triangle template flash")?;
+            for sy in 0..state.sr_y {
+                for sx in 0..state.sr_x {
+                    primitives.push(Primitive::TriangleTemplateFlash {
+                        template: Rc::clone(&template),
+                        x: x + sx as f32 * state.sr_i,
+                        y: y + sy as f32 * state.sr_j,
+                    });
+                }
+            }
+            return Ok(());
+        }
+
         // Step and Repeat iteration
         for sy in 0..state.sr_y {
             for sx in 0..state.sr_x {

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1078,16 +1078,15 @@ fn flash_aperture_no_sr(
         try_reserve_primitives(primitives, result_primitives.len(), "aperture flash")?;
         primitives.extend(result_primitives);
     } else {
-        if let Some(template) = &aperture.triangle_template {
-            if layer_scale == 1.0 && !mirror_x && !mirror_y && layer_rotation == 0.0 {
-                try_reserve_primitives(primitives, 1, "aperture triangle template flash")?;
-                primitives.push(Primitive::TriangleTemplateFlash {
-                    template: Rc::clone(template),
-                    x,
-                    y,
-                });
-                return Ok(());
-            }
+        if let Some(template) = aperture.triangle_template_for_transform(
+            layer_scale,
+            mirror_x,
+            mirror_y,
+            layer_rotation,
+        ) {
+            try_reserve_primitives(primitives, 1, "aperture triangle template flash")?;
+            primitives.push(Primitive::TriangleTemplateFlash { template, x, y });
+            return Ok(());
         }
 
         // Direct primitive cloning

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1464,6 +1464,8 @@ M02*",
     .expect("zero-length rectangle D01 should parse");
 
     assert_eq!(layers.len(), 1);
+    assert!(layers[0].triangles.vertices.is_empty());
+    assert_eq!(layers[0].triangle_templates.len(), 1);
     let vertices = collect_triangle_vertices(&layers[0]);
     assert_eq!(vertices.len(), 12);
     let (min_x, max_x, min_y, max_y) = triangle_bounds(&vertices);
@@ -1471,6 +1473,67 @@ M02*",
     assert_approx_eq(max_x, 0.5);
     assert_approx_eq(min_y, -0.5);
     assert_approx_eq(max_y, 0.5);
+}
+
+#[test]
+fn transformed_zero_length_non_solid_draw_uses_template_instance() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X1.0*%
+%LR45.0*%
+D10*
+X0000000Y0000000D02*
+X0000000Y0000000D01*
+M02*",
+    )
+    .expect("rotated zero-length rectangle D01 should parse");
+
+    assert_eq!(layers.len(), 1);
+    assert!(layers[0].triangles.vertices.is_empty());
+    assert_eq!(layers[0].triangle_templates.len(), 1);
+    let vertices = collect_triangle_vertices(&layers[0]);
+    assert_eq!(vertices.len(), 12);
+    let (min_x, max_x, min_y, max_y) = triangle_bounds(&vertices);
+    let expected_extent = std::f32::consts::FRAC_1_SQRT_2;
+    assert_approx_eq(min_x, -expected_extent);
+    assert_approx_eq(max_x, expected_extent);
+    assert_approx_eq(min_y, -expected_extent);
+    assert_approx_eq(max_y, expected_extent);
+}
+
+#[test]
+fn degenerate_triangle_apertures_do_not_create_template_instances() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,0.0X1.0*%
+D10*
+X0000000Y0000000D03*
+M02*",
+    )
+    .expect("degenerate rectangle aperture should parse");
+
+    assert!(layers.is_empty());
+}
+
+#[test]
+fn invalid_thermal_macro_is_filtered_before_render_buffers() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%AMBADTHERM*7,0,0,1.0,-0.2,0.1,0*%
+%ADD10BADTHERM*%
+D10*
+X0000000Y0000000D03*
+M02*",
+    )
+    .expect("invalid thermal macro should parse");
+
+    assert!(layers.is_empty());
 }
 
 #[test]

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1400,10 +1400,8 @@ X1000000Y0000000D01*
 M02*",
     )
     .expect("zero-width solid circle D01 should parse");
-    let layer = &layers[0];
 
-    assert!(layer.lines.start_x.is_empty());
-    assert!(layer.triangles.vertices.is_empty());
+    assert!(layers.is_empty());
 }
 
 #[test]

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1080,6 +1080,30 @@ M02*";
 }
 
 #[test]
+fn transformed_triangle_aperture_flashes_use_template_instances() {
+    let data = "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10R,1.0X0.5*%
+%LR45.0*%
+D10*
+X000000Y000000D03*
+X2000000Y000000D03*
+M02*";
+
+    let layers = parse_gerber(data).expect("rotated rectangle flashes should parse");
+
+    assert_eq!(layers.len(), 1);
+    assert!(layers[0].triangles.vertices.is_empty());
+    assert_eq!(layers[0].triangle_templates.len(), 1);
+    assert_eq!(layers[0].triangle_templates[0].vertices.len(), 12);
+    assert_eq!(layers[0].triangle_templates[0].instance_x.len(), 2);
+    assert_eq!(layers[0].triangle_templates[0].instance_y.len(), 2);
+    assert_approx_eq(layers[0].triangle_templates[0].instance_x[0], 0.0);
+    assert_approx_eq(layers[0].triangle_templates[0].instance_x[1], 2.0);
+}
+
+#[test]
 fn aperture_block_flashes_stored_graphics_at_operation_coordinate() {
     let data = "\
 %FSLAX24Y24*%

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -1677,6 +1677,7 @@ impl Renderer {
         gl.delete_program(Some(&programs.triangle_template.program));
         gl.delete_program(Some(&programs.line.program));
         gl.delete_program(Some(&programs.circle.program));
+        gl.delete_program(Some(&programs.circle_holed.program));
         gl.delete_program(Some(&programs.arc.program));
         gl.delete_program(Some(&programs.thermal.program));
         gl.delete_program(Some(&programs.texture.program));
@@ -2507,9 +2508,6 @@ impl Renderer {
         layer_id: usize,
         sublayer_idx: usize,
     ) -> Result<(), JsValue> {
-        let program = &self.programs.circle;
-        self.gl.use_program(Some(&program.program));
-
         let instance_count = {
             let layer = self.layers[layer_id]
                 .as_mut()
@@ -2521,6 +2519,13 @@ impl Renderer {
                     return Ok(());
                 }
                 let instance_count = circles.x.len() as i32;
+                let has_holes = !circles.hole_radius.is_empty();
+                let program = if has_holes {
+                    &self.programs.circle_holed
+                } else {
+                    &self.programs.circle
+                };
+                self.gl.use_program(Some(&program.program));
 
                 // Create VAO
                 let vao = self
@@ -2557,16 +2562,7 @@ impl Renderer {
                     "radius_instance",
                     1,
                 )?;
-                if circles.hole_radius.is_empty() {
-                    Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
-                    Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
-                    Self::use_constant_vertex_attrib_1f(
-                        &self.gl,
-                        program,
-                        "hole_radius_instance",
-                        0.0,
-                    )?;
-                } else {
+                if has_holes {
                     let hole_x_buffer = Self::create_instance_buffer(
                         &self.gl,
                         &circles.hole_x,
@@ -2620,14 +2616,15 @@ impl Renderer {
         // Re-get immutable reference for rendering
         let layer = self.get_layer(layer_id)?;
         let buffer_cache = &layer.buffer_caches[sublayer_idx];
+        let program = if buffer_cache.circle_hole_radius_buffer.is_some() {
+            &self.programs.circle_holed
+        } else {
+            &self.programs.circle
+        };
+        self.gl.use_program(Some(&program.program));
 
         // Bind cached VAO for this sublayer
         self.gl.bind_vertex_array(buffer_cache.circle_vao.as_ref());
-        if buffer_cache.circle_hole_radius_buffer.is_none() {
-            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_x_instance", 0.0)?;
-            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_y_instance", 0.0)?;
-            Self::use_constant_vertex_attrib_1f(&self.gl, program, "hole_radius_instance", 0.0)?;
-        }
 
         // Set uniforms (only these change per frame)
         if let Some(loc) = program.uniforms.get("transform") {

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -563,6 +563,13 @@ impl Renderer {
         Self::validate_js_finite_array("circle x", &x)?;
         Self::validate_js_finite_array("circle y", &y)?;
         Self::validate_js_non_negative_array("circle radius", &radius)?;
+        let hole_radius = Self::js_f32_array(&circles, "holeRadius")?;
+        let has_holes = hole_radius.length() > 0;
+        let program = if has_holes {
+            &self.programs.circle_holed
+        } else {
+            &self.programs.circle
+        };
 
         let vao = self
             .gl
@@ -571,11 +578,11 @@ impl Renderer {
         self.gl.bind_vertex_array(Some(&vao));
         buffer_cache.circle_vao = Some(vao);
         buffer_cache.circle_instance_count = instance_count;
-        self.bind_quad_position(&self.programs.circle)?;
+        self.bind_quad_position(program)?;
         let center_x_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &x,
-            &self.programs.circle,
+            program,
             "center_x_instance",
             1,
             1,
@@ -584,7 +591,7 @@ impl Renderer {
         let center_y_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &y,
-            &self.programs.circle,
+            program,
             "center_y_instance",
             1,
             1,
@@ -593,34 +600,14 @@ impl Renderer {
         let radius_buffer = Self::create_attrib_buffer_from_js_array(
             &self.gl,
             &radius,
-            &self.programs.circle,
+            program,
             "radius_instance",
             1,
             1,
         )?;
         buffer_cache.circle_radius_buffer = Some(radius_buffer);
 
-        let hole_radius = Self::js_f32_array(&circles, "holeRadius")?;
-        if hole_radius.length() == 0 {
-            Self::use_constant_vertex_attrib_1f(
-                &self.gl,
-                &self.programs.circle,
-                "hole_x_instance",
-                0.0,
-            )?;
-            Self::use_constant_vertex_attrib_1f(
-                &self.gl,
-                &self.programs.circle,
-                "hole_y_instance",
-                0.0,
-            )?;
-            Self::use_constant_vertex_attrib_1f(
-                &self.gl,
-                &self.programs.circle,
-                "hole_radius_instance",
-                0.0,
-            )?;
-        } else {
+        if has_holes {
             let hole_x = Self::js_f32_array(&circles, "holeX")?;
             let hole_y = Self::js_f32_array(&circles, "holeY")?;
             Self::validate_js_array_len("circle hole_x", &hole_x, instance_count as u32)?;
@@ -632,7 +619,7 @@ impl Renderer {
             buffer_cache.circle_hole_x_buffer = Some(Self::create_attrib_buffer_from_js_array(
                 &self.gl,
                 &hole_x,
-                &self.programs.circle,
+                program,
                 "hole_x_instance",
                 1,
                 1,
@@ -640,7 +627,7 @@ impl Renderer {
             buffer_cache.circle_hole_y_buffer = Some(Self::create_attrib_buffer_from_js_array(
                 &self.gl,
                 &hole_y,
-                &self.programs.circle,
+                program,
                 "hole_y_instance",
                 1,
                 1,
@@ -649,7 +636,7 @@ impl Renderer {
                 Some(Self::create_attrib_buffer_from_js_array(
                     &self.gl,
                     &hole_radius,
-                    &self.programs.circle,
+                    program,
                     "hole_radius_instance",
                     1,
                     1,

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -1037,8 +1037,7 @@ impl Renderer {
             .create_buffer()
             .ok_or_else(|| JsValue::from_str("Failed to create path sector buffer"))?;
         self.gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
-        self.gl
-            .buffer_data_with_array_buffer_view(ARRAY_BUFFER, data, STATIC_DRAW);
+        Self::upload_float_array_to_bound_buffer(&self.gl, data);
 
         let stride = 7 * 4;
         self.enable_path_sector_attribute("position", 2, stride, 0)?;
@@ -1075,7 +1074,7 @@ impl Renderer {
             .create_buffer()
             .ok_or_else(|| JsValue::from_str("Failed to create buffer"))?;
         gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
-        gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, data, STATIC_DRAW);
+        Self::upload_float_array_to_bound_buffer(gl, data);
         let loc = match Self::shader_attribute(program, attr_name) {
             Ok(loc) => loc,
             Err(error) => {
@@ -1965,11 +1964,7 @@ impl Renderer {
             .create_buffer()
             .ok_or_else(|| JsValue::from_str("Failed to create buffer"))?;
         gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
-        // Avoid JS memory copy.
-        unsafe {
-            let array = Float32Array::view(data);
-            gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
-        }
+        Self::upload_f32_slice_to_bound_buffer(gl, data);
         let loc = program.attributes.get(attr_name).ok_or_else(|| {
             JsValue::from_str(&format!("Missing shader attribute: {}", attr_name))
         })?;
@@ -2003,13 +1998,22 @@ impl Renderer {
 
         gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
 
-        // Avoid JS memory copy.
-        unsafe {
-            let array = Float32Array::view(&vertices);
-            gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
-        }
+        Self::upload_f32_slice_to_bound_buffer(gl, &vertices);
 
         Ok(buffer)
+    }
+
+    fn upload_float_array_to_bound_buffer(gl: &WebGl2RenderingContext, data: &Float32Array) {
+        gl.buffer_data_with_f64(ARRAY_BUFFER, data.byte_length() as f64, STATIC_DRAW);
+        gl.buffer_sub_data_with_i32_and_array_buffer_view(ARRAY_BUFFER, 0, data);
+    }
+
+    fn upload_f32_slice_to_bound_buffer(gl: &WebGl2RenderingContext, data: &[f32]) {
+        // Avoid JS memory copy.
+        unsafe {
+            let array = Float32Array::view(data);
+            Self::upload_float_array_to_bound_buffer(gl, &array);
+        }
     }
 
     fn get_canvas_size_from_gl(gl: &WebGl2RenderingContext) -> Result<(u32, u32), JsValue> {
@@ -2160,12 +2164,7 @@ impl Renderer {
                     .create_buffer()
                     .ok_or_else(|| JsValue::from_str("Failed to create vertex buffer"))?;
                 self.gl.bind_buffer(ARRAY_BUFFER, Some(&vertex_buffer));
-                // Avoid JS memory copy.
-                unsafe {
-                    let array = Float32Array::view(&triangles.vertices);
-                    self.gl
-                        .buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
-                }
+                Self::upload_f32_slice_to_bound_buffer(&self.gl, &triangles.vertices);
 
                 // Set up attributes
                 let position_loc = Self::shader_attribute(program, "position")?;
@@ -2320,15 +2319,7 @@ impl Renderer {
                         .create_buffer()
                         .ok_or_else(|| JsValue::from_str("Failed to create vertex buffer"))?;
                     self.gl.bind_buffer(ARRAY_BUFFER, Some(&vertex_buffer));
-                    // Avoid JS memory copy.
-                    unsafe {
-                        let array = Float32Array::view(&template.vertices);
-                        self.gl.buffer_data_with_array_buffer_view(
-                            ARRAY_BUFFER,
-                            &array,
-                            STATIC_DRAW,
-                        );
-                    }
+                    Self::upload_f32_slice_to_bound_buffer(&self.gl, &template.vertices);
 
                     let position_loc = Self::shader_attribute(program, "position")?;
                     self.gl.enable_vertex_attrib_array(position_loc);
@@ -3107,11 +3098,7 @@ impl Renderer {
             .create_buffer()
             .ok_or_else(|| JsValue::from_str("Failed to create vertex buffer"))?;
         gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
-        // Avoid JS memory copy.
-        unsafe {
-            let array = Float32Array::view(data);
-            gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
-        }
+        Self::upload_f32_slice_to_bound_buffer(gl, data);
         let loc = Self::shader_attribute(program, attr_name)?;
         gl.enable_vertex_attrib_array(loc);
         gl.vertex_attrib_pointer_with_i32(loc, components, FLOAT, false, 0, 0);
@@ -3127,11 +3114,7 @@ impl Renderer {
             .create_buffer()
             .ok_or_else(|| JsValue::from_str("Failed to create path sector buffer"))?;
         gl.bind_buffer(ARRAY_BUFFER, Some(&buffer));
-        // Avoid JS memory copy.
-        unsafe {
-            let array = Float32Array::view(data);
-            gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, STATIC_DRAW);
-        }
+        Self::upload_f32_slice_to_bound_buffer(gl, data);
 
         let stride = 7 * 4;
         Self::enable_interleaved_attribute(gl, program, "position", 2, stride, 0)?;

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -114,7 +114,7 @@ impl Renderer {
         let fbo = Self::create_fbo(&self.gl, width, height, needs_stencil)?;
 
         // Create buffer caches for each polarity sublayer
-        let buffer_caches = Self::create_buffer_caches(gerber_data.len());
+        let buffer_caches = Self::create_buffer_caches(gerber_data.len())?;
 
         let layer_metadata = LayerMetadata {
             gerber_data,
@@ -152,8 +152,10 @@ impl Renderer {
         let mut max_x = f32::NEG_INFINITY;
         let mut min_y = f32::INFINITY;
         let mut max_y = f32::NEG_INFINITY;
-        let mut gerber_data = Vec::with_capacity(sublayers.length() as usize);
-        let mut buffer_caches = Vec::with_capacity(sublayers.length() as usize);
+        let sublayer_count =
+            Self::checked_u32_to_usize("render payload sublayer count", sublayers.length())?;
+        let mut gerber_data = Self::reserved_vec("render payload sublayers", sublayer_count)?;
+        let mut buffer_caches = Self::reserved_vec("render payload buffer caches", sublayer_count)?;
         let mut needs_stencil = false;
 
         for sublayer in sublayers.iter() {
@@ -952,7 +954,10 @@ impl Renderer {
                 0,
             )?;
             buffer_cache.path_wedge_vao = Some(vao);
-            buffer_cache.path_wedge_vertex_count = (wedge_vertices.length() / 2) as i32;
+            buffer_cache.path_wedge_vertex_count = Self::checked_u32_to_i32(
+                "path region wedge vertex count",
+                wedge_vertices.length() / 2,
+            )?;
             buffer_cache.path_wedge_vertex_buffer = Some(buffer);
             self.gl.bind_vertex_array(None);
         }
@@ -971,7 +976,10 @@ impl Renderer {
             self.gl.bind_vertex_array(Some(&vao));
             let buffer = self.create_path_sector_buffer(&sector_vertices)?;
             buffer_cache.path_sector_vao = Some(vao);
-            buffer_cache.path_sector_vertex_count = (sector_vertices.length() / 7) as i32;
+            buffer_cache.path_sector_vertex_count = Self::checked_u32_to_i32(
+                "path region sector vertex count",
+                sector_vertices.length() / 7,
+            )?;
             buffer_cache.path_sector_vertex_buffer = Some(buffer);
             self.gl.bind_vertex_array(None);
         }
@@ -997,7 +1005,10 @@ impl Renderer {
                 0,
             )?;
             buffer_cache.path_cover_vao = Some(vao);
-            buffer_cache.path_cover_vertex_count = (cover_vertices.length() / 2) as i32;
+            buffer_cache.path_cover_vertex_count = Self::checked_u32_to_i32(
+                "path region cover vertex count",
+                cover_vertices.length() / 2,
+            )?;
             buffer_cache.path_cover_vertex_buffer = Some(buffer);
             self.gl.bind_vertex_array(None);
         }
@@ -1023,7 +1034,10 @@ impl Renderer {
                 0,
             )?;
             buffer_cache.path_clear_vao = Some(vao);
-            buffer_cache.path_clear_vertex_count = (clear_vertices.length() / 2) as i32;
+            buffer_cache.path_clear_vertex_count = Self::checked_u32_to_i32(
+                "path region clear vertex count",
+                clear_vertices.length() / 2,
+            )?;
             buffer_cache.path_clear_vertex_buffer = Some(buffer);
             self.gl.bind_vertex_array(None);
         }
@@ -1097,6 +1111,36 @@ impl Renderer {
         Ok(())
     }
 
+    fn checked_usize_to_i32(label: &str, value: usize) -> Result<i32, JsValue> {
+        i32::try_from(value)
+            .map_err(|_| JsValue::from_str(&format!("{label} exceeds WebGL draw limits")))
+    }
+
+    fn checked_u32_to_i32(label: &str, value: u32) -> Result<i32, JsValue> {
+        i32::try_from(value)
+            .map_err(|_| JsValue::from_str(&format!("{label} exceeds WebGL draw limits")))
+    }
+
+    fn checked_u32_to_usize(label: &str, value: u32) -> Result<usize, JsValue> {
+        usize::try_from(value)
+            .map_err(|_| JsValue::from_str(&format!("{label} exceeds platform limits")))
+    }
+
+    fn reserved_vec<T>(label: &str, capacity: usize) -> Result<Vec<T>, JsValue> {
+        let mut values = Vec::new();
+        values
+            .try_reserve(capacity)
+            .map_err(|_| JsValue::from_str(&format!("Unable to reserve memory for {label}")))?;
+        Ok(values)
+    }
+
+    fn checked_path_region_quad_start(region_idx: usize) -> Result<i32, JsValue> {
+        let start = region_idx.checked_mul(6).ok_or_else(|| {
+            JsValue::from_str("path region cover vertex start overflows WebGL draw limits")
+        })?;
+        Self::checked_usize_to_i32("path region cover vertex start", start)
+    }
+
     fn validate_triangle_vertex_array(label: &str, values: &Float32Array) -> Result<i32, JsValue> {
         if !values.length().is_multiple_of(2) {
             return Err(JsValue::from_str(&format!(
@@ -1117,7 +1161,7 @@ impl Renderer {
                 label
             )));
         }
-        Ok(vertex_count as i32)
+        Self::checked_u32_to_i32(label, vertex_count)
     }
 
     fn set_view_feature_uniforms(
@@ -1145,7 +1189,7 @@ impl Renderer {
                 label
             )));
         }
-        Ok(values.length() as i32)
+        Self::checked_u32_to_i32(label, values.length())
     }
 
     fn validate_js_array_len(
@@ -1453,26 +1497,47 @@ impl Renderer {
                 sublayer_idx
             )));
         }
+        Self::checked_usize_to_i32(
+            &format!("Sublayer {} path wedge vertex count", sublayer_idx),
+            wedge_vertex_count,
+        )?;
         if !path_regions.sector_vertices.len().is_multiple_of(7) {
             return Err(JsValue::from_str(&format!(
                 "Sublayer {} path sector vertex buffer length is not divisible by 7",
                 sublayer_idx
             )));
         }
+        let sector_vertex_count = path_regions.sector_vertices.len() / 7;
+        Self::checked_usize_to_i32(
+            &format!("Sublayer {} path sector vertex count", sublayer_idx),
+            sector_vertex_count,
+        )?;
         if !path_regions.cover_vertices.len().is_multiple_of(12) {
             return Err(JsValue::from_str(&format!(
                 "Sublayer {} path cover vertex buffer length is not divisible by 12",
                 sublayer_idx
             )));
         }
+        Self::checked_usize_to_i32(
+            &format!("Sublayer {} path cover vertex count", sublayer_idx),
+            path_regions.cover_vertices.len() / 2,
+        )?;
         if !path_regions.clear_vertices.len().is_multiple_of(12) {
             return Err(JsValue::from_str(&format!(
                 "Sublayer {} path clear vertex buffer length is not divisible by 12",
                 sublayer_idx
             )));
         }
+        Self::checked_usize_to_i32(
+            &format!("Sublayer {} path clear vertex count", sublayer_idx),
+            path_regions.clear_vertices.len() / 2,
+        )?;
 
         let region_count = path_regions.region_count();
+        Self::checked_path_region_quad_start(region_count)?;
+        let region_offset_count = region_count
+            .checked_add(1)
+            .ok_or_else(|| JsValue::from_str("path region offset count exceeds platform limits"))?;
         let cover_region_count = path_regions.cover_vertices.len() / 12;
         if cover_region_count != 0 && cover_region_count != region_count {
             return Err(JsValue::from_str(&format!(
@@ -1491,13 +1556,13 @@ impl Renderer {
             "path wedge offsets",
             sublayer_idx,
             path_regions.wedge_vertex_offsets.len(),
-            region_count + 1,
+            region_offset_count,
         )?;
         Self::validate_len(
             "path sector offsets",
             sublayer_idx,
             path_regions.sector_vertex_offsets.len(),
-            region_count + 1,
+            region_offset_count,
         )?;
         Self::validate_offsets(
             "path wedge offsets",
@@ -1509,7 +1574,7 @@ impl Renderer {
             "path sector offsets",
             sublayer_idx,
             &path_regions.sector_vertex_offsets,
-            path_regions.sector_vertices.len() / 7,
+            sector_vertex_count,
         )?;
         Self::validate_finite_slice("path wedge vertices", &path_regions.wedge_vertices)?;
         Self::validate_finite_slice("path sector vertices", &path_regions.sector_vertices)?;
@@ -1645,8 +1710,10 @@ impl Renderer {
         self.layer_count = 0;
     }
 
-    fn create_buffer_caches(count: usize) -> Vec<BufferCache> {
-        (0..count).map(|_| BufferCache::default()).collect()
+    fn create_buffer_caches(count: usize) -> Result<Vec<BufferCache>, JsValue> {
+        let mut caches = Self::reserved_vec("buffer caches", count)?;
+        caches.resize_with(count, BufferCache::default);
+        Ok(caches)
     }
 
     fn mark_all_layers_dirty(&mut self) {
@@ -1853,6 +1920,8 @@ impl Renderer {
                 width, height, max_texture_size
             )));
         }
+        let width_i32 = Self::checked_u32_to_i32("FBO width", width)?;
+        let height_i32 = Self::checked_u32_to_i32("FBO height", height)?;
 
         let texture = gl.create_texture().ok_or("Failed to create texture")?;
         gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&texture));
@@ -1861,8 +1930,8 @@ impl Renderer {
                 WebGl2RenderingContext::TEXTURE_2D,
                 0,
                 WebGl2RenderingContext::RGBA as i32,
-                width as i32,
-                height as i32,
+                width_i32,
+                height_i32,
                 0,
                 WebGl2RenderingContext::RGBA,
                 WebGl2RenderingContext::UNSIGNED_BYTE,
@@ -1912,8 +1981,8 @@ impl Renderer {
             gl.renderbuffer_storage(
                 WebGl2RenderingContext::RENDERBUFFER,
                 WebGl2RenderingContext::STENCIL_INDEX8,
-                width as i32,
-                height as i32,
+                width_i32,
+                height_i32,
             );
             gl.framebuffer_renderbuffer(
                 WebGl2RenderingContext::FRAMEBUFFER,
@@ -2150,7 +2219,10 @@ impl Renderer {
                 if triangles.vertices.is_empty() {
                     return Ok(());
                 }
-                let vertex_count = (triangles.vertices.len() / 2) as i32;
+                let vertex_count = Self::checked_usize_to_i32(
+                    "triangle vertex count",
+                    triangles.vertices.len() / 2,
+                )?;
 
                 // Create VAO
                 let vao = self
@@ -2306,8 +2378,14 @@ impl Renderer {
                         continue;
                     }
 
-                    let vertex_count = (template.vertices.len() / 2) as i32;
-                    let instance_count = template.instance_x.len() as i32;
+                    let vertex_count = Self::checked_usize_to_i32(
+                        "triangle template vertex count",
+                        template.vertices.len() / 2,
+                    )?;
+                    let instance_count = Self::checked_usize_to_i32(
+                        "triangle template instance count",
+                        template.instance_x.len(),
+                    )?;
 
                     let vao = self
                         .gl
@@ -2411,7 +2489,8 @@ impl Renderer {
                 if lines.start_x.is_empty() {
                     return Ok(());
                 }
-                let instance_count = lines.start_x.len() as i32;
+                let instance_count =
+                    Self::checked_usize_to_i32("line instance count", lines.start_x.len())?;
 
                 let vao = self
                     .gl
@@ -2518,7 +2597,8 @@ impl Renderer {
                 if circles.x.is_empty() {
                     return Ok(());
                 }
-                let instance_count = circles.x.len() as i32;
+                let instance_count =
+                    Self::checked_usize_to_i32("circle instance count", circles.x.len())?;
                 let has_holes = !circles.hole_radius.is_empty();
                 let program = if has_holes {
                     &self.programs.circle_holed
@@ -2668,7 +2748,8 @@ impl Renderer {
                 if arcs.x.is_empty() {
                     return Ok(());
                 }
-                let instance_count = arcs.x.len() as i32;
+                let instance_count =
+                    Self::checked_usize_to_i32("arc instance count", arcs.x.len())?;
 
                 // Create VAO
                 let vao = self
@@ -2798,7 +2879,8 @@ impl Renderer {
                 if thermals.x.is_empty() {
                     return Ok(());
                 }
-                let instance_count = thermals.x.len() as i32;
+                let instance_count =
+                    Self::checked_usize_to_i32("thermal instance count", thermals.x.len())?;
 
                 // Create VAO
                 let vao = self
@@ -2955,8 +3037,14 @@ impl Renderer {
             self.gl.stencil_func(ALWAYS, 0, 0xff);
             self.gl.stencil_op(KEEP, KEEP, INVERT);
 
-            let wedge_start = path_regions.wedge_vertex_offsets[region_idx] as i32;
-            let wedge_end = path_regions.wedge_vertex_offsets[region_idx + 1] as i32;
+            let wedge_start = Self::checked_u32_to_i32(
+                "path wedge vertex start",
+                path_regions.wedge_vertex_offsets[region_idx],
+            )?;
+            let wedge_end = Self::checked_u32_to_i32(
+                "path wedge vertex end",
+                path_regions.wedge_vertex_offsets[region_idx + 1],
+            )?;
             if wedge_end > wedge_start {
                 self.draw_path_solid_range(
                     transform,
@@ -2967,8 +3055,14 @@ impl Renderer {
                 )?;
             }
 
-            let sector_start = path_regions.sector_vertex_offsets[region_idx] as i32;
-            let sector_end = path_regions.sector_vertex_offsets[region_idx + 1] as i32;
+            let sector_start = Self::checked_u32_to_i32(
+                "path sector vertex start",
+                path_regions.sector_vertex_offsets[region_idx],
+            )?;
+            let sector_end = Self::checked_u32_to_i32(
+                "path sector vertex end",
+                path_regions.sector_vertex_offsets[region_idx + 1],
+            )?;
             if sector_end > sector_start {
                 self.draw_path_sector_range(
                     transform,
@@ -2986,7 +3080,7 @@ impl Renderer {
                 transform,
                 color,
                 buffer_cache.path_clear_vao.as_ref(),
-                (region_idx * 6) as i32,
+                Self::checked_path_region_quad_start(region_idx)?,
                 6,
             )?;
 
@@ -2997,7 +3091,7 @@ impl Renderer {
                 transform,
                 color,
                 buffer_cache.path_cover_vao.as_ref(),
-                (region_idx * 6) as i32,
+                Self::checked_path_region_quad_start(region_idx)?,
                 6,
             )?;
         }
@@ -3026,7 +3120,10 @@ impl Renderer {
                 "position",
                 2,
             )?;
-            buffer_cache.path_wedge_vertex_count = (path_regions.wedge_vertices.len() / 2) as i32;
+            buffer_cache.path_wedge_vertex_count = Self::checked_usize_to_i32(
+                "path region wedge vertex count",
+                path_regions.wedge_vertices.len() / 2,
+            )?;
             buffer_cache.path_wedge_vertex_buffer = Some(buffer);
             buffer_cache.path_wedge_vao = Some(vao);
         }
@@ -3041,7 +3138,10 @@ impl Renderer {
                 &programs.path_sector,
                 &path_regions.sector_vertices,
             )?;
-            buffer_cache.path_sector_vertex_count = (path_regions.sector_vertices.len() / 7) as i32;
+            buffer_cache.path_sector_vertex_count = Self::checked_usize_to_i32(
+                "path region sector vertex count",
+                path_regions.sector_vertices.len() / 7,
+            )?;
             buffer_cache.path_sector_vertex_buffer = Some(buffer);
             buffer_cache.path_sector_vao = Some(vao);
         }
@@ -3058,7 +3158,10 @@ impl Renderer {
                 "position",
                 2,
             )?;
-            buffer_cache.path_cover_vertex_count = (path_regions.cover_vertices.len() / 2) as i32;
+            buffer_cache.path_cover_vertex_count = Self::checked_usize_to_i32(
+                "path region cover vertex count",
+                path_regions.cover_vertices.len() / 2,
+            )?;
             buffer_cache.path_cover_vertex_buffer = Some(buffer);
             buffer_cache.path_cover_vao = Some(vao);
         }
@@ -3075,7 +3178,10 @@ impl Renderer {
                 "position",
                 2,
             )?;
-            buffer_cache.path_clear_vertex_count = (path_regions.clear_vertices.len() / 2) as i32;
+            buffer_cache.path_clear_vertex_count = Self::checked_usize_to_i32(
+                "path region clear vertex count",
+                path_regions.clear_vertices.len() / 2,
+            )?;
             buffer_cache.path_clear_vertex_buffer = Some(buffer);
             buffer_cache.path_clear_vao = Some(vao);
         }
@@ -3353,6 +3459,8 @@ impl Renderer {
         if width == 0 || height == 0 {
             return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
         }
+        let width_i32 = Self::checked_u32_to_i32("canvas width", width)?;
+        let height_i32 = Self::checked_u32_to_i32("canvas height", height)?;
 
         // STEP 1: Render active layer geometry to FBOs only when geometry/camera state changed.
         for &layer_id in active_layer_ids {
@@ -3370,7 +3478,7 @@ impl Renderer {
                 // Bind layer FBO
                 self.gl
                     .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&fbo.framebuffer));
-                self.gl.viewport(0, 0, width as i32, height as i32);
+                self.gl.viewport(0, 0, width_i32, height_i32);
 
                 // Clear layer FBO
                 self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
@@ -3456,11 +3564,13 @@ impl Renderer {
     ) -> Result<(), JsValue> {
         // Get canvas dimensions
         let (width, height) = self.get_canvas_size()?;
+        let width_i32 = Self::checked_u32_to_i32("canvas width", width)?;
+        let height_i32 = Self::checked_u32_to_i32("canvas height", height)?;
 
         // Bind canvas framebuffer
         self.gl
             .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
-        self.gl.viewport(0, 0, width as i32, height as i32);
+        self.gl.viewport(0, 0, width_i32, height_i32);
 
         // Clear canvas
         self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
@@ -3564,7 +3674,7 @@ impl Renderer {
         let programs = ShaderPrograms::new(&gl)?;
         let quad_buffer = Self::create_quad_buffer(&gl)?;
         let (width, height) = Self::get_canvas_size_from_gl(&gl)?;
-        let mut new_fbos = Vec::with_capacity(self.layers.len());
+        let mut new_fbos = Self::reserved_vec("restored framebuffers", self.layers.len())?;
 
         for layer in &self.layers {
             if layer.is_some() {
@@ -3598,7 +3708,7 @@ impl Renderer {
                 for cache in std::mem::take(&mut layer.buffer_caches) {
                     Self::delete_buffer_cache(&old_gl, cache);
                 }
-                layer.buffer_caches = Self::create_buffer_caches(layer.gerber_data.len());
+                layer.buffer_caches = Self::create_buffer_caches(layer.gerber_data.len())?;
                 layer.fbo_dirty = true;
                 layer.fbo_transform = None;
             }

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -144,6 +144,35 @@ in vec2 position;
 in float center_x_instance;
 in float center_y_instance;
 in float radius_instance;
+uniform mat3 transform;
+out highp vec2 vPosition;
+void main() {
+    vec2 center = vec2(center_x_instance, center_y_instance);
+    vec2 scaledPos = position * radius_instance + center;
+    vec3 transformed = transform * vec3(scaledPos, 1.0);
+    gl_Position = vec4(transformed.xy, 0.0, 1.0);
+    vPosition = position;
+}
+"#;
+
+pub const CIRCLE_FRAGMENT_SHADER: &str = r#"#version 300 es
+precision highp float;
+in highp vec2 vPosition;
+uniform lowp vec4 color;
+out lowp vec4 fragColor;
+void main() {
+    float dist = dot(vPosition, vPosition);
+    if (dist > 1.0) discard;
+    fragColor = color;
+}
+"#;
+
+pub const CIRCLE_HOLED_VERTEX_SHADER: &str = r#"#version 300 es
+precision highp float;
+in vec2 position;
+in float center_x_instance;
+in float center_y_instance;
+in float radius_instance;
 in float hole_x_instance;
 in float hole_y_instance;
 in float hole_radius_instance;
@@ -163,7 +192,7 @@ void main() {
 }
 "#;
 
-pub const CIRCLE_FRAGMENT_SHADER: &str = r#"#version 300 es
+pub const CIRCLE_HOLED_FRAGMENT_SHADER: &str = r#"#version 300 es
 precision highp float;
 in highp vec2 vPosition;
 in highp vec2 vHoleCenter;
@@ -492,6 +521,7 @@ pub struct ShaderPrograms {
     pub triangle_template: ShaderProgram,
     pub line: ShaderProgram,
     pub circle: ShaderProgram,
+    pub circle_holed: ShaderProgram,
     pub arc: ShaderProgram,
     pub thermal: ShaderProgram,
     pub texture: ShaderProgram,
@@ -547,6 +577,19 @@ impl ShaderPrograms {
             gl,
             CIRCLE_VERTEX_SHADER,
             CIRCLE_FRAGMENT_SHADER,
+            &[
+                "position",
+                "center_x_instance",
+                "center_y_instance",
+                "radius_instance",
+            ],
+            &["transform", "color"],
+        )?;
+
+        let circle_holed = compile_program(
+            gl,
+            CIRCLE_HOLED_VERTEX_SHADER,
+            CIRCLE_HOLED_FRAGMENT_SHADER,
             &[
                 "position",
                 "center_x_instance",
@@ -625,6 +668,7 @@ impl ShaderPrograms {
             triangle_template,
             line,
             circle,
+            circle_holed,
             arc,
             thermal,
             texture,


### PR DESCRIPTION
## Summary
- coalesce UI render requests through requestAnimationFrame
- skip degenerate parser geometry and reuse triangle aperture flash templates across transforms
- centralize WebGL buffer uploads and add checked renderer count/size conversions
- split solid circle rendering from holed-circle shader path

## Tests
- cargo test --manifest-path wasm/Cargo.toml
- wasm-pack build wasm --target web --out-dir pkg --release
- git diff --check