### PR TITLE
Prepare npm package publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ wasm-gerber-viewer/
 │   ├── screenshot-exporter.js         # Screenshot export
 │   ├── source-loader.js               # Local, archive, and URL loading
 │   └── viewport.js                    # Camera and viewport math
+├── packages/
+│   └── gerber-renderer/               # npm package and Node CLI
 ├── wasm/
 │   ├── Cargo.toml                     # Rust crate manifest
 │   ├── pkg/                           # Generated wasm-pack output

--- a/packages/gerber-renderer/LICENSE
+++ b/packages/gerber-renderer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 dsafdsaf132
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/gerber-renderer/README.md
+++ b/packages/gerber-renderer/README.md
@@ -1,0 +1,125 @@
+# wasm-gerber-renderer
+
+WebGL2 Gerber renderer powered by the `wasm-gerber-viewer` Rust/WASM parser and renderer.
+
+The package provides:
+
+- Browser canvas rendering from Gerber source strings, `File`, `Blob`, `ArrayBuffer`, or `Uint8Array` inputs
+- Node.js PNG rendering through a headless WebGL2 context
+- A `gerber-renderer` CLI for rendering Gerber files to PNG
+- Bundled `wasm-bindgen` output generated during packaging
+
+## Install
+
+```bash
+npm install wasm-gerber-renderer
+```
+
+For Node.js/headless rendering, also install a WebGL2-capable GLES package:
+
+```bash
+npm install wasm-gerber-renderer node-gles-webgl2
+```
+
+`node-gles-webgl2` is an optional native runtime for Node.js rendering, not a browser dependency. You can also pass a compatible custom GLES module through `rendererOptions.glesModule`.
+
+## Browser Usage
+
+```js
+import { renderGerberToCanvas } from "wasm-gerber-renderer";
+
+const canvas = document.querySelector("canvas");
+const gerber = await file.text();
+
+await renderGerberToCanvas(canvas, gerber, {
+  background: "#05070c",
+  padding: 24,
+});
+```
+
+For repeated rendering, reuse a renderer instance:
+
+```js
+import { createGerberRenderer } from "wasm-gerber-renderer";
+
+const renderer = await createGerberRenderer(canvas);
+
+await renderer.withFrame({ width: 1200, height: 800, padding: 24 }, async () => {
+  await renderer.renderLayer(topCopper, { color: [1, 0, 0] });
+  await renderer.renderLayer(bottomCopper, { color: [0, 0.7, 1], alpha: 0.8 });
+});
+```
+
+## Node.js Usage
+
+```js
+import { renderGerberToPngFile } from "wasm-gerber-renderer/node";
+
+await renderGerberToPngFile(
+  "board.png",
+  ["top.gbr", "bottom.gbr"],
+  {
+    width: 1200,
+    height: 800,
+    background: "#05070c",
+    padding: 24,
+  },
+);
+```
+
+## CLI
+
+```bash
+npx gerber-renderer board.gbr -o board.png --width 1200 --height 800 --background '#05070c'
+```
+
+Useful options:
+
+```text
+--padding <px>                   Fit padding in pixels
+--alpha <0-1>                    Global alpha
+--minimum-feature-pixels <px>    Minimum line/arc display width
+--approx-region-arcs             Approximate region arcs before rendering
+--arc-quality <0|1|2>            Approx arc quality
+--no-fit                         Use identity view instead of fit view
+```
+
+## Custom WASM or GLES Modules
+
+The default package includes the WASM renderer under `wasm/`.
+
+Advanced callers can override the WASM module or binary:
+
+```js
+import wasmModule from "./custom/wasm_gerber_processor.js";
+import { createNodeGerberRenderer } from "wasm-gerber-renderer/node";
+
+const renderer = await createNodeGerberRenderer({
+  wasmModule,
+  wasmModuleUrl: new URL("./custom/wasm_gerber_processor.js", import.meta.url),
+});
+```
+
+For Node.js, a custom GLES module can be supplied:
+
+```js
+await createNodeGerberRenderer({
+  glesModule: customGlesModule,
+});
+```
+
+## Publish Checklist
+
+From `packages/gerber-renderer`:
+
+```bash
+npm run check
+npm run verify:publish
+npm publish
+```
+
+`prepack` builds the Rust/WASM package and stages the generated files into this package before packing. `postpack` removes the staged WASM directory from the working tree.
+
+## License
+
+MIT

--- a/packages/gerber-renderer/package.json
+++ b/packages/gerber-renderer/package.json
@@ -16,7 +16,14 @@
     }
   },
   "bin": {
-    "gerber-renderer": "./bin/gerber-renderer.js"
+    "gerber-renderer": "bin/gerber-renderer.js"
+  },
+  "homepage": "https://github.com/dsafdsaf132/wasm-gerber-viewer#readme",
+  "bugs": {
+    "url": "https://github.com/dsafdsaf132/wasm-gerber-viewer/issues"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "files": [
     "bin",
@@ -24,6 +31,8 @@
     "index.d.ts",
     "node.js",
     "node.d.ts",
+    "README.md",
+    "LICENSE",
     "wasm/**/*"
   ],
   "scripts": {
@@ -32,20 +41,14 @@
     "clean:wasm": "node scripts/clean-wasm.mjs",
     "prepack": "npm run build:wasm && npm run stage:wasm",
     "postpack": "npm run clean:wasm",
-    "check": "node --check index.js && node --check node.js && node --check bin/gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs"
-  },
-  "peerDependencies": {
-    "node-gles-webgl2": "^0.1.0"
-  },
-  "peerDependenciesMeta": {
-    "node-gles-webgl2": {
-      "optional": true
-    }
+    "prepublishOnly": "npm run check",
+    "check": "node --check index.js && node --check node.js && node --check bin/gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs",
+    "verify:publish": "npm run check && npm pack --dry-run"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dsafdsaf132/wasm-gerber-viewer.git",
+    "url": "git+https://github.com/dsafdsaf132/wasm-gerber-viewer.git",
     "directory": "packages/gerber-renderer"
   },
   "keywords": [

--- a/wasm/LICENSE
+++ b/wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 dsafdsaf132
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add npm package README and LICENSE files
- add publish metadata, Node engine, prepublish checks, and publish verification script
- remove node-gles-webgl2 from package metadata so browser installs stay audit-clean; keep it documented as an optional Node runtime
- document packages/gerber-renderer in the root project structure

## Verification
- npm publish --dry-run
- tarball smoke test in a temporary project
- package-only install audit: 0 vulnerabilities
- node-gles-webgl2 optional runtime CLI render smoke test