### PR TITLE
Improve renderer package layer handling

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,8 +1,6 @@
 name: Publish npm Package
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -16,11 +14,11 @@ permissions:
   packages: write
 
 concurrency:
-  group: npm-publish-${{ github.event.release.tag_name || inputs.tag }}
+  group: npm-publish-${{ inputs.tag }}
   cancel-in-progress: false
 
 env:
-  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+  RELEASE_TAG: ${{ inputs.tag }}
 
 jobs:
   publish-npmjs:
@@ -30,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ inputs.tag }}
 
       - name: Setup Node.js for npmjs
         uses: actions/setup-node@v4
@@ -59,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ inputs.tag }}
 
       - name: Setup Node.js for GitHub Packages
         uses: actions/setup-node@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,7 @@ jobs:
           retention-days: 14
 
   deploy:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: build
 
@@ -121,7 +122,7 @@ jobs:
         if: steps.vercel-secrets.outputs.enabled == 'true'
         id: vercel-env
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             echo "environment=production" >> "$GITHUB_OUTPUT"
             echo "prod-flag=--prod" >> "$GITHUB_OUTPUT"
           else

--- a/packages/gerber-renderer/README.md
+++ b/packages/gerber-renderer/README.md
@@ -6,7 +6,7 @@ The package provides:
 
 - Browser canvas rendering from Gerber source strings, `File`, `Blob`, `ArrayBuffer`, or `Uint8Array` inputs
 - Node.js PNG rendering through a headless WebGL2 context
-- A `gerber-renderer` CLI for rendering Gerber files to PNG
+- A `gerber-renderer` CLI for rendering Gerber files or `.tar.gz`/`.tgz` archives to PNG
 - Bundled `wasm-bindgen` output generated during packaging
 
 The browser entrypoint uses the caller's WebGL2 canvas. The Node.js entrypoint
@@ -62,10 +62,16 @@ import { createGerberRenderer } from "wasm-gerber-renderer";
 const renderer = await createGerberRenderer(canvas);
 
 await renderer.withFrame({ width: 1200, height: 800, padding: 24 }, async () => {
-  await renderer.renderLayer(topCopper, { color: [1, 0, 0] });
-  await renderer.renderLayer(bottomCopper, { color: [0, 0.7, 1], alpha: 0.8 });
+  await renderer.renderLayers([
+    { source: topCopper, color: [1, 0, 0] },
+    { source: bottomCopper, color: [0, 0.7, 1], alpha: 0.8 },
+  ]);
 });
 ```
+
+Batch helpers render as many valid layers as possible by default. If one layer
+fails to parse, the remaining layers are still rendered. Use `onLayerError` to
+inspect skipped layers, or set `layerErrorMode: "throw"` for strict behavior.
 
 ## Type Reference
 
@@ -139,11 +145,12 @@ rendering from the filesystem.
 
 | API | Description |
 | --- | --- |
-| `renderGerberToCanvas(canvas, layers, frameOptions)` | One-shot render into an existing WebGL2-capable canvas. `layers` may be a single `GerberLayer`, an array of layers, or a `FileList`. |
-| `renderGerberToPng(canvas, layers, frameOptions, exportOptions)` | Renders through a browser canvas and returns a PNG `Blob`. `layers` accepts the same values as `renderGerberToCanvas`. |
+| `renderGerberToCanvas(canvas, layers, frameOptions)` | One-shot batch render into an existing WebGL2-capable canvas. `layers` may be a single `GerberLayer`, an array of layers, or a `FileList`. Failed layers are skipped by default. |
+| `renderGerberToPng(canvas, layers, frameOptions, exportOptions)` | One-shot batch render through a browser canvas and returns a PNG `Blob`. `layers` accepts the same values as `renderGerberToCanvas`. Failed layers are skipped by default. |
 | `createGerberRenderer(canvas, rendererOptions)` | Creates a reusable renderer for rendering multiple frames or layers without reloading the WASM module every time. |
 | `renderer.withFrame(frameOptions, callback)` | Starts a render frame, applies canvas/view options, runs the sync or async callback, and presents the rendered layers after the callback resolves. |
-| `renderer.renderLayer(layer, layerOptions)` | Adds one `GerberLayer` to the active frame and resolves to the numeric layer ID. Must be called inside `withFrame()`. |
+| `renderer.renderLayer(layer, layerOptions)` | Adds one `GerberLayer` to the active frame and resolves to the numeric layer ID. Must be called inside `withFrame()`. This strict single-layer API rejects on failure. |
+| `renderer.renderLayers(layers, options)` | Adds multiple layers to the active frame and resolves to `{ renderedCount, failures }`. By default, failed layers are skipped and reported through `onLayerError`; set `layerErrorMode: "throw"` for strict behavior. |
 | `renderer.exportPng(exportOptions)` | Exports the last rendered browser frame as a PNG `Blob`. |
 | `renderer.dispose()` | Releases the WebGL context when the renderer is no longer needed. |
 
@@ -165,6 +172,10 @@ await renderGerberToPngFile(
     height: 800,
     background: "#05070c",
     padding: 24,
+    onLayerError: ({ name, error }) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Skipped ${name}: ${message}`);
+    },
   },
 );
 ```
@@ -174,14 +185,20 @@ await renderGerberToPngFile(
 | API | Description |
 | --- | --- |
 | `createNodeGerberRenderer(rendererOptions)` | Creates a reusable headless renderer backed by a native WebGL2/GLES context. |
-| `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)` | One-shot render that resolves to PNG bytes as a `Uint8Array`. `layers` may be a single `GerberNodeLayer` or an array. |
-| `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)` | One-shot render that writes PNG bytes to `outputPath`. Parent directories must already exist. |
+| `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)` | One-shot batch render that resolves to PNG bytes as a `Uint8Array`. `layers` may be a single `GerberNodeLayer` or an array. Failed layers are skipped by default. |
+| `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)` | One-shot batch render that writes PNG bytes to `outputPath`. Parent directories must already exist. Failed layers are skipped by default. |
 | `fileLayer(path, options)` | Creates a path-backed Node layer config. `options` accepts `name`, `color`, `alpha`, `offsetX`, and `offsetY`. |
 | `packageRoot()` | Returns the installed package directory path. |
 | `renderer.withFrame(frameOptions, callback)` | Starts a headless render frame, runs the sync or async callback, and stores the rendered pixels after the callback resolves. |
-| `renderer.renderLayer(layer, layerOptions)` | Adds one `GerberNodeLayer` to the active frame and resolves to the numeric layer ID. Must be called inside `withFrame()`. |
+| `renderer.renderLayer(layer, layerOptions)` | Adds one `GerberNodeLayer` to the active frame and resolves to the numeric layer ID. Must be called inside `withFrame()`. This strict single-layer API rejects on failure. |
+| `renderer.renderLayers(layers, options)` | Adds multiple layers to the active frame and resolves to `{ renderedCount, failures }`. By default, failed layers are skipped and reported through `onLayerError`; set `layerErrorMode: "throw"` for strict behavior. |
 | `renderer.exportPng(exportOptions)` | Exports the last rendered Node frame as PNG bytes. |
 | `renderer.dispose()` | Releases the GLES context when the renderer is no longer needed. |
+
+Batch APIs (`renderGerberToCanvas`, `renderGerberToPng`,
+`renderGerberToPngBuffer`, `renderGerberToPngFile`, and `renderLayers`) render
+all valid layers they can load. If every layer fails, the operation rejects with
+the first layer error.
 
 ## API Options
 
@@ -200,6 +217,8 @@ await renderGerberToPngFile(
 | `arcTessellationQuality` | `1` | Arc approximation quality: `0` low, `1` normal, `2` high. |
 | `minimumFeaturePixels` | `1` | Minimum rendered line/arc width in screen pixels. |
 | `globalAlpha` | `0.7` | Global opacity multiplier applied to rendered layers. |
+| `layerErrorMode` | `"skip"` | Batch layer loading behavior for one-shot helpers and `renderLayers()`. `"skip"` renders remaining valid layers; `"throw"` rejects on the first failed layer. |
+| `onLayerError` | `undefined` | Callback invoked for each skipped layer in `"skip"` mode: `{ layer, name, error }`. |
 | `rendererOptions` | `{}` | Browser one-shot helpers only. Passed through when creating the renderer. |
 
 `layerOptions` control a single layer:
@@ -255,11 +274,21 @@ gerber-renderer top.gbr bottom.gbr \
   --minimum-feature-pixels 1
 ```
 
+Archive example:
+
+```bash
+gerber-renderer board-gerbers.tar.gz \
+  --output board.png \
+  --width 1600 \
+  --height 1000 \
+  --background '#05070c'
+```
+
 CLI options:
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `<input.gbr...>` | Required | One or more Gerber input files. Multiple files are rendered as separate layers in argument order. |
+| `<input...>` | Required | One or more Gerber files or `.tar.gz`/`.tgz` archives. Multiple files are rendered as separate layers in argument order. Regular archive entries are expanded in archive order; non-Gerber entries are skipped by the renderer. |
 | `-o, --output <path>` | Required | PNG output path. Parent directories must already exist. |
 | `--width <px>` | `1200` | Output canvas width in pixels. Must be a positive integer. |
 | `--height <px>` | `800` | Output canvas height in pixels. Must be a positive integer. |
@@ -274,6 +303,10 @@ CLI options:
 
 `--arc-quality` is used only with `--approx-region-arcs`. Quality values are
 `0` for low, `1` for normal, and `2` for high.
+
+When multiple input files are provided, the CLI skips failed layers, prints a
+warning for each skipped file, and renders the remaining layers. If every input
+fails, the command exits with an error.
 
 ## License
 

--- a/packages/gerber-renderer/bin/gerber-renderer.js
+++ b/packages/gerber-renderer/bin/gerber-renderer.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
+import { gunzipSync } from "node:zlib";
 import { fileLayer, renderGerberToPngFile } from "../node.js";
 
 const USAGE = `Usage:
-  gerber-renderer <input.gbr...> -o <output.png> [options]
+  gerber-renderer <input.gbr|input.tar.gz...> -o <output.png> [options]
 
 Options:
   -o, --output <path>              PNG output path
@@ -19,6 +21,8 @@ Options:
   -h, --help                       Show this help
 `;
 
+const TAR_GZ_EXTENSIONS = [".tar.gz", ".tgz"];
+
 async function main() {
   const { inputs, output, frameOptions } = parseArgs(process.argv.slice(2));
   if (inputs.length === 0 || !output) {
@@ -27,9 +31,20 @@ async function main() {
     return;
   }
 
-  const layers = inputs.map((path) => fileLayer(path, { name: basename(path) }));
+  const layers = await collectInputLayers(inputs);
+  if (layers.length === 0) {
+    throw new Error("No Gerber layers found in input files.");
+  }
+
+  const skippedLayers = [];
+  frameOptions.onLayerError = ({ name, error }) => {
+    skippedLayers.push(name);
+    process.stderr.write(`Skipped ${name}: ${errorMessage(error)}\n`);
+  };
   await renderGerberToPngFile(output, layers, frameOptions);
-  process.stdout.write(`Rendered ${inputs.length} layer(s) to ${output}\n`);
+  process.stdout.write(
+    `Rendered ${layers.length - skippedLayers.length}/${layers.length} layer(s) to ${output}\n`,
+  );
 }
 
 function parseArgs(args) {
@@ -105,7 +120,140 @@ function readNumber(args, index, option) {
   return value;
 }
 
+async function collectInputLayers(inputs) {
+  const layers = [];
+
+  for (const input of inputs) {
+    if (isTarGzPath(input)) {
+      const archiveLayers = await readTarGzLayers(input);
+      if (archiveLayers.length === 0) {
+        process.stderr.write(`Skipped ${input}: no regular files found in archive\n`);
+      }
+      layers.push(...archiveLayers);
+    } else {
+      layers.push(fileLayer(input, { name: basename(input) }));
+    }
+  }
+
+  return layers;
+}
+
+async function readTarGzLayers(path) {
+  const archive = gunzipSync(await readFile(path));
+  const layers = [];
+  let offset = 0;
+  let nextLongName = null;
+  let nextPaxHeaders = null;
+
+  while (offset + 512 <= archive.length) {
+    const header = archive.subarray(offset, offset + 512);
+    if (isZeroBlock(header)) break;
+
+    const size = readTarOctal(header, 124, 12);
+    const typeFlag = String.fromCharCode(header[156] || 0);
+    const name = nextLongName || nextPaxHeaders?.path || readTarPath(header);
+    nextLongName = null;
+    nextPaxHeaders = null;
+
+    offset += 512;
+    const data = archive.subarray(offset, offset + size);
+    offset += Math.ceil(size / 512) * 512;
+
+    if (typeFlag === "L") {
+      nextLongName = trimNulls(data.toString("utf8"));
+      continue;
+    }
+    if (typeFlag === "x") {
+      nextPaxHeaders = readPaxHeaders(data);
+      continue;
+    }
+    if (typeFlag === "g" || (typeFlag !== "0" && typeFlag !== "\0")) {
+      continue;
+    }
+
+    const entryPath = normalizeArchivePath(name);
+    if (entryPath && !isArchiveMetadataPath(entryPath)) {
+      layers.push({
+        source: data.toString("utf8"),
+        name: `${basename(path)}:${entryPath}`,
+      });
+    }
+  }
+
+  return layers;
+}
+
+function isTarGzPath(path) {
+  const lowerPath = path.toLowerCase();
+  return TAR_GZ_EXTENSIONS.some((extension) => lowerPath.endsWith(extension));
+}
+
+function isArchiveMetadataPath(path) {
+  const normalizedPath = normalizeArchivePath(path);
+  const fileName = normalizedPath.split("/").pop() ?? normalizedPath;
+  return normalizedPath.startsWith("__MACOSX/") || fileName.startsWith("._");
+}
+
+function readTarPath(header) {
+  const name = readTarString(header, 0, 100);
+  const prefix = readTarString(header, 345, 155);
+  return prefix ? `${prefix}/${name}` : name;
+}
+
+function readTarString(buffer, start, length) {
+  return trimNulls(buffer.subarray(start, start + length).toString("utf8"));
+}
+
+function readTarOctal(buffer, start, length) {
+  const value = readTarString(buffer, start, length).trim();
+  return value ? Number.parseInt(value, 8) : 0;
+}
+
+function readPaxHeaders(data) {
+  const headers = {};
+  let offset = 0;
+
+  while (offset < data.length) {
+    const spaceIndex = data.indexOf(0x20, offset);
+    if (spaceIndex < 0) break;
+
+    const recordLength = Number.parseInt(
+      data.subarray(offset, spaceIndex).toString("ascii"),
+      10,
+    );
+    if (!Number.isFinite(recordLength) || recordLength <= 0) break;
+
+    const record = data
+      .subarray(spaceIndex + 1, offset + recordLength - 1)
+      .toString("utf8");
+    const equalsIndex = record.indexOf("=");
+    if (equalsIndex > 0) {
+      headers[record.slice(0, equalsIndex)] = record.slice(equalsIndex + 1);
+    }
+    offset += recordLength;
+  }
+
+  return headers;
+}
+
+function normalizeArchivePath(path) {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function trimNulls(value) {
+  const nullIndex = value.indexOf("\0");
+  return nullIndex >= 0 ? value.slice(0, nullIndex) : value;
+}
+
+function isZeroBlock(buffer) {
+  return buffer.every((byte) => byte === 0);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.stderr.write(`${errorMessage(error)}\n`);
   process.exitCode = 1;
 });

--- a/packages/gerber-renderer/index.d.ts
+++ b/packages/gerber-renderer/index.d.ts
@@ -45,6 +45,16 @@ export type FrameOptions = {
   minimumFeaturePixels?: number;
   globalAlpha?: number;
   rendererOptions?: RendererOptions;
+  onLayerError?: (failure: LayerFailure) => void;
+  layerErrorMode?: LayerErrorMode;
+};
+
+export type LayerErrorMode = "skip" | "throw";
+
+export type LayerFailure = {
+  layer: GerberLayer;
+  name: string;
+  error: unknown;
 };
 
 export type LayerOptions = {
@@ -87,6 +97,11 @@ export declare class GerberRenderer {
   ): Promise<void>;
 
   renderLayer(layer: GerberLayer, layerOptions?: LayerOptions): Promise<number>;
+
+  renderLayers(
+    layers: GerberLayer | GerberLayer[] | FileList,
+    options?: Pick<FrameOptions, "onLayerError" | "layerErrorMode">,
+  ): Promise<{ renderedCount: number; failures: LayerFailure[] }>;
 
   exportPng(exportOptions?: ExportOptions): Promise<Blob>;
 

--- a/packages/gerber-renderer/index.js
+++ b/packages/gerber-renderer/index.js
@@ -32,9 +32,7 @@ export async function renderGerberToCanvas(
 
   try {
     await renderer.withFrame(frameOptions, async () => {
-      for (const layer of normalizeLayerList(layers)) {
-        await renderer.renderLayer(layer);
-      }
+      await renderer.renderLayers(layers, frameOptions);
     });
   } finally {
     renderer.dispose();
@@ -57,9 +55,7 @@ export async function renderGerberToPng(
 
   try {
     await renderer.withFrame(frameOptions, async () => {
-      for (const layer of normalizeLayerList(layers)) {
-        await renderer.renderLayer(layer);
-      }
+      await renderer.renderLayers(layers, frameOptions);
     });
     return await renderer.exportPng({
       background: frameOptions.background,
@@ -129,6 +125,15 @@ export class GerberRenderer {
     const layerRecord = await this.createLayerRecord(layer, layerOptions);
     this.frame.addLayer(layerRecord);
     return layerRecord.layerId;
+  }
+
+  async renderLayers(layers, options = {}) {
+    this.assertUsable();
+    if (!this.frame) {
+      throw new Error("renderLayers must be called inside withFrame().");
+    }
+
+    return renderLayersBestEffort(this, normalizeLayerList(layers), options);
   }
 
   async exportPng(exportOptions = {}) {
@@ -449,6 +454,42 @@ function normalizeLayerList(layers) {
   return Array.isArray(layers) ? layers : [layers];
 }
 
+async function renderLayersBestEffort(renderer, layers, options = {}) {
+  const layerErrorMode = options.layerErrorMode || "skip";
+  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
+    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
+  }
+
+  const failures = [];
+  let renderedCount = 0;
+
+  for (const layer of layers) {
+    try {
+      await renderer.renderLayer(layer);
+      renderedCount += 1;
+    } catch (error) {
+      const failure = {
+        layer,
+        name: getLayerFailureName(layer),
+        error,
+      };
+      failures.push(failure);
+      if (typeof options.onLayerError === "function") {
+        options.onLayerError(failure);
+      }
+      if (layerErrorMode === "throw") {
+        throw error;
+      }
+    }
+  }
+
+  if (renderedCount === 0 && failures.length > 0) {
+    throw failures[0].error;
+  }
+
+  return { renderedCount, failures };
+}
+
 function normalizeLayer(layer, layerOptions = {}) {
   if (isLayerConfig(layer)) {
     const { source, ...inlineOptions } = layer;
@@ -503,6 +544,18 @@ function getSourceName(source) {
     return String(source.name);
   }
   return "";
+}
+
+function getLayerFailureName(layer) {
+  if (layer && typeof layer === "object") {
+    if ("name" in layer && layer.name) {
+      return String(layer.name);
+    }
+    if ("source" in layer) {
+      return getSourceName(layer.source);
+    }
+  }
+  return getSourceName(layer) || "Layer";
 }
 
 function isBlob(value) {

--- a/packages/gerber-renderer/node.d.ts
+++ b/packages/gerber-renderer/node.d.ts
@@ -58,6 +58,16 @@ export type NodeFrameOptions = {
   arcTessellationQuality?: 0 | 1 | 2;
   minimumFeaturePixels?: number;
   globalAlpha?: number;
+  onLayerError?: (failure: NodeLayerFailure) => void;
+  layerErrorMode?: LayerErrorMode;
+};
+
+export type LayerErrorMode = "skip" | "throw";
+
+export type NodeLayerFailure = {
+  layer: GerberNodeLayer;
+  name: string;
+  error: unknown;
 };
 
 export type NodeLayerOptions = {
@@ -107,6 +117,11 @@ export declare class NodeGerberRenderer {
     layer: GerberNodeLayer,
     layerOptions?: NodeLayerOptions,
   ): Promise<number>;
+
+  renderLayers(
+    layers: GerberNodeLayer | GerberNodeLayer[],
+    options?: Pick<NodeFrameOptions, "onLayerError" | "layerErrorMode">,
+  ): Promise<{ renderedCount: number; failures: NodeLayerFailure[] }>;
 
   exportPng(exportOptions?: NodeExportOptions): Promise<Uint8Array>;
 

--- a/packages/gerber-renderer/node.js
+++ b/packages/gerber-renderer/node.js
@@ -48,9 +48,7 @@ export async function renderGerberToPngBuffer(
   const renderer = await createNodeGerberRenderer(rendererOptions);
   try {
     await renderer.withFrame(frameOptions, async () => {
-      for (const layer of normalizeLayerList(layers)) {
-        await renderer.renderLayer(layer);
-      }
+      await renderer.renderLayers(layers, frameOptions);
     });
     return renderer.exportPng(exportOptions);
   } finally {
@@ -138,6 +136,15 @@ export class NodeGerberRenderer {
     const layerRecord = await this.createLayerRecord(layer, layerOptions);
     this.frame.addLayer(layerRecord);
     return layerRecord.layerId;
+  }
+
+  async renderLayers(layers, options = {}) {
+    this.assertUsable();
+    if (!this.frame) {
+      throw new Error("renderLayers must be called inside withFrame().");
+    }
+
+    return renderLayersBestEffort(this, normalizeLayerList(layers), options);
   }
 
   async exportPng(exportOptions = {}) {
@@ -530,6 +537,42 @@ function normalizeLayerList(layers) {
   return Array.isArray(layers) ? layers : [layers];
 }
 
+async function renderLayersBestEffort(renderer, layers, options = {}) {
+  const layerErrorMode = options.layerErrorMode || "skip";
+  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
+    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
+  }
+
+  const failures = [];
+  let renderedCount = 0;
+
+  for (const layer of layers) {
+    try {
+      await renderer.renderLayer(layer);
+      renderedCount += 1;
+    } catch (error) {
+      const failure = {
+        layer,
+        name: getLayerFailureName(layer),
+        error,
+      };
+      failures.push(failure);
+      if (typeof options.onLayerError === "function") {
+        options.onLayerError(failure);
+      }
+      if (layerErrorMode === "throw") {
+        throw error;
+      }
+    }
+  }
+
+  if (renderedCount === 0 && failures.length > 0) {
+    throw failures[0].error;
+  }
+
+  return { renderedCount, failures };
+}
+
 function normalizeLayer(layer, layerOptions = {}) {
   if (isPathLayerConfig(layer)) {
     const { path, ...inlineOptions } = layer;
@@ -612,6 +655,21 @@ function getSourceName(source) {
     return basename(fileURLToPath(source));
   }
   return "";
+}
+
+function getLayerFailureName(layer) {
+  if (layer && typeof layer === "object") {
+    if ("name" in layer && layer.name) {
+      return String(layer.name);
+    }
+    if ("path" in layer) {
+      return basename(String(layer.path));
+    }
+    if ("source" in layer) {
+      return getSourceName(layer.source);
+    }
+  }
+  return getSourceName(layer) || "Layer";
 }
 
 function isBlob(value) {


### PR DESCRIPTION
## Summary
- add best-effort batch layer rendering APIs so failed layers can be skipped while valid layers still render
- support .tar.gz/.tgz CLI inputs without dropping archive members by extension
- make Vercel deploy and npm publish workflows manual-only

## Tests
- npm run check
- git diff --check
- CLI render test for extensionless Gerber inside .tar.gz
- CLI render test for LibrePCB sample .tar.gz