### PR TITLE
[codex] Update publish workflow title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "npm version to publish, for example 0.1.4 or v0.1.4"
+        description: "npm version to publish, for example 0.1.7 or v0.1.7"
         required: true
         type: string
 
@@ -59,8 +59,8 @@ jobs:
           version="${INPUT_VERSION#v}"
           tag="v${version}"
 
-          if ! node -e 'const version = process.argv[1]; if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) process.exit(1)' "$version"; then
-            echo "::error::Invalid semver version: ${INPUT_VERSION}"
+          if ! node -e 'const version = process.argv[1]; if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) process.exit(1)' "$version"; then
+            echo "::error::Invalid version: ${INPUT_VERSION}. Use x.y.z, for example 0.1.7 or v0.1.7"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-name: Release Package
+name: Publish
+run-name: Publish ${{ inputs.version }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Publish
-run-name: Publish ${{ inputs.version }}
+run-name: Publish ${{ startsWith(inputs.version, 'v') && inputs.version || format('v{0}', inputs.version) }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Rename the manual publish workflow from `Release Package` to `Publish`.
- Add a normalized run name so both `v0.1.7` and `0.1.7` inputs display as `Publish v0.1.7`.
- Validate publish versions as exactly three numeric parts, with optional leading `v` in the input.

## Validation

- Local regex check for valid/invalid version inputs
- `git diff --check`