### PR TITLE
[codex] Dispose frame processors explicitly

### DIFF
--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -102,12 +102,11 @@ export class GerberRenderer {
     this.prepareCanvas(normalizedFrameOptions);
 
     const processor = new this.wasmModule.GerberProcessor();
-    processor.init(this.getContext());
-    applyProcessorOptions(processor, normalizedFrameOptions);
-
-    this.frame = new FrameState(processor, normalizedFrameOptions);
-
     try {
+      processor.init(this.getContext());
+      applyProcessorOptions(processor, normalizedFrameOptions);
+
+      this.frame = new FrameState(processor, normalizedFrameOptions);
       await callback();
       this.renderFrame();
     } finally {
@@ -316,6 +315,11 @@ export class GerberRenderer {
       processor.clear();
     } catch (_error) {
       // The canvas result is already rendered; cleanup failures should not hide it.
+    }
+    try {
+      processor.free?.();
+    } catch (_error) {
+      // The context may already be unrecoverable; cleanup is best-effort.
     }
   }
 

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -104,21 +104,20 @@ export class NodeGerberRenderer {
       normalizedFrameOptions.height,
     );
     const processor = new this.wasmModule.GerberProcessor();
-    if (typeof processor.init_with_size !== "function") {
-      throw new Error("Headless rendering requires an updated WASM module.");
-    }
-    processor.init_with_size(
-      gl,
-      normalizedFrameOptions.width,
-      normalizedFrameOptions.height,
-    );
-    applyProcessorOptions(processor, normalizedFrameOptions);
-
-    this.frame = new FrameState(processor, normalizedFrameOptions);
-    this.lastFrame = null;
-    this.lastPixels = null;
-
     try {
+      if (typeof processor.init_with_size !== "function") {
+        throw new Error("Headless rendering requires an updated WASM module.");
+      }
+      processor.init_with_size(
+        gl,
+        normalizedFrameOptions.width,
+        normalizedFrameOptions.height,
+      );
+      applyProcessorOptions(processor, normalizedFrameOptions);
+
+      this.frame = new FrameState(processor, normalizedFrameOptions);
+      this.lastFrame = null;
+      this.lastPixels = null;
       await callback();
       this.renderFrameToPixels();
     } finally {
@@ -280,6 +279,11 @@ export class NodeGerberRenderer {
       processor.clear();
     } catch (_error) {
       // The pixel result is already copied; cleanup failures should not hide it.
+    }
+    try {
+      processor.free?.();
+    } catch (_error) {
+      // The context may already be unrecoverable; cleanup is best-effort.
     }
   }
 


### PR DESCRIPTION
## Summary
- Explicitly free per-frame WASM `GerberProcessor` instances after existing `clear()` cleanup.
- Apply the cleanup to both browser and Node renderer entrypoints.
- Ensure processors are also disposed if frame initialization or renderer option application fails.

## Why
`node-gles-webgl2` now destroys contexts when `WEBGL_lose_context.loseContext()` is called. Without explicit WASM disposal before context teardown, wasm-bindgen finalizers can run later and try to delete GL resources against an already destroyed context.

## Validation
- `npm run check` in `packages/wasm-gerber-renderer`
- Mocked browser and Node initialization-failure paths to verify `clear()` and `free()` are both called
- Rendered `/mnt/c/git/gdata` direct files and subdirectories at 3000x2000 with local `node-gles-webgl2`: `SUMMARY ok=15 fail=0`
- Rendered `performance-test-1M_stars.gbr` stacked 10 times at 3000x2000 with black background successfully