### PR TITLE
Add npm Gerber renderer package and Node CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ wasm_gerber_processor/target/
 wasm/target
 wasm/pkg/
 packages/gerber-renderer/wasm/
+packages/gerber-renderer/node_modules/
+packages/gerber-renderer/package-lock.json
 
 # Large demo files are stored in Vercel Blob.
 demo/performance-test-arc-region-*.gbr

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 wasm_gerber_processor/target/
 wasm/target
 wasm/pkg/
+packages/gerber-renderer/wasm/
 
 # Large demo files are stored in Vercel Blob.
 demo/performance-test-arc-region-*.gbr

--- a/packages/gerber-renderer/bin/gerber-renderer.js
+++ b/packages/gerber-renderer/bin/gerber-renderer.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { basename } from "node:path";
+import { fileLayer, renderGerberToPngFile } from "../node.js";
+
+const USAGE = `Usage:
+  gerber-renderer <input.gbr...> -o <output.png> [options]
+
+Options:
+  -o, --output <path>              PNG output path
+  --width <px>                     Output width (default: 1200)
+  --height <px>                    Output height (default: 800)
+  --padding <px>                   Fit padding in pixels
+  --background <color>             Background color, e.g. #05070c
+  --alpha <0-1>                    Global alpha
+  --minimum-feature-pixels <px>    Minimum line/arc display width
+  --approx-region-arcs             Approximate region arcs before rendering
+  --arc-quality <0|1|2>            Approx arc quality
+  --no-fit                         Use identity view instead of fit view
+  -h, --help                       Show this help
+`;
+
+async function main() {
+  const { inputs, output, frameOptions } = parseArgs(process.argv.slice(2));
+  if (inputs.length === 0 || !output) {
+    process.stderr.write(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+
+  const layers = inputs.map((path) => fileLayer(path, { name: basename(path) }));
+  await renderGerberToPngFile(output, layers, frameOptions);
+  process.stdout.write(`Rendered ${inputs.length} layer(s) to ${output}\n`);
+}
+
+function parseArgs(args) {
+  const inputs = [];
+  const frameOptions = {};
+  let output = "";
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "-h" || arg === "--help") {
+      process.stdout.write(USAGE);
+      process.exit(0);
+    } else if (arg === "-o" || arg === "--output") {
+      output = readOptionValue(args, ++index, arg);
+    } else if (arg === "--width") {
+      frameOptions.width = readPositiveInteger(args, ++index, arg);
+    } else if (arg === "--height") {
+      frameOptions.height = readPositiveInteger(args, ++index, arg);
+    } else if (arg === "--padding") {
+      frameOptions.padding = readNumber(args, ++index, arg);
+    } else if (arg === "--background") {
+      frameOptions.background = readOptionValue(args, ++index, arg);
+    } else if (arg === "--alpha") {
+      frameOptions.globalAlpha = readNumber(args, ++index, arg);
+    } else if (arg === "--minimum-feature-pixels") {
+      frameOptions.minimumFeaturePixels = readNumber(args, ++index, arg);
+    } else if (arg === "--approx-region-arcs") {
+      frameOptions.preserveArcRegions = false;
+    } else if (arg === "--arc-quality") {
+      frameOptions.arcTessellationQuality = readNonNegativeInteger(args, ++index, arg);
+    } else if (arg === "--no-fit") {
+      frameOptions.fit = false;
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      inputs.push(arg);
+    }
+  }
+
+  return { inputs, output, frameOptions };
+}
+
+function readOptionValue(args, index, option) {
+  const value = args[index];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${option} requires a value.`);
+  }
+  return value;
+}
+
+function readPositiveInteger(args, index, option) {
+  const value = Number(readOptionValue(args, index, option));
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${option} requires a positive integer.`);
+  }
+  return value;
+}
+
+function readNonNegativeInteger(args, index, option) {
+  const value = Number(readOptionValue(args, index, option));
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${option} requires a non-negative integer.`);
+  }
+  return value;
+}
+
+function readNumber(args, index, option) {
+  const value = Number(readOptionValue(args, index, option));
+  if (!Number.isFinite(value)) {
+    throw new Error(`${option} requires a finite number.`);
+  }
+  return value;
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/gerber-renderer/index.d.ts
+++ b/packages/gerber-renderer/index.d.ts
@@ -1,0 +1,94 @@
+export type GerberSource =
+  | File
+  | string
+  | Blob
+  | ArrayBuffer
+  | Uint8Array;
+
+export type GerberLayer =
+  | GerberSource
+  | {
+      source: GerberSource;
+      name?: string;
+      color?: RGBColor;
+      alpha?: number;
+      offsetX?: number;
+      offsetY?: number;
+    };
+
+export type RGBColor = [number, number, number];
+export type RGBAColor = [number, number, number, number];
+
+export type RendererOptions = {
+  wasmModule?: unknown;
+  wasmModuleUrl?: string | URL;
+  wasmInitInput?: unknown;
+  contextAttributes?: WebGLContextAttributes;
+  releaseContext?: boolean;
+};
+
+export type FrameOptions = {
+  width?: number;
+  height?: number;
+  clear?: boolean;
+  background?: null | string | RGBAColor;
+  fit?: boolean;
+  padding?: number;
+  view?: {
+    zoomX: number;
+    zoomY: number;
+    offsetX: number;
+    offsetY: number;
+  };
+  preserveArcRegions?: boolean;
+  arcTessellationQuality?: 0 | 1 | 2;
+  minimumFeaturePixels?: number;
+  globalAlpha?: number;
+  rendererOptions?: RendererOptions;
+};
+
+export type LayerOptions = {
+  color?: RGBColor;
+  alpha?: number;
+  offsetX?: number;
+  offsetY?: number;
+};
+
+export type ExportOptions = {
+  type?: "image/png" | string;
+  quality?: number;
+  background?: null | string | RGBAColor;
+};
+
+export type GerberCanvas = HTMLCanvasElement;
+
+export declare function createGerberRenderer(
+  canvas: GerberCanvas,
+  rendererOptions?: RendererOptions,
+): Promise<GerberRenderer>;
+
+export declare function renderGerberToCanvas(
+  canvas: GerberCanvas,
+  layers: GerberLayer | GerberLayer[] | FileList,
+  frameOptions?: FrameOptions,
+): Promise<void>;
+
+export declare function renderGerberToPng(
+  canvas: GerberCanvas,
+  layers: GerberLayer | GerberLayer[] | FileList,
+  frameOptions?: FrameOptions,
+  exportOptions?: ExportOptions,
+): Promise<Blob>;
+
+export declare class GerberRenderer {
+  withFrame(
+    frameOptions: FrameOptions,
+    callback: () => void | Promise<void>,
+  ): Promise<void>;
+
+  renderLayer(layer: GerberLayer, layerOptions?: LayerOptions): Promise<number>;
+
+  exportPng(exportOptions?: ExportOptions): Promise<Blob>;
+
+  dispose(): void;
+}

--- a/packages/gerber-renderer/index.js
+++ b/packages/gerber-renderer/index.js
@@ -1,0 +1,674 @@
+const DEFAULT_WASM_MODULE_URL = new URL(
+  "./wasm/wasm_gerber_processor.js",
+  import.meta.url,
+);
+
+const DEFAULT_COLORS = [
+  [1.0, 0.0, 0.0],
+  [0.0, 1.0, 0.0],
+  [0.0, 0.0, 1.0],
+  [1.0, 0.0, 1.0],
+  [1.0, 1.0, 0.0],
+  [0.0, 1.0, 1.0],
+];
+const DEFAULT_BACKGROUND = null;
+
+export async function createGerberRenderer(canvas, rendererOptions = {}) {
+  return GerberRenderer.create(canvas, rendererOptions);
+}
+
+export async function renderGerberToCanvas(
+  canvas,
+  layers,
+  frameOptions = {},
+) {
+  const renderer = await createGerberRenderer(canvas, {
+    releaseContext: false,
+    ...(frameOptions.rendererOptions || {}),
+  });
+
+  try {
+    await renderer.withFrame(frameOptions, async () => {
+      for (const layer of normalizeLayerList(layers)) {
+        await renderer.renderLayer(layer);
+      }
+    });
+  } finally {
+    renderer.dispose();
+  }
+}
+
+export async function renderGerberToPng(
+  canvas,
+  layers,
+  frameOptions = {},
+  exportOptions = {},
+) {
+  const renderer = await createGerberRenderer(
+    canvas,
+    frameOptions.rendererOptions || {},
+  );
+
+  try {
+    await renderer.withFrame(frameOptions, async () => {
+      for (const layer of normalizeLayerList(layers)) {
+        await renderer.renderLayer(layer);
+      }
+    });
+    return await renderer.exportPng({
+      background: frameOptions.background,
+      ...exportOptions,
+    });
+  } finally {
+    renderer.dispose();
+  }
+}
+
+export class GerberRenderer {
+  static async create(canvas, rendererOptions = {}) {
+    const wasmModule = await loadWasmModule(rendererOptions);
+    if (typeof wasmModule.default === "function") {
+      await wasmModule.default(rendererOptions.wasmInitInput);
+    }
+    return new GerberRenderer(canvas, rendererOptions, wasmModule);
+  }
+
+  constructor(canvas, rendererOptions, wasmModule) {
+    if (!canvas || typeof canvas.getContext !== "function") {
+      throw new TypeError("A canvas with getContext() is required.");
+    }
+
+    this.canvas = canvas;
+    this.rendererOptions = { ...rendererOptions };
+    this.wasmModule = wasmModule;
+    this.gl = null;
+    this.frame = null;
+    this.lastFrame = null;
+    this.disposed = false;
+  }
+
+  async withFrame(frameOptions = {}, callback) {
+    this.assertUsable();
+    if (this.frame) {
+      throw new Error("A render frame is already active.");
+    }
+    if (typeof callback !== "function") {
+      throw new TypeError("withFrame requires a callback.");
+    }
+
+    const normalizedFrameOptions = normalizeFrameOptions(frameOptions);
+    this.prepareCanvas(normalizedFrameOptions);
+
+    const processor = new this.wasmModule.GerberProcessor();
+    processor.init(this.getContext());
+    applyProcessorOptions(processor, normalizedFrameOptions);
+
+    this.frame = new FrameState(processor, normalizedFrameOptions);
+
+    try {
+      await callback();
+      this.renderFrame();
+    } finally {
+      this.disposeFrameProcessor(processor);
+      this.frame = null;
+    }
+  }
+
+  async renderLayer(layer, layerOptions = {}) {
+    this.assertUsable();
+    if (!this.frame) {
+      throw new Error("renderLayer must be called inside withFrame().");
+    }
+
+    const layerRecord = await this.createLayerRecord(layer, layerOptions);
+    this.frame.addLayer(layerRecord);
+    return layerRecord.layerId;
+  }
+
+  async exportPng(exportOptions = {}) {
+    this.assertUsable();
+    const type = exportOptions.type || "image/png";
+    const quality = exportOptions.quality;
+    const background =
+      "background" in exportOptions
+        ? exportOptions.background
+        : (this.lastFrame?.background ?? DEFAULT_BACKGROUND);
+
+    if (background == null) {
+      return canvasToBlob(this.canvas, type, quality);
+    }
+
+    const output = createOutputCanvas(this.canvas.width, this.canvas.height);
+    if (!output) {
+      return canvasToBlob(this.canvas, type, quality);
+    }
+
+    const context = output.getContext("2d");
+    if (!context) {
+      return canvasToBlob(this.canvas, type, quality);
+    }
+
+    context.fillStyle = normalizeCssColor(background);
+    context.fillRect(0, 0, output.width, output.height);
+    context.drawImage(this.canvas, 0, 0);
+    return canvasToBlob(output, type, quality);
+  }
+
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.frame = null;
+    this.lastFrame = null;
+
+    if (this.rendererOptions.releaseContext !== false && this.gl) {
+      try {
+        this.gl.getExtension("WEBGL_lose_context")?.loseContext();
+      } catch (_error) {
+        // Best-effort cleanup.
+      }
+    }
+  }
+
+  async createLayerRecord(layer, layerOptions) {
+    const { source, options } = normalizeLayer(layer, layerOptions);
+    const content = await sourceToText(source);
+    const offsetX = numberOrDefault(options.offsetX, 0);
+    const offsetY = numberOrDefault(options.offsetY, 0);
+    const layerId = addLayerToProcessor(
+      this.frame.processor,
+      content,
+      offsetX,
+      offsetY,
+    );
+    const bounds = boundaryToPlainObject(
+      this.frame.processor.get_layer_boundary(layerId),
+    );
+    const color =
+      options.color == null
+        ? this.frame.nextColor()
+        : normalizeColor(options.color, this.frame.options.colors[0]);
+    const alpha = clamp01(numberOrDefault(options.alpha, 1));
+
+    return {
+      layerId,
+      name: options.name || getSourceName(source) || `Layer ${layerId}`,
+      bounds,
+      color,
+      alpha,
+    };
+  }
+
+  renderFrame() {
+    const frame = this.frame;
+    if (!frame) {
+      throw new Error("No active frame to render.");
+    }
+
+    const gl = this.getContext();
+    const clear = frame.options.clear !== false;
+    if (frame.layers.length === 0) {
+      if (clear) {
+        clearCanvas(gl, this.canvas);
+      }
+      this.lastFrame = frame.toResult(null);
+      return;
+    }
+
+    const view = resolveFrameView(frame, this.canvas);
+    const activeLayerIds = new Uint32Array(frame.layers.map((layer) => layer.layerId));
+    const globalAlpha = clamp01(numberOrDefault(frame.options.globalAlpha, 1));
+
+    if (typeof frame.processor.render_with_clear === "function") {
+      const colorData = new Float32Array(
+        frame.layers.flatMap((layer) => [
+          layer.color[0],
+          layer.color[1],
+          layer.color[2],
+          layer.alpha,
+        ]),
+      );
+      frame.processor.render_with_clear(
+        activeLayerIds,
+        colorData,
+        view.zoomX,
+        view.zoomY,
+        view.offsetX,
+        view.offsetY,
+        globalAlpha,
+        clear,
+      );
+    } else {
+      if (!clear) {
+        throw new Error("clear:false requires an updated WASM renderer.");
+      }
+      if (frame.layers.some((layer) => layer.alpha !== 1)) {
+        throw new Error("Layer alpha requires an updated WASM renderer.");
+      }
+      const colorData = new Float32Array(
+        frame.layers.flatMap((layer) => layer.color),
+      );
+      frame.processor.render(
+        activeLayerIds,
+        colorData,
+        view.zoomX,
+        view.zoomY,
+        view.offsetX,
+        view.offsetY,
+        globalAlpha,
+      );
+    }
+
+    this.lastFrame = frame.toResult(view);
+  }
+
+  getContext() {
+    if (this.gl) return this.gl;
+
+    const contextAttributes = {
+      alpha: true,
+      antialias: false,
+      preserveDrawingBuffer: true,
+      ...(this.rendererOptions.contextAttributes || {}),
+    };
+    const gl = this.canvas.getContext("webgl2", contextAttributes);
+    if (!gl) {
+      throw new Error("WebGL2 is unavailable.");
+    }
+
+    this.gl = gl;
+    return gl;
+  }
+
+  prepareCanvas(frameOptions) {
+    const width = positiveIntegerOrDefault(
+      frameOptions.width,
+      this.canvas.width || this.canvas.clientWidth || 1,
+    );
+    const height = positiveIntegerOrDefault(
+      frameOptions.height,
+      this.canvas.height || this.canvas.clientHeight || 1,
+    );
+
+    if (this.canvas.width !== width) {
+      this.canvas.width = width;
+    }
+    if (this.canvas.height !== height) {
+      this.canvas.height = height;
+    }
+
+    frameOptions.width = width;
+    frameOptions.height = height;
+  }
+
+  disposeFrameProcessor(processor) {
+    try {
+      processor.clear();
+    } catch (_error) {
+      // The canvas result is already rendered; cleanup failures should not hide it.
+    }
+  }
+
+  assertUsable() {
+    if (this.disposed) {
+      throw new Error("GerberRenderer has been disposed.");
+    }
+  }
+}
+
+class FrameState {
+  constructor(processor, options) {
+    this.processor = processor;
+    this.options = options;
+    this.layers = [];
+    this.bounds = null;
+    this.nextColorIndex = 0;
+  }
+
+  addLayer(layer) {
+    this.layers.push(layer);
+    this.bounds = mergeBounds(this.bounds, layer.bounds);
+  }
+
+  nextColor() {
+    const color = this.options.colors[
+      this.nextColorIndex % this.options.colors.length
+    ];
+    this.nextColorIndex += 1;
+    return [...color];
+  }
+
+  toResult(view) {
+    return {
+      width: this.options.width,
+      height: this.options.height,
+      background: this.options.background,
+      bounds: this.bounds,
+      view,
+      layers: this.layers.map((layer) => ({
+        id: layer.layerId,
+        name: layer.name,
+        bounds: layer.bounds,
+        color: layer.color,
+        alpha: layer.alpha,
+      })),
+    };
+  }
+}
+
+async function loadWasmModule(rendererOptions) {
+  if (rendererOptions.wasmModule) {
+    return rendererOptions.wasmModule;
+  }
+
+  const wasmModuleUrl =
+    rendererOptions.wasmModuleUrl || DEFAULT_WASM_MODULE_URL.href;
+  try {
+    return await import(String(wasmModuleUrl));
+  } catch (error) {
+    throw new Error(
+      `Failed to load wasm-gerber renderer module from ${wasmModuleUrl}. ` +
+        "Run npm run build:wasm before using the package.",
+      { cause: error },
+    );
+  }
+}
+
+function applyProcessorOptions(processor, frameOptions) {
+  if (typeof processor.set_preserve_arc_regions === "function") {
+    processor.set_preserve_arc_regions(frameOptions.preserveArcRegions !== false);
+  }
+  if (
+    typeof processor.set_arc_tessellation_quality === "function" &&
+    frameOptions.arcTessellationQuality != null
+  ) {
+    processor.set_arc_tessellation_quality(frameOptions.arcTessellationQuality);
+  }
+  if (
+    typeof processor.set_minimum_feature_pixels === "function" &&
+    frameOptions.minimumFeaturePixels != null
+  ) {
+    processor.set_minimum_feature_pixels(frameOptions.minimumFeaturePixels);
+  }
+}
+
+function addLayerToProcessor(processor, content, offsetX, offsetY) {
+  if (offsetX !== 0 || offsetY !== 0) {
+    if (typeof processor.add_layer_with_offset !== "function") {
+      throw new Error("Layer offsets require an updated WASM renderer.");
+    }
+    return processor.add_layer_with_offset(content, offsetX, offsetY);
+  }
+  return processor.add_layer(content);
+}
+
+function normalizeFrameOptions(frameOptions) {
+  return {
+    width: frameOptions.width,
+    height: frameOptions.height,
+    clear: frameOptions.clear !== false,
+    background:
+      "background" in frameOptions ? frameOptions.background : DEFAULT_BACKGROUND,
+    fit: frameOptions.fit !== false,
+    padding: numberOrDefault(frameOptions.padding, 0),
+    view: frameOptions.view || null,
+    preserveArcRegions: frameOptions.preserveArcRegions !== false,
+    arcTessellationQuality: frameOptions.arcTessellationQuality,
+    minimumFeaturePixels: frameOptions.minimumFeaturePixels,
+    globalAlpha: numberOrDefault(frameOptions.globalAlpha, 1),
+    colors: DEFAULT_COLORS.map((color) => [...color]),
+  };
+}
+
+function normalizeLayerList(layers) {
+  if (layers == null) {
+    return [];
+  }
+  if (typeof FileList !== "undefined" && layers instanceof FileList) {
+    return Array.from(layers);
+  }
+  return Array.isArray(layers) ? layers : [layers];
+}
+
+function normalizeLayer(layer, layerOptions = {}) {
+  if (isLayerConfig(layer)) {
+    const { source, ...inlineOptions } = layer;
+    if (source == null) {
+      throw new TypeError("Layer config requires a source.");
+    }
+    return {
+      source,
+      options: { ...inlineOptions, ...layerOptions },
+    };
+  }
+
+  return {
+    source: layer,
+    options: { ...layerOptions },
+  };
+}
+
+function isLayerConfig(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    "source" in value &&
+    !isBlob(value) &&
+    !isArrayBufferLike(value)
+  );
+}
+
+async function sourceToText(source) {
+  if (typeof source === "string") {
+    return source;
+  }
+  if (isBlob(source)) {
+    return source.text();
+  }
+  if (source instanceof ArrayBuffer) {
+    return new TextDecoder().decode(source);
+  }
+  if (ArrayBuffer.isView(source)) {
+    return new TextDecoder().decode(
+      source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength),
+    );
+  }
+
+  throw new TypeError(
+    "Layer source must be a string, File, Blob, ArrayBuffer, or Uint8Array.",
+  );
+}
+
+function getSourceName(source) {
+  if (source && typeof source === "object" && "name" in source) {
+    return String(source.name);
+  }
+  return "";
+}
+
+function isBlob(value) {
+  return typeof Blob !== "undefined" && value instanceof Blob;
+}
+
+function isArrayBufferLike(value) {
+  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+}
+
+function resolveFrameView(frame, canvas) {
+  if (frame.options.view) {
+    return {
+      zoomX: finiteOrThrow(frame.options.view.zoomX, "view.zoomX"),
+      zoomY: finiteOrThrow(frame.options.view.zoomY, "view.zoomY"),
+      offsetX: finiteOrThrow(frame.options.view.offsetX, "view.offsetX"),
+      offsetY: finiteOrThrow(frame.options.view.offsetY, "view.offsetY"),
+    };
+  }
+
+  if (frame.options.fit === false) {
+    return { zoomX: 1, zoomY: 1, offsetX: 0, offsetY: 0 };
+  }
+
+  if (!frame.bounds) {
+    throw new Error("Cannot fit an empty Gerber frame.");
+  }
+
+  return calculateFitView(
+    frame.bounds,
+    canvas.width,
+    canvas.height,
+    frame.options.padding,
+  );
+}
+
+function calculateFitView(bounds, width, height, padding) {
+  const minX = Number(bounds.minX);
+  const maxX = Number(bounds.maxX);
+  const minY = Number(bounds.minY);
+  const maxY = Number(bounds.maxY);
+  if (![minX, maxX, minY, maxY].every(Number.isFinite)) {
+    throw new Error("Cannot fit Gerber layer because bounds are invalid.");
+  }
+
+  const boundsWidth = Math.max(0, maxX - minX);
+  const boundsHeight = Math.max(0, maxY - minY);
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+  const aspect = width / height;
+  const viewWidth = aspect > 1 ? 2 * aspect : 2;
+  const viewHeight = aspect > 1 ? 2 : 2 / aspect;
+  const usableWidth = viewWidth * Math.max(1, width - padding * 2) / width;
+  const usableHeight = viewHeight * Math.max(1, height - padding * 2) / height;
+
+  let zoom = 2;
+  if (boundsWidth > 0 && boundsHeight > 0) {
+    zoom = Math.min(usableWidth / boundsWidth, usableHeight / boundsHeight);
+  } else if (boundsWidth > 0) {
+    zoom = usableWidth / boundsWidth;
+  } else if (boundsHeight > 0) {
+    zoom = usableHeight / boundsHeight;
+  }
+
+  return {
+    zoomX: zoom,
+    zoomY: zoom,
+    offsetX: -centerX * zoom,
+    offsetY: -centerY * zoom,
+  };
+}
+
+function boundaryToPlainObject(boundary) {
+  return {
+    minX: readBoundaryNumber(boundary, "min_x", "minX"),
+    maxX: readBoundaryNumber(boundary, "max_x", "maxX"),
+    minY: readBoundaryNumber(boundary, "min_y", "minY"),
+    maxY: readBoundaryNumber(boundary, "max_y", "maxY"),
+  };
+}
+
+function mergeBounds(first, second) {
+  if (!second) return first;
+  if (!first) return { ...second };
+  return {
+    minX: Math.min(first.minX, second.minX),
+    maxX: Math.max(first.maxX, second.maxX),
+    minY: Math.min(first.minY, second.minY),
+    maxY: Math.max(first.maxY, second.maxY),
+  };
+}
+
+function normalizeColor(color, fallback = DEFAULT_COLORS[0]) {
+  const input = color == null ? fallback : color;
+  if (!input || (!Array.isArray(input) && !ArrayBuffer.isView(input))) {
+    return fallback == null ? null : [...fallback];
+  }
+  if (input.length < 3) {
+    return fallback == null ? null : [...fallback];
+  }
+  const fallbackColor = fallback || DEFAULT_COLORS[0];
+  return [
+    clamp01(numberOrDefault(input[0], fallbackColor[0])),
+    clamp01(numberOrDefault(input[1], fallbackColor[1])),
+    clamp01(numberOrDefault(input[2], fallbackColor[2])),
+  ];
+}
+
+function readBoundaryNumber(boundary, snakeName, camelName) {
+  const value = boundary[snakeName] ?? boundary[camelName];
+  return Number(typeof value === "function" ? value.call(boundary) : value);
+}
+
+function normalizeCssColor(color) {
+  if (typeof color === "string") {
+    return color;
+  }
+  if (Array.isArray(color) && color.length >= 3) {
+    const r = Math.round(clamp01(color[0]) * 255);
+    const g = Math.round(clamp01(color[1]) * 255);
+    const b = Math.round(clamp01(color[2]) * 255);
+    const a = color.length >= 4 ? clamp01(color[3]) : 1;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+  }
+  return "transparent";
+}
+
+function canvasToBlob(canvas, type, quality) {
+  if (typeof canvas.convertToBlob === "function") {
+    return canvas.convertToBlob({ type, quality });
+  }
+  if (typeof canvas.toBlob !== "function") {
+    return Promise.reject(new Error("Canvas PNG export is unavailable."));
+  }
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error("Canvas PNG export failed."));
+      }
+    }, type, quality);
+  });
+}
+
+function createOutputCanvas(width, height) {
+  if (typeof OffscreenCanvas !== "undefined") {
+    return new OffscreenCanvas(width, height);
+  }
+  if (typeof document !== "undefined") {
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    return canvas;
+  }
+  return null;
+}
+
+function clearCanvas(gl, canvas) {
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.clearColor(0, 0, 0, 0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+}
+
+function positiveIntegerOrDefault(value, fallback) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number > 0) {
+    return Math.max(1, Math.round(number));
+  }
+  return Math.max(1, Math.round(Number(fallback) || 1));
+}
+
+function numberOrDefault(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function finiteOrThrow(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new TypeError(`${name} must be finite.`);
+  }
+  return number;
+}
+
+function clamp01(value) {
+  return Math.min(1, Math.max(0, numberOrDefault(value, 0)));
+}

--- a/packages/gerber-renderer/index.js
+++ b/packages/gerber-renderer/index.js
@@ -1,7 +1,7 @@
-const DEFAULT_WASM_MODULE_URL = new URL(
-  "./wasm/wasm_gerber_processor.js",
-  import.meta.url,
-);
+const DEFAULT_WASM_MODULE_URLS = [
+  new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
+  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
+];
 
 const DEFAULT_COLORS = [
   [1.0, 0.0, 0.0],
@@ -360,17 +360,25 @@ async function loadWasmModule(rendererOptions) {
     return rendererOptions.wasmModule;
   }
 
-  const wasmModuleUrl =
-    rendererOptions.wasmModuleUrl || DEFAULT_WASM_MODULE_URL.href;
-  try {
-    return await import(String(wasmModuleUrl));
-  } catch (error) {
-    throw new Error(
-      `Failed to load wasm-gerber renderer module from ${wasmModuleUrl}. ` +
-        "Run npm run build:wasm before using the package.",
-      { cause: error },
-    );
+  const wasmModuleUrls = rendererOptions.wasmModuleUrl
+    ? [rendererOptions.wasmModuleUrl]
+    : DEFAULT_WASM_MODULE_URLS;
+  const errors = [];
+
+  for (const wasmModuleUrl of wasmModuleUrls) {
+    try {
+      return await import(String(wasmModuleUrl));
+    } catch (error) {
+      errors.push({ wasmModuleUrl, error });
+    }
   }
+
+  const attemptedUrls = wasmModuleUrls.map(String).join(", ");
+  throw new Error(
+    `Failed to load wasm-gerber renderer module from ${attemptedUrls}. ` +
+      "Run npm run build:wasm before using the package.",
+    { cause: errors[0]?.error },
+  );
 }
 
 function applyProcessorOptions(processor, frameOptions) {

--- a/packages/gerber-renderer/index.js
+++ b/packages/gerber-renderer/index.js
@@ -46,7 +46,10 @@ export async function renderGerberToPng(
 ) {
   const renderer = await createGerberRenderer(
     canvas,
-    frameOptions.rendererOptions || {},
+    {
+      releaseContext: false,
+      ...(frameOptions.rendererOptions || {}),
+    },
   );
 
   try {

--- a/packages/gerber-renderer/node.d.ts
+++ b/packages/gerber-renderer/node.d.ts
@@ -1,0 +1,112 @@
+export type GerberNodeSource =
+  | File
+  | string
+  | Blob
+  | ArrayBuffer
+  | Uint8Array
+  | URL
+  | { path: string };
+
+export type GerberNodeLayer =
+  | GerberNodeSource
+  | {
+      source: GerberNodeSource;
+      name?: string;
+      color?: RGBColor | string;
+      alpha?: number;
+      offsetX?: number;
+      offsetY?: number;
+    }
+  | {
+      path: string;
+      name?: string;
+      color?: RGBColor | string;
+      alpha?: number;
+      offsetX?: number;
+      offsetY?: number;
+    };
+
+export type RGBColor = [number, number, number];
+export type RGBAColor = [number, number, number, number];
+
+export type NodeRendererOptions = {
+  wasmModule?: unknown;
+  wasmModuleUrl?: string | URL;
+  wasmBinaryUrl?: string | URL;
+  wasmInitInput?: unknown;
+  gl?: unknown;
+  contextAttributes?: Record<string, unknown>;
+  releaseContext?: boolean;
+};
+
+export type NodeFrameOptions = {
+  width?: number;
+  height?: number;
+  clear?: boolean;
+  background?: null | string | RGBAColor;
+  fit?: boolean;
+  padding?: number;
+  view?: {
+    zoomX: number;
+    zoomY: number;
+    offsetX: number;
+    offsetY: number;
+  };
+  preserveArcRegions?: boolean;
+  arcTessellationQuality?: 0 | 1 | 2;
+  minimumFeaturePixels?: number;
+  globalAlpha?: number;
+};
+
+export type NodeLayerOptions = {
+  color?: RGBColor | string;
+  alpha?: number;
+  offsetX?: number;
+  offsetY?: number;
+};
+
+export type NodeExportOptions = {
+  background?: null | string | RGBAColor;
+};
+
+export declare function createNodeGerberRenderer(
+  rendererOptions?: NodeRendererOptions,
+): Promise<NodeGerberRenderer>;
+
+export declare function renderGerberToPngBuffer(
+  layers: GerberNodeLayer | GerberNodeLayer[],
+  frameOptions?: NodeFrameOptions,
+  exportOptions?: NodeExportOptions,
+  rendererOptions?: NodeRendererOptions,
+): Promise<Uint8Array>;
+
+export declare function renderGerberToPngFile(
+  outputPath: string,
+  layers: GerberNodeLayer | GerberNodeLayer[],
+  frameOptions?: NodeFrameOptions,
+  exportOptions?: NodeExportOptions,
+  rendererOptions?: NodeRendererOptions,
+): Promise<void>;
+
+export declare function fileLayer(
+  path: string,
+  options?: Omit<NodeLayerOptions, "path"> & { name?: string },
+): GerberNodeLayer;
+
+export declare function packageRoot(): string;
+
+export declare class NodeGerberRenderer {
+  withFrame(
+    frameOptions: NodeFrameOptions,
+    callback: () => void | Promise<void>,
+  ): Promise<void>;
+
+  renderLayer(
+    layer: GerberNodeLayer,
+    layerOptions?: NodeLayerOptions,
+  ): Promise<number>;
+
+  exportPng(exportOptions?: NodeExportOptions): Promise<Uint8Array>;
+
+  dispose(): void;
+}

--- a/packages/gerber-renderer/node.d.ts
+++ b/packages/gerber-renderer/node.d.ts
@@ -34,6 +34,8 @@ export type NodeRendererOptions = {
   wasmModuleUrl?: string | URL;
   wasmBinaryUrl?: string | URL;
   wasmInitInput?: unknown;
+  glesModule?: unknown;
+  glesModuleName?: string;
   gl?: unknown;
   contextAttributes?: Record<string, unknown>;
   releaseContext?: boolean;

--- a/packages/gerber-renderer/node.d.ts
+++ b/packages/gerber-renderer/node.d.ts
@@ -44,7 +44,7 @@ export type NodeRendererOptions = {
 export type NodeFrameOptions = {
   width?: number;
   height?: number;
-  clear?: boolean;
+  clear?: true;
   background?: null | string | RGBAColor;
   fit?: boolean;
   padding?: number;

--- a/packages/gerber-renderer/node.js
+++ b/packages/gerber-renderer/node.js
@@ -169,6 +169,7 @@ export class NodeGerberRenderer {
     this.gl = createNodeGlesContext(
       width,
       height,
+      this.rendererOptions,
       this.rendererOptions.contextAttributes || {},
     );
     return this.gl;
@@ -366,31 +367,20 @@ async function readBinaryUrl(url) {
   return new Uint8Array(await response.arrayBuffer());
 }
 
-function createNodeGlesContext(width, height, contextAttributes) {
-  let nodeGles;
-  try {
-    nodeGles = require("node-gles");
-  } catch (error) {
-    throw new Error(
-      "node-gles is required for Node CLI rendering. Install it with `npm install node-gles`.",
-      { cause: error },
-    );
-  }
+function createNodeGlesContext(width, height, rendererOptions, contextAttributes) {
+  const { moduleName, module: nodeGles } = loadNodeGlesModule(rendererOptions);
 
   const createContext =
     nodeGles.binding?.createWebGLRenderingContext ||
     nodeGles.createWebGLRenderingContext;
   if (typeof createContext !== "function") {
-    throw new Error("node-gles does not expose createWebGLRenderingContext().");
+    throw new Error(`${moduleName} does not expose createWebGLRenderingContext().`);
   }
 
   const attempts = [
-    [width, height, contextAttributes],
-    [width, height],
     [{ width, height, ...contextAttributes }],
-    [contextAttributes],
-    [],
   ];
+  const errors = [];
 
   for (const args of attempts) {
     try {
@@ -399,12 +389,45 @@ function createNodeGlesContext(width, height, contextAttributes) {
         validateWebGl2Context(gl);
         return gl;
       }
-    } catch (_error) {
-      // Try the next node-gles signature.
+    } catch (error) {
+      errors.push(error);
     }
   }
 
-  throw new Error("node-gles failed to create a WebGL2 context.");
+  throw new Error(
+    `${moduleName} failed to create a compatible WebGL2 context. ` +
+      "The installed GLES module must expose createVertexArray(), " +
+      "drawArraysInstanced(), and vertexAttribDivisor().",
+    { cause: errors[0] },
+  );
+}
+
+function loadNodeGlesModule(rendererOptions) {
+  if (rendererOptions.glesModule) {
+    return { moduleName: "custom GLES module", module: rendererOptions.glesModule };
+  }
+
+  const moduleNames = [
+    rendererOptions.glesModuleName,
+    process.env.GERBER_RENDERER_GLES_MODULE,
+    "node-gles-webgl2",
+    "node-gles",
+  ].filter(Boolean);
+  const errors = [];
+
+  for (const moduleName of moduleNames) {
+    try {
+      return { moduleName, module: require(moduleName) };
+    } catch (error) {
+      errors.push({ moduleName, error });
+    }
+  }
+
+  throw new Error(
+    "A WebGL2-capable GLES module is required for Node CLI rendering. " +
+      "Install node-gles-webgl2 or pass rendererOptions.glesModule.",
+    { cause: errors[0]?.error },
+  );
 }
 
 function validateWebGl2Context(gl) {

--- a/packages/gerber-renderer/node.js
+++ b/packages/gerber-renderer/node.js
@@ -322,7 +322,12 @@ class FrameState {
 
 async function loadWasmModule(rendererOptions) {
   if (rendererOptions.wasmModule) {
-    return { wasmModule: rendererOptions.wasmModule, wasmModuleUrl: null };
+    return {
+      wasmModule: rendererOptions.wasmModule,
+      wasmModuleUrl: rendererOptions.wasmModuleUrl
+        ? toUrl(rendererOptions.wasmModuleUrl)
+        : null,
+    };
   }
 
   const wasmModuleUrls = rendererOptions.wasmModuleUrl
@@ -361,7 +366,13 @@ async function initializeWasmModule(wasmModule, wasmModuleUrl, rendererOptions) 
     ? toUrl(rendererOptions.wasmBinaryUrl)
     : wasmModuleUrl
       ? new URL("wasm_gerber_processor_bg.wasm", wasmModuleUrl)
-      : new URL("./wasm/wasm_gerber_processor_bg.wasm", import.meta.url);
+      : null;
+
+  if (!wasmBinaryUrl) {
+    await wasmModule.default();
+    return;
+  }
+
   const bytes = await readBinaryUrl(wasmBinaryUrl);
   await wasmModule.default({ module_or_path: bytes });
 }

--- a/packages/gerber-renderer/node.js
+++ b/packages/gerber-renderer/node.js
@@ -1,0 +1,874 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { deflateSync } from "node:zlib";
+
+const require = createRequire(import.meta.url);
+
+const DEFAULT_WASM_MODULE_URLS = [
+  new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
+  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
+];
+
+const DEFAULT_COLORS = [
+  [1.0, 0.0, 0.0],
+  [0.0, 1.0, 0.0],
+  [0.0, 0.0, 1.0],
+  [1.0, 0.0, 1.0],
+  [1.0, 1.0, 0.0],
+  [0.0, 1.0, 1.0],
+];
+
+const DEFAULT_WIDTH = 1200;
+const DEFAULT_HEIGHT = 800;
+const DEFAULT_BACKGROUND = null;
+
+export async function createNodeGerberRenderer(rendererOptions = {}) {
+  return NodeGerberRenderer.create(rendererOptions);
+}
+
+export async function renderGerberToPngBuffer(
+  layers,
+  frameOptions = {},
+  exportOptions = {},
+  rendererOptions = {},
+) {
+  const renderer = await createNodeGerberRenderer(rendererOptions);
+  try {
+    await renderer.withFrame(frameOptions, async () => {
+      for (const layer of normalizeLayerList(layers)) {
+        await renderer.renderLayer(layer);
+      }
+    });
+    return renderer.exportPng(exportOptions);
+  } finally {
+    renderer.dispose();
+  }
+}
+
+export async function renderGerberToPngFile(
+  outputPath,
+  layers,
+  frameOptions = {},
+  exportOptions = {},
+  rendererOptions = {},
+) {
+  const png = await renderGerberToPngBuffer(
+    layers,
+    frameOptions,
+    exportOptions,
+    rendererOptions,
+  );
+  await writeFile(outputPath, png);
+}
+
+export class NodeGerberRenderer {
+  static async create(rendererOptions = {}) {
+    const { wasmModule, wasmModuleUrl } = await loadWasmModule(rendererOptions);
+    await initializeWasmModule(wasmModule, wasmModuleUrl, rendererOptions);
+    return new NodeGerberRenderer(rendererOptions, wasmModule);
+  }
+
+  constructor(rendererOptions, wasmModule) {
+    this.rendererOptions = { ...rendererOptions };
+    this.wasmModule = wasmModule;
+    this.gl = rendererOptions.gl || null;
+    this.frame = null;
+    this.lastFrame = null;
+    this.lastPixels = null;
+    this.disposed = false;
+  }
+
+  async withFrame(frameOptions = {}, callback) {
+    this.assertUsable();
+    if (this.frame) {
+      throw new Error("A render frame is already active.");
+    }
+    if (typeof callback !== "function") {
+      throw new TypeError("withFrame requires a callback.");
+    }
+
+    const normalizedFrameOptions = normalizeFrameOptions(frameOptions);
+    const gl = this.getContext(
+      normalizedFrameOptions.width,
+      normalizedFrameOptions.height,
+    );
+    const processor = new this.wasmModule.GerberProcessor();
+    if (typeof processor.init_with_size !== "function") {
+      throw new Error("Headless rendering requires an updated WASM module.");
+    }
+    processor.init_with_size(
+      gl,
+      normalizedFrameOptions.width,
+      normalizedFrameOptions.height,
+    );
+    applyProcessorOptions(processor, normalizedFrameOptions);
+
+    this.frame = new FrameState(processor, normalizedFrameOptions);
+    this.lastFrame = null;
+    this.lastPixels = null;
+
+    try {
+      await callback();
+      this.renderFrameToPixels();
+    } finally {
+      this.disposeFrameProcessor(processor);
+      this.frame = null;
+    }
+  }
+
+  async renderLayer(layer, layerOptions = {}) {
+    this.assertUsable();
+    if (!this.frame) {
+      throw new Error("renderLayer must be called inside withFrame().");
+    }
+
+    const layerRecord = await this.createLayerRecord(layer, layerOptions);
+    this.frame.addLayer(layerRecord);
+    return layerRecord.layerId;
+  }
+
+  async exportPng(exportOptions = {}) {
+    this.assertUsable();
+    if (!this.lastFrame || !this.lastPixels) {
+      throw new Error("No rendered frame is available for export.");
+    }
+
+    const background =
+      "background" in exportOptions
+        ? exportOptions.background
+        : this.lastFrame.background;
+    const pixels =
+      background == null
+        ? this.lastPixels
+        : compositeBackground(this.lastPixels, parseColor(background, true));
+
+    return rgbaToPngBuffer(pixels, this.lastFrame.width, this.lastFrame.height);
+  }
+
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.frame = null;
+    this.lastFrame = null;
+    this.lastPixels = null;
+
+    if (this.rendererOptions.releaseContext !== false && this.gl) {
+      try {
+        this.gl.getExtension("WEBGL_lose_context")?.loseContext();
+      } catch (_error) {
+        // Best-effort cleanup.
+      }
+    }
+  }
+
+  getContext(width, height) {
+    if (this.gl) return this.gl;
+
+    this.gl = createNodeGlesContext(
+      width,
+      height,
+      this.rendererOptions.contextAttributes || {},
+    );
+    return this.gl;
+  }
+
+  async createLayerRecord(layer, layerOptions) {
+    const { source, options } = normalizeLayer(layer, layerOptions);
+    const content = await sourceToText(source);
+    const offsetX = numberOrDefault(options.offsetX, 0);
+    const offsetY = numberOrDefault(options.offsetY, 0);
+    const layerId = addLayerToProcessor(
+      this.frame.processor,
+      content,
+      offsetX,
+      offsetY,
+    );
+    const bounds = boundaryToPlainObject(
+      this.frame.processor.get_layer_boundary(layerId),
+    );
+    const color =
+      options.color == null
+        ? this.frame.nextColor()
+        : normalizeColor(options.color, this.frame.options.colors[0]);
+    const alpha = clamp01(numberOrDefault(options.alpha, 1));
+
+    return {
+      layerId,
+      name: options.name || getSourceName(source) || `Layer ${layerId}`,
+      bounds,
+      color,
+      alpha,
+    };
+  }
+
+  renderFrameToPixels() {
+    const frame = this.frame;
+    if (!frame) {
+      throw new Error("No active frame to render.");
+    }
+
+    if (frame.layers.length === 0) {
+      const pixelCount = frame.options.width * frame.options.height * 4;
+      this.lastPixels = Buffer.alloc(pixelCount);
+      this.lastFrame = frame.toResult(null);
+      return;
+    }
+
+    const view = resolveFrameView(
+      frame,
+      frame.options.width,
+      frame.options.height,
+    );
+    const activeLayerIds = new Uint32Array(
+      frame.layers.map((layer) => layer.layerId),
+    );
+    const colorData = new Float32Array(frame.layers.length * 4);
+    for (const [index, layer] of frame.layers.entries()) {
+      const offset = index * 4;
+      colorData[offset] = layer.color[0];
+      colorData[offset + 1] = layer.color[1];
+      colorData[offset + 2] = layer.color[2];
+      colorData[offset + 3] = layer.alpha;
+    }
+
+    const globalAlpha = clamp01(numberOrDefault(frame.options.globalAlpha, 1));
+    const pixels = frame.processor.render_pixels_with_clear(
+      activeLayerIds,
+      colorData,
+      view.zoomX,
+      view.zoomY,
+      view.offsetX,
+      view.offsetY,
+      globalAlpha,
+      frame.options.clear !== false,
+    );
+
+    this.lastPixels = flipRgbaRows(
+      Buffer.from(pixels),
+      frame.options.width,
+      frame.options.height,
+    );
+    this.lastFrame = frame.toResult(view);
+  }
+
+  disposeFrameProcessor(processor) {
+    try {
+      processor.clear();
+    } catch (_error) {
+      // The pixel result is already copied; cleanup failures should not hide it.
+    }
+  }
+
+  assertUsable() {
+    if (this.disposed) {
+      throw new Error("NodeGerberRenderer has been disposed.");
+    }
+  }
+}
+
+class FrameState {
+  constructor(processor, options) {
+    this.processor = processor;
+    this.options = options;
+    this.layers = [];
+    this.bounds = null;
+    this.nextColorIndex = 0;
+  }
+
+  addLayer(layer) {
+    this.layers.push(layer);
+    this.bounds = mergeBounds(this.bounds, layer.bounds);
+  }
+
+  nextColor() {
+    const color = this.options.colors[
+      this.nextColorIndex % this.options.colors.length
+    ];
+    this.nextColorIndex += 1;
+    return [...color];
+  }
+
+  toResult(view) {
+    return {
+      width: this.options.width,
+      height: this.options.height,
+      background: this.options.background,
+      bounds: this.bounds,
+      view,
+      layers: this.layers.map((layer) => ({
+        id: layer.layerId,
+        name: layer.name,
+        bounds: layer.bounds,
+        color: layer.color,
+        alpha: layer.alpha,
+      })),
+    };
+  }
+}
+
+async function loadWasmModule(rendererOptions) {
+  if (rendererOptions.wasmModule) {
+    return { wasmModule: rendererOptions.wasmModule, wasmModuleUrl: null };
+  }
+
+  const wasmModuleUrls = rendererOptions.wasmModuleUrl
+    ? [toUrl(rendererOptions.wasmModuleUrl)]
+    : DEFAULT_WASM_MODULE_URLS;
+  const errors = [];
+
+  for (const wasmModuleUrl of wasmModuleUrls) {
+    try {
+      return {
+        wasmModule: await import(String(wasmModuleUrl)),
+        wasmModuleUrl,
+      };
+    } catch (error) {
+      errors.push({ wasmModuleUrl, error });
+    }
+  }
+
+  const attemptedUrls = wasmModuleUrls.map(String).join(", ");
+  throw new Error(
+    `Failed to load wasm-gerber renderer module from ${attemptedUrls}. ` +
+      "Run npm run build:wasm before using the Node renderer.",
+    { cause: errors[0]?.error },
+  );
+}
+
+async function initializeWasmModule(wasmModule, wasmModuleUrl, rendererOptions) {
+  if (typeof wasmModule.default !== "function") return;
+
+  if (rendererOptions.wasmInitInput !== undefined) {
+    await wasmModule.default(rendererOptions.wasmInitInput);
+    return;
+  }
+
+  const wasmBinaryUrl = rendererOptions.wasmBinaryUrl
+    ? toUrl(rendererOptions.wasmBinaryUrl)
+    : wasmModuleUrl
+      ? new URL("wasm_gerber_processor_bg.wasm", wasmModuleUrl)
+      : new URL("./wasm/wasm_gerber_processor_bg.wasm", import.meta.url);
+  const bytes = await readBinaryUrl(wasmBinaryUrl);
+  await wasmModule.default({ module_or_path: bytes });
+}
+
+async function readBinaryUrl(url) {
+  if (url.protocol === "file:") {
+    return readFile(fileURLToPath(url));
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch WASM binary: ${response.status}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function createNodeGlesContext(width, height, contextAttributes) {
+  let nodeGles;
+  try {
+    nodeGles = require("node-gles");
+  } catch (error) {
+    throw new Error(
+      "node-gles is required for Node CLI rendering. Install it with `npm install node-gles`.",
+      { cause: error },
+    );
+  }
+
+  const createContext =
+    nodeGles.binding?.createWebGLRenderingContext ||
+    nodeGles.createWebGLRenderingContext;
+  if (typeof createContext !== "function") {
+    throw new Error("node-gles does not expose createWebGLRenderingContext().");
+  }
+
+  const attempts = [
+    [width, height, contextAttributes],
+    [width, height],
+    [{ width, height, ...contextAttributes }],
+    [contextAttributes],
+    [],
+  ];
+
+  for (const args of attempts) {
+    try {
+      const gl = createContext(...args);
+      if (gl) {
+        validateWebGl2Context(gl);
+        return gl;
+      }
+    } catch (_error) {
+      // Try the next node-gles signature.
+    }
+  }
+
+  throw new Error("node-gles failed to create a WebGL2 context.");
+}
+
+function validateWebGl2Context(gl) {
+  const requiredMethods = [
+    "createVertexArray",
+    "drawArraysInstanced",
+    "vertexAttribDivisor",
+    "readPixels",
+  ];
+  const missing = requiredMethods.filter((name) => typeof gl[name] !== "function");
+  if (missing.length > 0) {
+    throw new Error(
+      `node-gles returned a context without required WebGL2 methods: ${missing.join(", ")}`,
+    );
+  }
+}
+
+function applyProcessorOptions(processor, frameOptions) {
+  if (typeof processor.set_preserve_arc_regions === "function") {
+    processor.set_preserve_arc_regions(frameOptions.preserveArcRegions !== false);
+  }
+  if (
+    typeof processor.set_arc_tessellation_quality === "function" &&
+    frameOptions.arcTessellationQuality != null
+  ) {
+    processor.set_arc_tessellation_quality(frameOptions.arcTessellationQuality);
+  }
+  if (
+    typeof processor.set_minimum_feature_pixels === "function" &&
+    frameOptions.minimumFeaturePixels != null
+  ) {
+    processor.set_minimum_feature_pixels(frameOptions.minimumFeaturePixels);
+  }
+}
+
+function addLayerToProcessor(processor, content, offsetX, offsetY) {
+  if (offsetX !== 0 || offsetY !== 0) {
+    if (typeof processor.add_layer_with_offset !== "function") {
+      throw new Error("Layer offsets require an updated WASM renderer.");
+    }
+    return processor.add_layer_with_offset(content, offsetX, offsetY);
+  }
+  return processor.add_layer(content);
+}
+
+function normalizeFrameOptions(frameOptions) {
+  return {
+    width: positiveIntegerOrDefault(frameOptions.width, DEFAULT_WIDTH),
+    height: positiveIntegerOrDefault(frameOptions.height, DEFAULT_HEIGHT),
+    clear: frameOptions.clear !== false,
+    background:
+      "background" in frameOptions ? frameOptions.background : DEFAULT_BACKGROUND,
+    fit: frameOptions.fit !== false,
+    padding: numberOrDefault(frameOptions.padding, 0),
+    view: frameOptions.view || null,
+    preserveArcRegions: frameOptions.preserveArcRegions !== false,
+    arcTessellationQuality: frameOptions.arcTessellationQuality,
+    minimumFeaturePixels: frameOptions.minimumFeaturePixels,
+    globalAlpha: numberOrDefault(frameOptions.globalAlpha, 1),
+    colors: DEFAULT_COLORS.map((color) => [...color]),
+  };
+}
+
+function normalizeLayerList(layers) {
+  if (layers == null) {
+    return [];
+  }
+  return Array.isArray(layers) ? layers : [layers];
+}
+
+function normalizeLayer(layer, layerOptions = {}) {
+  if (isPathLayerConfig(layer)) {
+    const { path, ...inlineOptions } = layer;
+    return {
+      source: { path },
+      options: { ...inlineOptions, ...layerOptions },
+    };
+  }
+  if (isLayerConfig(layer)) {
+    const { source, ...inlineOptions } = layer;
+    if (source == null) {
+      throw new TypeError("Layer config requires a source.");
+    }
+    return {
+      source,
+      options: { ...inlineOptions, ...layerOptions },
+    };
+  }
+
+  return {
+    source: layer,
+    options: { ...layerOptions },
+  };
+}
+
+function isPathLayerConfig(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    "path" in value &&
+    !("source" in value)
+  );
+}
+
+function isLayerConfig(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    "source" in value &&
+    !isBlob(value) &&
+    !isArrayBufferLike(value)
+  );
+}
+
+async function sourceToText(source) {
+  if (typeof source === "string") {
+    return source;
+  }
+  if (source instanceof URL) {
+    return readFile(fileURLToPath(source), "utf8");
+  }
+  if (source && typeof source === "object" && "path" in source) {
+    return readFile(String(source.path), "utf8");
+  }
+  if (isBlob(source)) {
+    return source.text();
+  }
+  if (source instanceof ArrayBuffer) {
+    return new TextDecoder().decode(source);
+  }
+  if (ArrayBuffer.isView(source)) {
+    return new TextDecoder().decode(
+      source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength),
+    );
+  }
+
+  throw new TypeError(
+    "Layer source must be a string, File, Blob, ArrayBuffer, Uint8Array, URL, or path config.",
+  );
+}
+
+function getSourceName(source) {
+  if (source && typeof source === "object" && "name" in source) {
+    return String(source.name);
+  }
+  if (source && typeof source === "object" && "path" in source) {
+    return basename(String(source.path));
+  }
+  if (source instanceof URL && source.protocol === "file:") {
+    return basename(fileURLToPath(source));
+  }
+  return "";
+}
+
+function isBlob(value) {
+  return typeof Blob !== "undefined" && value instanceof Blob;
+}
+
+function isArrayBufferLike(value) {
+  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+}
+
+function resolveFrameView(frame, width, height) {
+  if (frame.options.view) {
+    return {
+      zoomX: finiteOrThrow(frame.options.view.zoomX, "view.zoomX"),
+      zoomY: finiteOrThrow(frame.options.view.zoomY, "view.zoomY"),
+      offsetX: finiteOrThrow(frame.options.view.offsetX, "view.offsetX"),
+      offsetY: finiteOrThrow(frame.options.view.offsetY, "view.offsetY"),
+    };
+  }
+
+  if (frame.options.fit === false) {
+    return { zoomX: 1, zoomY: 1, offsetX: 0, offsetY: 0 };
+  }
+
+  if (!frame.bounds) {
+    throw new Error("Cannot fit an empty Gerber frame.");
+  }
+
+  return calculateFitView(frame.bounds, width, height, frame.options.padding);
+}
+
+function calculateFitView(bounds, width, height, padding) {
+  const minX = Number(bounds.minX);
+  const maxX = Number(bounds.maxX);
+  const minY = Number(bounds.minY);
+  const maxY = Number(bounds.maxY);
+  if (![minX, maxX, minY, maxY].every(Number.isFinite)) {
+    throw new Error("Cannot fit Gerber layer because bounds are invalid.");
+  }
+
+  const boundsWidth = Math.max(0, maxX - minX);
+  const boundsHeight = Math.max(0, maxY - minY);
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+  const aspect = width / height;
+  const viewWidth = aspect > 1 ? 2 * aspect : 2;
+  const viewHeight = aspect > 1 ? 2 : 2 / aspect;
+  const usableWidth = viewWidth * Math.max(1, width - padding * 2) / width;
+  const usableHeight = viewHeight * Math.max(1, height - padding * 2) / height;
+
+  let zoom = 2;
+  if (boundsWidth > 0 && boundsHeight > 0) {
+    zoom = Math.min(usableWidth / boundsWidth, usableHeight / boundsHeight);
+  } else if (boundsWidth > 0) {
+    zoom = usableWidth / boundsWidth;
+  } else if (boundsHeight > 0) {
+    zoom = usableHeight / boundsHeight;
+  }
+
+  return {
+    zoomX: zoom,
+    zoomY: zoom,
+    offsetX: -centerX * zoom,
+    offsetY: -centerY * zoom,
+  };
+}
+
+function boundaryToPlainObject(boundary) {
+  return {
+    minX: readBoundaryNumber(boundary, "min_x", "minX"),
+    maxX: readBoundaryNumber(boundary, "max_x", "maxX"),
+    minY: readBoundaryNumber(boundary, "min_y", "minY"),
+    maxY: readBoundaryNumber(boundary, "max_y", "maxY"),
+  };
+}
+
+function readBoundaryNumber(boundary, snakeName, camelName) {
+  const value = boundary[snakeName] ?? boundary[camelName];
+  return Number(typeof value === "function" ? value.call(boundary) : value);
+}
+
+function mergeBounds(first, second) {
+  if (!second) return first;
+  if (!first) return { ...second };
+  return {
+    minX: Math.min(first.minX, second.minX),
+    maxX: Math.max(first.maxX, second.maxX),
+    minY: Math.min(first.minY, second.minY),
+    maxY: Math.max(first.maxY, second.maxY),
+  };
+}
+
+function normalizeColor(color, fallback = DEFAULT_COLORS[0]) {
+  const input = color == null ? fallback : color;
+  if (typeof input === "string") {
+    return parseColor(input).slice(0, 3).map((value) => value / 255);
+  }
+  if (!input || (!Array.isArray(input) && !ArrayBuffer.isView(input))) {
+    return fallback == null ? null : [...fallback];
+  }
+  if (input.length < 3) {
+    return fallback == null ? null : [...fallback];
+  }
+  const fallbackColor = fallback || DEFAULT_COLORS[0];
+  return [
+    clamp01(numberOrDefault(input[0], fallbackColor[0])),
+    clamp01(numberOrDefault(input[1], fallbackColor[1])),
+    clamp01(numberOrDefault(input[2], fallbackColor[2])),
+  ];
+}
+
+function parseColor(color, allowAlpha = false) {
+  if (Array.isArray(color) || ArrayBuffer.isView(color)) {
+    if (color.length < 3) {
+      throw new TypeError("Color arrays must have at least three channels.");
+    }
+    return [
+      Math.round(clamp01(color[0]) * 255),
+      Math.round(clamp01(color[1]) * 255),
+      Math.round(clamp01(color[2]) * 255),
+      Math.round(clamp01(color.length >= 4 ? color[3] : 1) * 255),
+    ];
+  }
+
+  if (typeof color !== "string") {
+    throw new TypeError("Color must be a CSS hex/rgb string or RGBA array.");
+  }
+
+  const hex = color.trim().match(/^#([0-9a-f]{3,8})$/i);
+  if (hex) {
+    const value = hex[1];
+    if (value.length === 3 || value.length === 4) {
+      return [
+        parseInt(value[0] + value[0], 16),
+        parseInt(value[1] + value[1], 16),
+        parseInt(value[2] + value[2], 16),
+        value.length === 4 && allowAlpha ? parseInt(value[3] + value[3], 16) : 255,
+      ];
+    }
+    if (value.length === 6 || value.length === 8) {
+      return [
+        parseInt(value.slice(0, 2), 16),
+        parseInt(value.slice(2, 4), 16),
+        parseInt(value.slice(4, 6), 16),
+        value.length === 8 && allowAlpha ? parseInt(value.slice(6, 8), 16) : 255,
+      ];
+    }
+  }
+
+  const rgb = color
+    .trim()
+    .match(/^rgba?\(([^,]+),([^,]+),([^,]+)(?:,([^,]+))?\)$/i);
+  if (rgb) {
+    return [
+      parseCssChannel(rgb[1]),
+      parseCssChannel(rgb[2]),
+      parseCssChannel(rgb[3]),
+      rgb[4] && allowAlpha ? Math.round(clamp01(Number(rgb[4])) * 255) : 255,
+    ];
+  }
+
+  throw new TypeError(`Unsupported color format: ${color}`);
+}
+
+function parseCssChannel(value) {
+  const trimmed = value.trim();
+  if (trimmed.endsWith("%")) {
+    return Math.round(clamp01(Number(trimmed.slice(0, -1)) / 100) * 255);
+  }
+  return Math.min(255, Math.max(0, Math.round(Number(trimmed))));
+}
+
+function compositeBackground(pixels, background) {
+  const output = Buffer.from(pixels);
+  const bgA = background[3] / 255;
+  for (let index = 0; index < output.length; index += 4) {
+    const srcA = output[index + 3] / 255;
+    const outA = srcA + bgA * (1 - srcA);
+    if (outA <= 0) {
+      output[index] = 0;
+      output[index + 1] = 0;
+      output[index + 2] = 0;
+      output[index + 3] = 0;
+      continue;
+    }
+
+    output[index] = Math.round(
+      (output[index] * srcA + background[0] * bgA * (1 - srcA)) / outA,
+    );
+    output[index + 1] = Math.round(
+      (output[index + 1] * srcA + background[1] * bgA * (1 - srcA)) / outA,
+    );
+    output[index + 2] = Math.round(
+      (output[index + 2] * srcA + background[2] * bgA * (1 - srcA)) / outA,
+    );
+    output[index + 3] = Math.round(outA * 255);
+  }
+  return output;
+}
+
+function flipRgbaRows(pixels, width, height) {
+  const rowSize = width * 4;
+  const output = Buffer.allocUnsafe(pixels.length);
+  for (let y = 0; y < height; y += 1) {
+    const sourceStart = (height - 1 - y) * rowSize;
+    const targetStart = y * rowSize;
+    pixels.copy(output, targetStart, sourceStart, sourceStart + rowSize);
+  }
+  return output;
+}
+
+function rgbaToPngBuffer(rgba, width, height) {
+  const rowSize = width * 4;
+  const raw = Buffer.allocUnsafe((rowSize + 1) * height);
+  for (let y = 0; y < height; y += 1) {
+    const rawOffset = y * (rowSize + 1);
+    raw[rawOffset] = 0;
+    rgba.copy(raw, rawOffset + 1, y * rowSize, (y + 1) * rowSize);
+  }
+
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 6;
+  header[10] = 0;
+  header[11] = 0;
+  header[12] = 0;
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk("IHDR", header),
+    pngChunk("IDAT", deflateSync(raw)),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+function pngChunk(type, data) {
+  const typeBuffer = Buffer.from(type, "ascii");
+  const chunk = Buffer.allocUnsafe(12 + data.length);
+  chunk.writeUInt32BE(data.length, 0);
+  typeBuffer.copy(chunk, 4);
+  data.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(Buffer.concat([typeBuffer, data])), 8 + data.length);
+  return chunk;
+}
+
+let crcTable = null;
+
+function crc32(buffer) {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let n = 0; n < 256; n += 1) {
+      let c = n;
+      for (let k = 0; k < 8; k += 1) {
+        c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      }
+      crcTable[n] = c >>> 0;
+    }
+  }
+
+  let c = 0xffffffff;
+  for (const byte of buffer) {
+    c = crcTable[(c ^ byte) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function positiveIntegerOrDefault(value, fallback) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number > 0) {
+    return Math.max(1, Math.round(number));
+  }
+  return Math.max(1, Math.round(Number(fallback) || 1));
+}
+
+function numberOrDefault(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function finiteOrThrow(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new TypeError(`${name} must be finite.`);
+  }
+  return number;
+}
+
+function clamp01(value) {
+  return Math.min(1, Math.max(0, numberOrDefault(value, 0)));
+}
+
+function toUrl(value) {
+  if (value instanceof URL) return value;
+  if (typeof value === "string") {
+    if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+      return new URL(value);
+    }
+    return pathToFileURL(resolve(value));
+  }
+  throw new TypeError("Expected a URL or path string.");
+}
+
+export function fileLayer(path, options = {}) {
+  return {
+    source: { path },
+    name: options.name || basename(path),
+    ...options,
+  };
+}
+
+export function packageRoot() {
+  return resolve(dirname(fileURLToPath(import.meta.url)));
+}

--- a/packages/gerber-renderer/node.js
+++ b/packages/gerber-renderer/node.js
@@ -23,6 +23,14 @@ const DEFAULT_COLORS = [
 const DEFAULT_WIDTH = 1200;
 const DEFAULT_HEIGHT = 800;
 const DEFAULT_BACKGROUND = null;
+const REQUIRED_WEBGL2_METHODS = [
+  "createVertexArray",
+  "bindVertexArray",
+  "deleteVertexArray",
+  "drawArraysInstanced",
+  "vertexAttribDivisor",
+  "readPixels",
+];
 
 export async function createNodeGerberRenderer(rendererOptions = {}) {
   return NodeGerberRenderer.create(rendererOptions);
@@ -164,7 +172,10 @@ export class NodeGerberRenderer {
   }
 
   getContext(width, height) {
-    if (this.gl) return this.gl;
+    if (this.gl) {
+      validateWebGl2Context(this.gl);
+      return this.gl;
+    }
 
     this.gl = createNodeGlesContext(
       width,
@@ -396,8 +407,7 @@ function createNodeGlesContext(width, height, rendererOptions, contextAttributes
 
   throw new Error(
     `${moduleName} failed to create a compatible WebGL2 context. ` +
-      "The installed GLES module must expose createVertexArray(), " +
-      "drawArraysInstanced(), and vertexAttribDivisor().",
+      `The installed GLES module must expose ${REQUIRED_WEBGL2_METHODS.join(", ")}.`,
     { cause: errors[0] },
   );
 }
@@ -431,16 +441,12 @@ function loadNodeGlesModule(rendererOptions) {
 }
 
 function validateWebGl2Context(gl) {
-  const requiredMethods = [
-    "createVertexArray",
-    "drawArraysInstanced",
-    "vertexAttribDivisor",
-    "readPixels",
-  ];
-  const missing = requiredMethods.filter((name) => typeof gl[name] !== "function");
+  const missing = REQUIRED_WEBGL2_METHODS.filter(
+    (name) => typeof gl[name] !== "function",
+  );
   if (missing.length > 0) {
     throw new Error(
-      `node-gles returned a context without required WebGL2 methods: ${missing.join(", ")}`,
+      `GLES context is missing required WebGL2 methods: ${missing.join(", ")}`,
     );
   }
 }
@@ -474,10 +480,16 @@ function addLayerToProcessor(processor, content, offsetX, offsetY) {
 }
 
 function normalizeFrameOptions(frameOptions) {
+  if (frameOptions.clear === false) {
+    throw new Error(
+      "clear:false is not supported by Node rendering because each frame renders to a fresh output buffer.",
+    );
+  }
+
   return {
     width: positiveIntegerOrDefault(frameOptions.width, DEFAULT_WIDTH),
     height: positiveIntegerOrDefault(frameOptions.height, DEFAULT_HEIGHT),
-    clear: frameOptions.clear !== false,
+    clear: true,
     background:
       "background" in frameOptions ? frameOptions.background : DEFAULT_BACKGROUND,
     fit: frameOptions.fit !== false,

--- a/packages/gerber-renderer/package.json
+++ b/packages/gerber-renderer/package.json
@@ -17,8 +17,12 @@
     "wasm/**/*"
   ],
   "scripts": {
-    "build:wasm": "wasm-pack build ../../wasm --target web --out-dir ../packages/gerber-renderer/wasm --release",
-    "check": "node --check index.js"
+    "build:wasm": "wasm-pack build ../../wasm --target web --out-dir pkg --release",
+    "stage:wasm": "node scripts/stage-wasm.mjs",
+    "clean:wasm": "node scripts/clean-wasm.mjs",
+    "prepack": "npm run build:wasm && npm run stage:wasm",
+    "postpack": "npm run clean:wasm",
+    "check": "node --check index.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs"
   },
   "license": "MIT",
   "repository": {

--- a/packages/gerber-renderer/package.json
+++ b/packages/gerber-renderer/package.json
@@ -35,7 +35,7 @@
     "check": "node --check index.js && node --check node.js && node --check bin/gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs"
   },
   "peerDependencies": {
-    "node-gles-webgl2": "*"
+    "node-gles-webgl2": "^0.1.0"
   },
   "peerDependenciesMeta": {
     "node-gles-webgl2": {

--- a/packages/gerber-renderer/package.json
+++ b/packages/gerber-renderer/package.json
@@ -34,9 +34,6 @@
     "postpack": "npm run clean:wasm",
     "check": "node --check index.js && node --check node.js && node --check bin/gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs"
   },
-  "optionalDependencies": {
-    "node-gles": "^0.0.17"
-  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/gerber-renderer/package.json
+++ b/packages/gerber-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wasm-gerber-renderer",
   "version": "0.1.0",
-  "description": "Canvas/WebGL2 Gerber renderer powered by wasm-gerber-viewer",
+  "description": "Browser and Node WebGL2 Gerber renderer powered by wasm-gerber-viewer",
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
@@ -9,11 +9,21 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
+    },
+    "./node": {
+      "types": "./node.d.ts",
+      "default": "./node.js"
     }
   },
+  "bin": {
+    "gerber-renderer": "./bin/gerber-renderer.js"
+  },
   "files": [
+    "bin",
     "index.js",
     "index.d.ts",
+    "node.js",
+    "node.d.ts",
     "wasm/**/*"
   ],
   "scripts": {
@@ -22,7 +32,10 @@
     "clean:wasm": "node scripts/clean-wasm.mjs",
     "prepack": "npm run build:wasm && npm run stage:wasm",
     "postpack": "npm run clean:wasm",
-    "check": "node --check index.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs"
+    "check": "node --check index.js && node --check node.js && node --check bin/gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs"
+  },
+  "optionalDependencies": {
+    "node-gles": "^0.0.17"
   },
   "license": "MIT",
   "repository": {

--- a/packages/gerber-renderer/package.json
+++ b/packages/gerber-renderer/package.json
@@ -34,6 +34,14 @@
     "postpack": "npm run clean:wasm",
     "check": "node --check index.js && node --check node.js && node --check bin/gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs"
   },
+  "peerDependencies": {
+    "node-gles-webgl2": "*"
+  },
+  "peerDependenciesMeta": {
+    "node-gles-webgl2": {
+      "optional": true
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/gerber-renderer/package.json
+++ b/packages/gerber-renderer/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "wasm-gerber-renderer",
+  "version": "0.1.0",
+  "description": "Canvas/WebGL2 Gerber renderer powered by wasm-gerber-viewer",
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "wasm/**/*"
+  ],
+  "scripts": {
+    "build:wasm": "wasm-pack build ../../wasm --target web --out-dir ../packages/gerber-renderer/wasm --release",
+    "check": "node --check index.js"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dsafdsaf132/wasm-gerber-viewer.git",
+    "directory": "packages/gerber-renderer"
+  },
+  "keywords": [
+    "gerber",
+    "rs-274x",
+    "webgl",
+    "wasm",
+    "pcb"
+  ],
+  "sideEffects": false
+}

--- a/packages/gerber-renderer/scripts/clean-wasm.mjs
+++ b/packages/gerber-renderer/scripts/clean-wasm.mjs
@@ -1,0 +1,7 @@
+import { rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+rmSync(resolve(packageDir, "wasm"), { recursive: true, force: true });

--- a/packages/gerber-renderer/scripts/stage-wasm.mjs
+++ b/packages/gerber-renderer/scripts/stage-wasm.mjs
@@ -1,0 +1,17 @@
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = resolve(packageDir, "../../wasm/pkg");
+const outputDir = resolve(packageDir, "wasm");
+const files = [
+  "wasm_gerber_processor.js",
+  "wasm_gerber_processor_bg.wasm",
+];
+
+mkdirSync(outputDir, { recursive: true });
+
+for (const file of files) {
+  copyFileSync(resolve(sourceDir, file), resolve(outputDir, file));
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -577,7 +577,6 @@ impl GerberProcessor {
     /// Resize framebuffers to explicit dimensions.
     pub fn resize_to(&mut self, width: u32, height: u32) -> Result<String, JsValue> {
         if let Some(renderer) = &mut self.renderer {
-            renderer.set_framebuffer_size(width, height)?;
             renderer.resize_to(width, height)?;
             Ok("resize_done".to_string())
         } else {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -185,6 +185,22 @@ impl GerberProcessor {
         Ok("init_done".to_string())
     }
 
+    /// Initialize with WebGL 2.0 context and explicit framebuffer size.
+    ///
+    /// This is intended for headless contexts that do not expose an HTML canvas.
+    pub fn init_with_size(
+        &mut self,
+        gl: WebGl2RenderingContext,
+        width: u32,
+        height: u32,
+    ) -> Result<String, JsValue> {
+        let mut renderer = Renderer::new_headless(gl.clone(), width, height)?;
+        renderer.set_minimum_feature_pixels(self.minimum_feature_pixels);
+        self.renderer = Some(renderer);
+        self.gl = Some(gl);
+        Ok("init_done".to_string())
+    }
+
     /// Configure how regions containing arcs are parsed.
     ///
     /// When true, arc-containing regions are preserved for analytic WebGL rendering.
@@ -226,6 +242,26 @@ impl GerberProcessor {
             renderer.restore_context(gl.clone())?;
         } else {
             let mut renderer = Renderer::new(gl.clone())?;
+            renderer.set_minimum_feature_pixels(self.minimum_feature_pixels);
+            self.renderer = Some(renderer);
+        }
+
+        self.gl = Some(gl);
+        Ok("restore_done".to_string())
+    }
+
+    /// Recreate WebGL-owned resources with an explicit framebuffer size.
+    pub fn restore_context_with_size(
+        &mut self,
+        gl: WebGl2RenderingContext,
+        width: u32,
+        height: u32,
+    ) -> Result<String, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.set_framebuffer_size(width, height)?;
+            renderer.restore_context(gl.clone())?;
+        } else {
+            let mut renderer = Renderer::new_headless(gl.clone(), width, height)?;
             renderer.set_minimum_feature_pixels(self.minimum_feature_pixels);
             self.renderer = Some(renderer);
         }
@@ -415,6 +451,37 @@ impl GerberProcessor {
         }
     }
 
+    /// Render into an offscreen framebuffer and return bottom-up RGBA pixels.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_pixels_with_clear(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<Vec<u8>, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.render_pixels_with_clear(
+                active_layer_ids,
+                color_data,
+                zoom_x,
+                zoom_y,
+                offset_x,
+                offset_y,
+                alpha,
+                clear_canvas,
+            )
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
     /// Render one tile of a larger virtual canvas to the current WebGL canvas.
     ///
     /// The caller is expected to resize the WebGL canvas to `tile_width` x
@@ -499,6 +566,19 @@ impl GerberProcessor {
     pub fn resize(&mut self) -> Result<String, JsValue> {
         if let Some(renderer) = &mut self.renderer {
             renderer.resize()?;
+            Ok("resize_done".to_string())
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() and parse() first.",
+            ))
+        }
+    }
+
+    /// Resize framebuffers to explicit dimensions.
+    pub fn resize_to(&mut self, width: u32, height: u32) -> Result<String, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.set_framebuffer_size(width, height)?;
+            renderer.resize_to(width, height)?;
             Ok("resize_done".to_string())
         } else {
             Err(JsValue::from_str(

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -345,7 +345,7 @@ impl GerberProcessor {
     ///
     /// # Arguments
     /// * `active_layer_ids` - Array of layer IDs to render (in order)
-    /// * `color_data` - Flat array of [r, g, b] for each active layer (NO alpha)
+    /// * `color_data` - Flat array of [r, g, b] or [r, g, b, a] for each active layer
     /// * `zoom_x` - Horizontal zoom factor
     /// * `zoom_y` - Vertical zoom factor
     /// * `offset_x` - Horizontal pan offset
@@ -374,6 +374,38 @@ impl GerberProcessor {
                 offset_x,
                 offset_y,
                 alpha,
+            )?;
+            Ok("render_done".to_string())
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
+    /// Render geometry to the canvas, optionally preserving existing canvas contents.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_with_clear(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<String, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.render_with_clear(
+                active_layer_ids,
+                color_data,
+                zoom_x,
+                zoom_y,
+                offset_x,
+                offset_y,
+                alpha,
+                clear_canvas,
             )?;
             Ok("render_done".to_string())
         } else {

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -14,7 +14,7 @@ use state::{
     parse_format_spec, parse_if, parse_lm, parse_lp, parse_lr, parse_ls, parse_mo, parse_sr,
 };
 
-use self::geometry::{parse_graphic_command, Primitive, RegionContour};
+use self::geometry::{arc_curve_bounds, parse_graphic_command, Primitive, RegionContour};
 use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
     Triangles,
@@ -688,11 +688,17 @@ impl PrimitiveOutputBuffers {
             let y = self.arcs_y[i];
             let r = self.arcs_radius[i];
             let t = self.arcs_thickness[i];
-            let outer = r + t / 2.0;
-            min_x = min_x.min(x - outer);
-            max_x = max_x.max(x + outer);
-            min_y = min_y.min(y - outer);
-            max_y = max_y.max(y + outer);
+            let half_width = t * 0.5;
+            let (arc_min_x, arc_max_x, arc_min_y, arc_max_y) = arc_curve_bounds(
+                [x, y],
+                r,
+                self.arcs_start_angle[i],
+                self.arcs_sweep_angle[i],
+            );
+            min_x = min_x.min(arc_min_x - half_width);
+            max_x = max_x.max(arc_max_x + half_width);
+            min_y = min_y.min(arc_min_y - half_width);
+            max_y = max_y.max(arc_max_y + half_width);
         }
 
         for i in 0..self.thermals_x.len() {

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -2020,7 +2020,7 @@ fn push_sector_quad(
     Ok(())
 }
 
-fn arc_curve_bounds(
+pub(crate) fn arc_curve_bounds(
     center: [f32; 2],
     radius: f32,
     start_angle: f32,

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1387,6 +1387,29 @@ M02*",
 }
 
 #[test]
+fn arc_boundary_uses_sweep_not_full_circle() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+G03*
+G75*
+X1000000Y0000000D02*
+X0000000Y1000000I-1000000J0000000D01*
+M02*",
+    )
+    .expect("arc should parse");
+    let boundary = &layers[0].boundary;
+
+    assert_approx_eq(boundary.min_x, -0.5);
+    assert_approx_eq(boundary.max_x, 1.5);
+    assert_approx_eq(boundary.min_y, -0.5);
+    assert_approx_eq(boundary.max_y, 1.5);
+}
+
+#[test]
 fn full_circle_arc_preserves_equal_start_end_with_center_offset() {
     let layers = parse_gerber(
         "\

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -2152,6 +2152,15 @@ impl Renderer {
         Ok(())
     }
 
+    fn color_data_stride(active_layer_ids: &[u32], color_data: &[f32]) -> usize {
+        let rgba_len = active_layer_ids.len().saturating_mul(4);
+        if color_data.len() >= rgba_len {
+            4
+        } else {
+            3
+        }
+    }
+
     /// Draw a specific FBO texture to the current framebuffer
     fn draw_fbo_texture(&self, texture: &WebGlTexture, color: &[f32; 4]) -> Result<(), JsValue> {
         let program = &self.programs.texture;
@@ -3382,7 +3391,41 @@ impl Renderer {
         // Get transform matrix
         let transform = self.camera.get_transform_matrix(width, height);
 
-        self.render_with_transform(active_layer_ids, color_data, alpha, transform)
+        self.render_with_transform(active_layer_ids, color_data, alpha, transform, true)
+    }
+
+    /// Render geometry and optionally preserve the existing canvas contents.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_with_clear(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<(), JsValue> {
+        Self::validate_render_inputs(
+            active_layer_ids,
+            color_data,
+            zoom_x,
+            zoom_y,
+            offset_x,
+            offset_y,
+            alpha,
+        )?;
+
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
+        let (width, height) = self.get_canvas_size()?;
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
+        }
+
+        let transform = self.camera.get_transform_matrix(width, height);
+
+        self.render_with_transform(active_layer_ids, color_data, alpha, transform, clear_canvas)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3432,7 +3475,7 @@ impl Renderer {
             tile_height,
         );
 
-        self.render_with_transform(active_layer_ids, color_data, alpha, transform)
+        self.render_with_transform(active_layer_ids, color_data, alpha, transform, true)
     }
 
     fn render_with_transform(
@@ -3441,6 +3484,7 @@ impl Renderer {
         color_data: &[f32],
         alpha: f32,
         transform: [f32; 9],
+        clear_canvas: bool,
     ) -> Result<(), JsValue> {
         let (width, height) = self.get_canvas_size()?;
         if width == 0 || height == 0 {
@@ -3482,7 +3526,7 @@ impl Renderer {
         }
 
         // STEP 2: Composite FBOs to canvas
-        self.composite_layers(active_layer_ids, color_data, alpha)?;
+        self.composite_layers(active_layer_ids, color_data, alpha, clear_canvas)?;
 
         Ok(())
     }
@@ -3548,6 +3592,7 @@ impl Renderer {
         active_layer_ids: &[u32],
         color_data: &[f32],
         alpha: f32,
+        clear_canvas: bool,
     ) -> Result<(), JsValue> {
         // Get canvas dimensions
         let (width, height) = self.get_canvas_size()?;
@@ -3559,9 +3604,10 @@ impl Renderer {
             .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
         self.gl.viewport(0, 0, width_i32, height_i32);
 
-        // Clear canvas
-        self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
-        self.gl.clear(COLOR_BUFFER_BIT);
+        if clear_canvas {
+            self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
+            self.gl.clear(COLOR_BUFFER_BIT);
+        }
 
         // Setup additive blending for layer compositing (lighter blend mode)
         self.gl.enable(BLEND);
@@ -3569,18 +3615,23 @@ impl Renderer {
         self.gl.blend_equation(FUNC_ADD);
 
         // Render each active layer's FBO to canvas with its color/alpha
+        let color_stride = Self::color_data_stride(active_layer_ids, color_data);
         for (color_index, &layer_id) in active_layer_ids.iter().enumerate() {
             let layer_idx = layer_id as usize;
 
             if let Some(layer) = &self.layers[layer_idx] {
-                // Get RGB color from array (3 floats per layer)
-                let color_offset = color_index * 3;
+                let color_offset = color_index * color_stride;
                 if color_offset + 2 < color_data.len() {
+                    let layer_alpha = if color_stride == 4 {
+                        color_data[color_offset + 3] * alpha
+                    } else {
+                        alpha
+                    };
                     let color = [
                         color_data[color_offset],
                         color_data[color_offset + 1],
                         color_data[color_offset + 2],
-                        alpha, // Use provided alpha
+                        layer_alpha,
                     ];
                     self.draw_fbo_texture(&layer.fbo.texture, &color)?;
                 }

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -17,7 +17,7 @@ use crate::shape::{
 };
 use js_sys::{Array, Float32Array, Reflect, Uint32Array};
 use wasm_bindgen::{prelude::*, JsCast};
-use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlTexture};
+use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlTexture};
 
 /// Metadata for a single user layer (may contain multiple polarity sublayers)
 pub struct LayerMetadata {
@@ -34,6 +34,7 @@ pub struct LayerMetadata {
 /// WebGL renderer for Gerber graphics with multi-layer support
 pub struct Renderer {
     gl: WebGl2RenderingContext,
+    explicit_size: Option<(u32, u32)>,
     layers: Vec<Option<LayerMetadata>>, // Sparse vec (None = deallocated slot)
     layer_count: usize,                 // Active layer count
     programs: ShaderPrograms,
@@ -45,6 +46,23 @@ pub struct Renderer {
 impl Renderer {
     /// Create a new renderer with WebGL context (no layers initially)
     pub fn new(gl: WebGl2RenderingContext) -> Result<Renderer, JsValue> {
+        Self::new_with_size(gl, None)
+    }
+
+    /// Create a renderer with an explicit framebuffer size.
+    pub fn new_headless(
+        gl: WebGl2RenderingContext,
+        width: u32,
+        height: u32,
+    ) -> Result<Renderer, JsValue> {
+        Self::validate_framebuffer_size(width, height)?;
+        Self::new_with_size(gl, Some((width, height)))
+    }
+
+    fn new_with_size(
+        gl: WebGl2RenderingContext,
+        explicit_size: Option<(u32, u32)>,
+    ) -> Result<Renderer, JsValue> {
         // Compile shader programs
         let programs = ShaderPrograms::new(&gl)?;
 
@@ -53,6 +71,7 @@ impl Renderer {
 
         Ok(Renderer {
             gl,
+            explicit_size,
             layers: Vec::new(),
             layer_count: 0,
             programs,
@@ -60,6 +79,13 @@ impl Renderer {
             quad_buffer,
             minimum_feature_pixels: 0.0,
         })
+    }
+
+    /// Update explicit framebuffer dimensions used by headless renderers.
+    pub fn set_framebuffer_size(&mut self, width: u32, height: u32) -> Result<(), JsValue> {
+        Self::validate_framebuffer_size(width, height)?;
+        self.explicit_size = Some((width, height));
+        Ok(())
     }
 
     /// Configure a display-space minimum feature size in CSS/device pixels.
@@ -2083,7 +2109,23 @@ impl Renderer {
 
     /// Get canvas dimensions
     fn get_canvas_size(&self) -> Result<(u32, u32), JsValue> {
+        if let Some(size) = self.explicit_size {
+            return Ok(size);
+        }
         Self::get_canvas_size_from_gl(&self.gl)
+    }
+
+    fn validate_framebuffer_size(width: u32, height: u32) -> Result<(), JsValue> {
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Framebuffer size must be non-zero"));
+        }
+
+        let max_i32 = i32::MAX as u32;
+        if width > max_i32 || height > max_i32 {
+            return Err(JsValue::from_str("Framebuffer size is too large"));
+        }
+
+        Ok(())
     }
 
     /// Get layer reference with error handling
@@ -3478,6 +3520,79 @@ impl Renderer {
         self.render_with_transform(active_layer_ids, color_data, alpha, transform, true)
     }
 
+    /// Render to an offscreen framebuffer and return bottom-up RGBA pixels.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_pixels_with_clear(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<Vec<u8>, JsValue> {
+        Self::validate_render_inputs(
+            active_layer_ids,
+            color_data,
+            zoom_x,
+            zoom_y,
+            offset_x,
+            offset_y,
+            alpha,
+        )?;
+
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
+        let (width, height) = self.get_canvas_size()?;
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
+        }
+
+        let transform = self.camera.get_transform_matrix(width, height);
+        let width_i32 = Self::checked_u32_to_i32("canvas width", width)?;
+        let height_i32 = Self::checked_u32_to_i32("canvas height", height)?;
+        let pixel_count = Self::checked_u32_to_usize("render output width", width)?
+            .checked_mul(Self::checked_u32_to_usize("render output height", height)?)
+            .and_then(|value| value.checked_mul(4))
+            .ok_or_else(|| JsValue::from_str("Render output size exceeds platform limits"))?;
+        let mut pixels = Self::reserved_vec("render output pixels", pixel_count)?;
+        pixels.resize(pixel_count, 0);
+
+        let output_fbo = Self::create_fbo(&self.gl, width, height, false)?;
+        let result = (|| {
+            self.render_layer_fbos(active_layer_ids, transform, width, height)?;
+            self.composite_layers_to_target(
+                active_layer_ids,
+                color_data,
+                alpha,
+                clear_canvas,
+                Some(&output_fbo.framebuffer),
+            )?;
+            self.gl
+                .read_pixels_with_opt_u8_array(
+                    0,
+                    0,
+                    width_i32,
+                    height_i32,
+                    WebGl2RenderingContext::RGBA,
+                    WebGl2RenderingContext::UNSIGNED_BYTE,
+                    Some(&mut pixels),
+                )
+                .map_err(|error| {
+                    if error.is_string() {
+                        error
+                    } else {
+                        JsValue::from_str("Failed to read rendered pixels")
+                    }
+                })?;
+            Ok(pixels)
+        })();
+
+        Self::delete_fbo(&self.gl, output_fbo);
+        result
+    }
+
     fn render_with_transform(
         &mut self,
         active_layer_ids: &[u32],
@@ -3490,10 +3605,26 @@ impl Renderer {
         if width == 0 || height == 0 {
             return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
         }
+
+        // STEP 1: Render active layer geometry to FBOs only when geometry/camera state changed.
+        self.render_layer_fbos(active_layer_ids, transform, width, height)?;
+
+        // STEP 2: Composite FBOs to canvas
+        self.composite_layers(active_layer_ids, color_data, alpha, clear_canvas)?;
+
+        Ok(())
+    }
+
+    fn render_layer_fbos(
+        &mut self,
+        active_layer_ids: &[u32],
+        transform: [f32; 9],
+        width: u32,
+        height: u32,
+    ) -> Result<(), JsValue> {
         let width_i32 = Self::checked_u32_to_i32("canvas width", width)?;
         let height_i32 = Self::checked_u32_to_i32("canvas height", height)?;
 
-        // STEP 1: Render active layer geometry to FBOs only when geometry/camera state changed.
         for &layer_id in active_layer_ids {
             let layer_idx = layer_id as usize;
             let should_redraw = {
@@ -3524,9 +3655,6 @@ impl Renderer {
                 }
             }
         }
-
-        // STEP 2: Composite FBOs to canvas
-        self.composite_layers(active_layer_ids, color_data, alpha, clear_canvas)?;
 
         Ok(())
     }
@@ -3594,14 +3722,25 @@ impl Renderer {
         alpha: f32,
         clear_canvas: bool,
     ) -> Result<(), JsValue> {
+        self.composite_layers_to_target(active_layer_ids, color_data, alpha, clear_canvas, None)
+    }
+
+    fn composite_layers_to_target(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        alpha: f32,
+        clear_canvas: bool,
+        target_framebuffer: Option<&WebGlFramebuffer>,
+    ) -> Result<(), JsValue> {
         // Get canvas dimensions
         let (width, height) = self.get_canvas_size()?;
         let width_i32 = Self::checked_u32_to_i32("canvas width", width)?;
         let height_i32 = Self::checked_u32_to_i32("canvas height", height)?;
 
-        // Bind canvas framebuffer
+        // Bind output framebuffer
         self.gl
-            .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+            .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, target_framebuffer);
         self.gl.viewport(0, 0, width_i32, height_i32);
 
         if clear_canvas {
@@ -3680,6 +3819,15 @@ impl Renderer {
     /// Resize framebuffers when canvas size changes
     pub fn resize(&mut self) -> Result<(), JsValue> {
         let (width, height) = self.get_canvas_size()?;
+        self.resize_to(width, height)
+    }
+
+    /// Resize framebuffers to explicit dimensions.
+    pub fn resize_to(&mut self, width: u32, height: u32) -> Result<(), JsValue> {
+        Self::validate_framebuffer_size(width, height)?;
+        if self.explicit_size.is_some() {
+            self.explicit_size = Some((width, height));
+        }
 
         // Recreate FBO for each active layer
         for layer in self.layers.iter_mut().flatten() {
@@ -3711,7 +3859,10 @@ impl Renderer {
 
         let programs = ShaderPrograms::new(&gl)?;
         let quad_buffer = Self::create_quad_buffer(&gl)?;
-        let (width, height) = Self::get_canvas_size_from_gl(&gl)?;
+        let (width, height) = match self.explicit_size {
+            Some(size) => size,
+            None => Self::get_canvas_size_from_gl(&gl)?,
+        };
         let mut new_fbos = Self::reserved_vec("restored framebuffers", self.layers.len())?;
 
         for layer in &self.layers {


### PR DESCRIPTION
## Summary
- add browser and Node package APIs for rendering Gerber layers to canvas/PNG
- add Node CLI rendering through a WebGL2-capable GLES module
- harden Node renderer context validation and reject unsupported clear:false output rendering
- stage generated WASM files during npm packing

## Validation
- npm run check in packages/gerber-renderer
- node ./bin/gerber-renderer.js ../../demo/font-test.gbr -o /tmp/font-test.png --width 1200 --height 800 --background '#05070c'
- npm pack --dry-run in packages/gerber-renderer
- git diff --check