### PR TITLE
Improve Node PNG export performance and memory handling

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,7 @@
 export const NOTIFICATION_DURATION_MS = 2000;
 export const MAX_FILE_SIZE_BYTES = 300 * 1024 * 1024;
 export const MAX_SCREENSHOT_STREAM_BAND_BYTES = 1024 * 1024 * 1024;
+export const MAX_SCREENSHOT_RENDER_TARGET_BYTES = 2 * 1024 * 1024 * 1024;
 
 export const ZIP_MIME_TYPES = new Set([
   "application/zip",

--- a/js/screenshot-exporter.js
+++ b/js/screenshot-exporter.js
@@ -1,4 +1,7 @@
-import { MAX_SCREENSHOT_STREAM_BAND_BYTES } from "./config.js";
+import {
+  MAX_SCREENSHOT_RENDER_TARGET_BYTES,
+  MAX_SCREENSHOT_STREAM_BAND_BYTES,
+} from "./config.js";
 import { formatFileSize, getErrorMessage } from "./file-utils.js";
 
 function normalizeLayerOffset(offset = {}) {
@@ -382,6 +385,7 @@ export class ScreenshotExporter {
       canvas,
       gl,
       processor,
+      layerCount: this.getLayers().length,
       activeLayerIds: new Uint32Array(activeLayerIds),
       colorData: new Float32Array(colorData),
     };
@@ -425,7 +429,11 @@ export class ScreenshotExporter {
       );
     }
 
-    const tileSize = this.getStreamTileDimensions();
+    const tileSize = this.getStreamTileDimensions(
+      exportWidth,
+      exportHeight,
+      screenshotRenderer.layerCount,
+    );
     this.validateStreamMemory(exportWidth, exportHeight, tileSize);
     const totalTiles =
       Math.ceil(exportWidth / tileSize.width) *
@@ -565,13 +573,33 @@ export class ScreenshotExporter {
     ].join(" ");
   }
 
-  getStreamTileDimensions() {
-    const rect = this.canvas.getBoundingClientRect();
+  getStreamTileDimensions(exportWidth, exportHeight, layerCount = 1) {
     const maxDimension = this.getMaxDimension();
+    const tileWidth = Math.max(1, Math.min(exportWidth, maxDimension));
+
+    const layerTargetCount = Math.max(1, Math.floor(Number(layerCount) || 1)) + 1;
+    const rowStride = this.getPngRowStride(exportWidth);
+    const heightByBandMemory = Math.floor(
+      MAX_SCREENSHOT_STREAM_BAND_BYTES / rowStride,
+    );
+    const heightByRenderTargets = Math.floor(
+      MAX_SCREENSHOT_RENDER_TARGET_BYTES / (tileWidth * 4 * layerTargetCount),
+    );
+    const tileHeight = Math.min(
+      exportHeight,
+      maxDimension,
+      heightByBandMemory,
+      heightByRenderTargets,
+    );
+    if (!Number.isFinite(tileHeight) || tileHeight < 1) {
+      throw new Error(
+        this.getMemoryLimitMessage(exportWidth, exportHeight, rowStride),
+      );
+    }
 
     return {
-      width: Math.max(1, Math.min(maxDimension, Math.round(rect.width * 2))),
-      height: Math.max(1, Math.min(maxDimension, Math.round(rect.height))),
+      width: tileWidth,
+      height: Math.max(1, Math.floor(tileHeight)),
     };
   }
 

--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -293,6 +293,7 @@ CLI options:
 - `--background <color>`: hex or `rgb()`/`rgba()` background. Omit for transparent output.
 - `--alpha <0-1>`: global layer opacity. Defaults to `0.7`.
 - `--minimum-feature-pixels <px>`: minimum rendered line/arc width. Defaults to `1`.
+- `--max-render-target-bytes <size>`: per-render target memory cap. Accepts bytes or suffixes like `512m` and `2g`.
 - `--approx-region-arcs`: converts region arcs to line segments before rendering.
 - `--arc-quality <0|1|2>`: approximate arc quality. Defaults to `1`.
 - `--no-fit`: disables fit-to-view.

--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -222,7 +222,7 @@ the first layer error.
 - `preserveArcRegions`: keeps exact region arcs. Defaults to `true`; set `false` to approximate region arcs.
 - `arcTessellationQuality`: arc approximation quality, `0` low, `1` normal, `2` high. Defaults to `1`.
 - `minimumFeaturePixels`: minimum rendered line/arc width in screen pixels. Defaults to `1`.
-- `globalAlpha`: opacity multiplier applied to rendered layers. Defaults to `0.7`.
+- `globalAlpha`: opacity for layers without an explicit layer `alpha`. Defaults to `0.7`.
 - `layerErrorMode`: `"skip"` renders remaining valid layers; `"throw"` rejects on first failure. Defaults to `"skip"`.
 - `onLayerError`: callback for skipped layers in `"skip"` mode: `{ layer, name, error }`.
 - `rendererOptions`: browser one-shot helpers only; passed through when creating the renderer.
@@ -230,7 +230,7 @@ the first layer error.
 `layerOptions` control a single layer:
 
 - `color`: layer color. Browser accepts `[r, g, b]`; Node also accepts hex and `rgb()`/`rgba()` strings. Defaults to an automatic color cycle.
-- `alpha`: per-layer opacity before `globalAlpha` is applied. Defaults to `1`.
+- `alpha`: per-layer opacity. When set, it overrides `globalAlpha` for that layer.
 - `offsetX`: X offset applied while loading geometry. Defaults to `0`.
 - `offsetY`: Y offset applied while loading geometry. Defaults to `0`.
 - `name`: layer display name for config objects such as `{ source, name }` or `{ path, name }`.

--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -197,11 +197,43 @@ await renderGerberToPngFile(
 - `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that writes PNG bytes to `outputPath`. Parent directories must already exist.
 - `fileLayer(path, options)`: creates a path-backed Node layer config. `options` accepts `name`, `color`, `alpha`, `offsetX`, and `offsetY`.
 - `packageRoot()`: returns the installed package directory path.
+- `renderer.loadLayer(layer, layerOptions)`: parses a Node layer once and returns a prepared layer that can be reused across frames.
+- `renderer.loadLayers(layers, options)`: parses multiple layers and returns `{ layers, loadedCount, failures }`. Failed layers are skipped by default.
 - `renderer.withFrame(frameOptions, callback)`: starts a headless render frame and stores rendered pixels after the callback resolves.
 - `renderer.renderLayer(layer, layerOptions)`: adds one layer to the active frame and returns its numeric layer ID. Must be called inside `withFrame()`. This strict API rejects on failure.
 - `renderer.renderLayers(layers, options)`: adds multiple layers and returns `{ renderedCount, failures }`. Failed layers are skipped by default; use `layerErrorMode: "throw"` for strict behavior.
 - `renderer.exportPng(exportOptions)`: exports the last Node frame as PNG bytes.
 - `renderer.dispose()`: releases the GLES context.
+
+Use prepared layers when rendering the same Gerber inputs more than once:
+
+```js
+const renderer = await createNodeGerberRenderer();
+
+try {
+  const prepared = await renderer.loadLayers([
+    fileLayer("top.gbr", { color: "#ff4040" }),
+    fileLayer("bottom.gbr", { color: "#40ff40" }),
+  ]);
+
+  await renderer.withFrame({ width: 1920, height: 1080, background: "#000" }, async () => {
+    await renderer.renderLayers(prepared.layers);
+  });
+  const preview = await renderer.exportPng();
+
+  await renderer.withFrame({ width: 3840, height: 2160, background: "#000" }, async () => {
+    await renderer.renderLayers(prepared.layers);
+  });
+  const highRes = await renderer.exportPng();
+} finally {
+  renderer.dispose();
+}
+```
+
+Prepared layer geometry is parsed with the `offsetX`, `offsetY`,
+`preserveArcRegions`, and `arcTessellationQuality` values used at load time.
+Load the layer again to change those options. Per-frame color and alpha can be
+overridden in `renderLayer(preparedLayer, layerOptions)`.
 
 Batch APIs (`renderGerberToCanvas`, `renderGerberToPng`,
 `renderGerberToPngBuffer`, `renderGerberToPngFile`, and `renderLayers`) render

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -178,6 +178,35 @@ try {
 }
 ```
 
+In Node, parse repeated inputs once with prepared layers:
+
+```js
+import { createNodeGerberRenderer, fileLayer } from "wasm-gerber-renderer/node";
+
+const renderer = await createNodeGerberRenderer();
+
+try {
+  const prepared = await renderer.loadLayers([
+    fileLayer("top.gbr", { color: "#ff4040" }),
+    fileLayer("bottom.gbr", { color: "#40ff40" }),
+  ]);
+
+  await renderer.withFrame({ width: 1920, height: 1080, background: "#000" }, async () => {
+    await renderer.renderLayers(prepared.layers);
+  });
+  const preview = await renderer.exportPng();
+
+  await renderer.withFrame({ width: 3840, height: 2160, background: "#000" }, async () => {
+    await renderer.renderLayers(prepared.layers);
+  });
+  const highRes = await renderer.exportPng();
+} finally {
+  renderer.dispose();
+}
+```
+
+Prepared layer parse options and offsets are fixed at load time. Load the layer again to change `offsetX`, `offsetY`, `preserveArcRegions`, or `arcTessellationQuality`.
+
 ## Input Rules
 
 Browser sources:
@@ -214,10 +243,11 @@ Batch APIs skip failed layers by default and continue rendering valid layers:
 - `renderGerberToPngBuffer`
 - `renderGerberToPngFile`
 - `renderer.renderLayers`
+- `renderer.loadLayers`
 
 Use `onLayerError` to report skipped layers. Use `layerErrorMode: "throw"` when a single bad layer should reject the whole render.
 
-`renderer.renderLayer()` is strict and rejects on failure. Use `renderLayers()` for best-effort batch rendering.
+`renderer.renderLayer()` and `renderer.loadLayer()` are strict and reject on failure. Use `renderLayers()` or `loadLayers()` for best-effort batch handling.
 
 ## Common Options
 

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -61,6 +61,7 @@ Useful CLI options:
 - `--padding <px>` adds fit-to-view padding.
 - `--alpha <0-1>` sets global layer opacity.
 - `--minimum-feature-pixels <px>` keeps thin lines/arcs visible.
+- `--max-render-target-bytes <size>` caps per-render target memory, e.g. `512m` or `2g`.
 - `--approx-region-arcs` uses faster approximate region arcs.
 - `--arc-quality <0|1|2>` controls approximate arc quality.
 - `--no-fit` disables automatic fit-to-view.

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -199,7 +199,7 @@ Layer options:
 
 - `name`
 - `color`
-- `alpha`
+- `alpha` overrides frame/global alpha for that layer
 - `offsetX`
 - `offsetY`
 

--- a/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
+++ b/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
@@ -15,6 +15,7 @@ Options:
   --background <color>             Background color, e.g. #05070c (default: transparent)
   --alpha <0-1>                    Global layer alpha (default: 0.7)
   --minimum-feature-pixels <px>    Minimum line/arc display width (default: 1)
+  --max-render-target-bytes <size> Per-render target memory cap, e.g. 2g, 512m
   --approx-region-arcs             Approximate region arcs before rendering (default: false)
   --arc-quality <0|1|2>            Approx arc quality: low, normal, high (default: 1)
   --no-fit                         Use identity view instead of fit view (default: fit enabled)
@@ -89,6 +90,8 @@ function parseArgs(args) {
       frameOptions.globalAlpha = readNumber(args, ++index, arg);
     } else if (arg === "--minimum-feature-pixels") {
       frameOptions.minimumFeaturePixels = readNumber(args, ++index, arg);
+    } else if (arg === "--max-render-target-bytes") {
+      frameOptions.maxRenderTargetBytes = readByteSize(args, ++index, arg);
     } else if (arg === "--approx-region-arcs") {
       frameOptions.preserveArcRegions = false;
     } else if (arg === "--arc-quality") {
@@ -162,6 +165,40 @@ function readNumber(args, index, option) {
     throw new Error(`${option} requires a finite number.`);
   }
   return value;
+}
+
+function readByteSize(args, index, option) {
+  const rawValue = readOptionValue(args, index, option).trim();
+  const match = rawValue.match(/^(\d+(?:\.\d+)?)\s*([kmgt]?i?b?|bytes?)?$/i);
+  if (!match) {
+    throw new Error(`${option} requires a byte size such as 2147483648, 512m, or 2g.`);
+  }
+
+  const value = Number(match[1]);
+  const unit = (match[2] || "b").toLowerCase();
+  const multipliers = {
+    b: 1,
+    byte: 1,
+    bytes: 1,
+    k: 1024,
+    kb: 1024,
+    kib: 1024,
+    m: 1024 ** 2,
+    mb: 1024 ** 2,
+    mib: 1024 ** 2,
+    g: 1024 ** 3,
+    gb: 1024 ** 3,
+    gib: 1024 ** 3,
+    t: 1024 ** 4,
+    tb: 1024 ** 4,
+    tib: 1024 ** 4,
+  };
+  const multiplier = multipliers[unit];
+  const bytes = value * multiplier;
+  if (!Number.isFinite(bytes) || bytes <= 0 || !Number.isSafeInteger(Math.round(bytes))) {
+    throw new Error(`${option} requires a positive safe byte size.`);
+  }
+  return Math.round(bytes);
 }
 
 async function collectInputLayers(inputs) {

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -197,7 +197,7 @@ export class GerberRenderer {
       options.color == null
         ? this.frame.nextColor()
         : normalizeColor(options.color, this.frame.options.colors[0]);
-    const alpha = clamp01(numberOrDefault(options.alpha, 1));
+    const alpha = optionalAlpha(options.alpha);
 
     return {
       layerId,
@@ -234,7 +234,7 @@ export class GerberRenderer {
           layer.color[0],
           layer.color[1],
           layer.color[2],
-          layer.alpha,
+          resolveLayerAlpha(layer.alpha, globalAlpha),
         ]),
       );
       frame.processor.render_with_clear(
@@ -244,14 +244,14 @@ export class GerberRenderer {
         view.zoomY,
         view.offsetX,
         view.offsetY,
-        globalAlpha,
+        1,
         clear,
       );
     } else {
       if (!clear) {
         throw new Error("clear:false requires an updated WASM renderer.");
       }
-      if (frame.layers.some((layer) => layer.alpha !== 1)) {
+      if (frame.layers.some((layer) => layer.alpha != null)) {
         throw new Error("Layer alpha requires an updated WASM renderer.");
       }
       const colorData = new Float32Array(
@@ -353,6 +353,7 @@ class FrameState {
   }
 
   toResult(view) {
+    const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
     return {
       width: this.options.width,
       height: this.options.height,
@@ -364,7 +365,7 @@ class FrameState {
         name: layer.name,
         bounds: layer.bounds,
         color: layer.color,
-        alpha: layer.alpha,
+        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
       })),
     };
   }
@@ -736,6 +737,14 @@ function positiveIntegerOrDefault(value, fallback) {
 function numberOrDefault(value, fallback) {
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
+}
+
+function optionalAlpha(value) {
+  return value == null ? null : clamp01(value);
+}
+
+function resolveLayerAlpha(layerAlpha, globalAlpha) {
+  return layerAlpha == null ? globalAlpha : layerAlpha;
 }
 
 function finiteOrThrow(value, name) {

--- a/packages/wasm-gerber-renderer/node.d.ts
+++ b/packages/wasm-gerber-renderer/node.d.ts
@@ -9,6 +9,7 @@ export type GerberNodeSource =
 
 export type GerberNodeLayer =
   | GerberNodeSource
+  | GerberNodePreparedLayer
   | {
       source: GerberNodeSource;
       name?: string;
@@ -25,6 +26,24 @@ export type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
     };
+
+export type NodeLayerBounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+};
+
+declare const preparedLayerBrand: unique symbol;
+
+export type GerberNodePreparedLayer = {
+  readonly [preparedLayerBrand]: true;
+  readonly name: string;
+  readonly sourceName: string;
+  readonly bounds: NodeLayerBounds;
+  readonly offsetX: number;
+  readonly offsetY: number;
+};
 
 export type RGBColor = [number, number, number];
 export type RGBAColor = [number, number, number, number];
@@ -77,10 +96,16 @@ export type NodeLayerFailure = {
 };
 
 export type NodeLayerOptions = {
+  name?: string;
   color?: RGBColor | string;
   alpha?: number;
   offsetX?: number;
   offsetY?: number;
+};
+
+export type NodeLayerLoadOptions = NodeLayerOptions & {
+  preserveArcRegions?: boolean;
+  arcTessellationQuality?: 0 | 1 | 2;
 };
 
 export type NodeExportOptions = {
@@ -133,6 +158,21 @@ export declare class NodeGerberRenderer {
     layers: GerberNodeLayer | GerberNodeLayer[],
     options?: Pick<NodeFrameOptions, "onLayerError" | "layerErrorMode">,
   ): Promise<{ renderedCount: number; failures: NodeLayerFailure[] }>;
+
+  loadLayer(
+    layer: GerberNodeLayer,
+    layerOptions?: NodeLayerLoadOptions,
+  ): Promise<GerberNodePreparedLayer>;
+
+  loadLayers(
+    layers: GerberNodeLayer | GerberNodeLayer[],
+    options?: NodeLayerLoadOptions &
+      Pick<NodeFrameOptions, "onLayerError" | "layerErrorMode">,
+  ): Promise<{
+    layers: GerberNodePreparedLayer[];
+    loadedCount: number;
+    failures: NodeLayerFailure[];
+  }>;
 
   exportPng(exportOptions?: NodeExportOptions): Promise<Uint8Array>;
 

--- a/packages/wasm-gerber-renderer/node.d.ts
+++ b/packages/wasm-gerber-renderer/node.d.ts
@@ -28,6 +28,7 @@ export type GerberNodeLayer =
 
 export type RGBColor = [number, number, number];
 export type RGBAColor = [number, number, number, number];
+export type PngRenderStrategy = "auto" | "full-frame" | "stream";
 
 export type NodeRendererOptions = {
   wasmModule?: unknown;
@@ -58,6 +59,11 @@ export type NodeFrameOptions = {
   arcTessellationQuality?: 0 | 1 | 2;
   minimumFeaturePixels?: number;
   globalAlpha?: number;
+  maxBandBytes?: number;
+  maxFullFrameBytes?: number;
+  maxRenderTargetBytes?: number;
+  framebufferMemorySafetyFactor?: number;
+  strategy?: PngRenderStrategy;
   onLayerError?: (failure: NodeLayerFailure) => void;
   layerErrorMode?: LayerErrorMode;
 };
@@ -79,6 +85,11 @@ export type NodeLayerOptions = {
 
 export type NodeExportOptions = {
   background?: null | string | RGBAColor;
+  maxBandBytes?: number;
+  maxFullFrameBytes?: number;
+  maxRenderTargetBytes?: number;
+  framebufferMemorySafetyFactor?: number;
+  strategy?: PngRenderStrategy;
 };
 
 export declare function createNodeGerberRenderer(

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -247,7 +247,7 @@ export class NodeGerberRenderer {
       options.color == null
         ? this.frame.nextColor()
         : normalizeColor(options.color, this.frame.options.colors[0]);
-    const alpha = clamp01(numberOrDefault(options.alpha, 1));
+    const alpha = optionalAlpha(options.alpha);
 
     return {
       layerId,
@@ -312,6 +312,7 @@ class FrameState {
   }
 
   toResult(view) {
+    const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
     return {
       width: this.options.width,
       height: this.options.height,
@@ -323,7 +324,7 @@ class FrameState {
         name: layer.name,
         bounds: layer.bounds,
         color: layer.color,
-        alpha: layer.alpha,
+        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
       })),
     };
   }
@@ -1029,30 +1030,30 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
     try {
       for (let tileY = 0; tileY < height; tileY += tileHeight) {
         const currentTileHeight = Math.min(tileHeight, height - tileY);
-        if (currentTileHeight !== tileHeight) {
-          resizeRenderTarget(renderContext.processor, gl, width, currentTileHeight);
-        }
+        const renderTileY =
+          currentTileHeight === tileHeight ? tileY : Math.max(0, height - tileHeight);
+        const sourceRowOffset = tileY - renderTileY;
         renderContext.processor.render_tile(
           renderContext.activeLayerIds,
           renderContext.colorData,
           width,
           height,
           0,
-          tileY,
+          renderTileY,
           width,
-          currentTileHeight,
+          tileHeight,
           plan.view.zoomX,
           plan.view.zoomY,
           plan.view.offsetX,
           plan.view.offsetY,
-          plan.globalAlpha,
+          1,
         );
         gl.finish?.();
         gl.readPixels(
           0,
           0,
           width,
-          currentTileHeight,
+          tileHeight,
           gl.RGBA,
           gl.UNSIGNED_BYTE,
           tilePixels,
@@ -1061,7 +1062,9 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
           writeRow,
           tilePixels,
           width,
+          tileHeight,
           currentTileHeight,
+          sourceRowOffset,
           rowStride,
           background,
         );
@@ -1105,7 +1108,7 @@ function renderPlanToFullFramePngBuffer(
           plan.view.zoomY,
           plan.view.offsetX,
           plan.view.offsetY,
-          plan.globalAlpha,
+          1,
           true,
         );
     return bottomUpRgbaToPngBuffer(Buffer.from(pixels), width, height, background);
@@ -1132,7 +1135,7 @@ function createProcessorForPlan(renderer, plan, gl, width, height) {
       colorData[offset] = layer.color[0];
       colorData[offset + 1] = layer.color[1];
       colorData[offset + 2] = layer.color[2];
-      colorData[offset + 3] = layer.alpha;
+      colorData[offset + 3] = resolveLayerAlpha(layer.alpha, plan.globalAlpha);
     }
 
     return { processor, activeLayerIds, colorData };
@@ -1246,30 +1249,57 @@ async function writeTileRows(
   tilePixels,
   width,
   tileHeight,
+  rowCount,
+  sourceRowOffset,
   rowStride,
   background,
 ) {
   const row = Buffer.allocUnsafe(rowStride);
   const sourceRowBytes = width * 4;
-  for (let y = 0; y < tileHeight; y += 1) {
+  for (let y = 0; y < rowCount; y += 1) {
     row[0] = 0;
-    const sourceStart = (tileHeight - 1 - y) * sourceRowBytes;
+    const sourceRow = sourceRowOffset + y;
+    const sourceStart = (tileHeight - 1 - sourceRow) * sourceRowBytes;
     if (background) {
-      compositeRowBackground(
-        row,
-        1,
-        tilePixels,
-        sourceStart,
-        sourceRowBytes,
-        background,
-      );
+      writeOpaqueBackgroundRow(row, 1, tilePixels, sourceStart, sourceRowBytes, background);
     } else {
-      row.set(
-        tilePixels.subarray(sourceStart, sourceStart + sourceRowBytes),
-        1,
-      );
+      copyPremultipliedRowToPng(row, 1, tilePixels, sourceStart, sourceRowBytes);
     }
     await writeRow(row);
+  }
+}
+
+function writeOpaqueBackgroundRow(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+  background,
+) {
+  if (background[3] !== 255) {
+    compositePremultipliedRowBackground(
+      output,
+      outputOffset,
+      source,
+      sourceOffset,
+      byteLength,
+      background,
+    );
+    return;
+  }
+
+  const bgR = background[0];
+  const bgG = background[1];
+  const bgB = background[2];
+  for (let offset = 0; offset < byteLength; offset += 4) {
+    const srcA = source[sourceOffset + offset + 3];
+    const inverseA = 255 - srcA;
+    const target = outputOffset + offset;
+    output[target] = source[sourceOffset + offset] + Math.round((bgR * inverseA) / 255);
+    output[target + 1] = source[sourceOffset + offset + 1] + Math.round((bgG * inverseA) / 255);
+    output[target + 2] = source[sourceOffset + offset + 2] + Math.round((bgB * inverseA) / 255);
+    output[target + 3] = 255;
   }
 }
 
@@ -1287,7 +1317,35 @@ function fillBandBackground(band, width, height, rowStride, background) {
   }
 }
 
-function compositeRowBackground(
+function copyPremultipliedRowToPng(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+) {
+  for (let offset = 0; offset < byteLength; offset += 4) {
+    const srcA = source[sourceOffset + offset + 3];
+    const target = outputOffset + offset;
+    output[target + 3] = srcA;
+    if (srcA === 0) {
+      output[target] = 0;
+      output[target + 1] = 0;
+      output[target + 2] = 0;
+    } else if (srcA === 255) {
+      output[target] = source[sourceOffset + offset];
+      output[target + 1] = source[sourceOffset + offset + 1];
+      output[target + 2] = source[sourceOffset + offset + 2];
+    } else {
+      const scale = 255 / srcA;
+      output[target] = toByte(source[sourceOffset + offset] * scale);
+      output[target + 1] = toByte(source[sourceOffset + offset + 1] * scale);
+      output[target + 2] = toByte(source[sourceOffset + offset + 2] * scale);
+    }
+  }
+}
+
+function compositePremultipliedRowBackground(
   output,
   outputOffset,
   source,
@@ -1297,9 +1355,9 @@ function compositeRowBackground(
 ) {
   const bgA = background[3] / 255;
   for (let offset = 0; offset < byteLength; offset += 4) {
-    const srcR = source[sourceOffset + offset];
-    const srcG = source[sourceOffset + offset + 1];
-    const srcB = source[sourceOffset + offset + 2];
+    const srcR = source[sourceOffset + offset] / 255;
+    const srcG = source[sourceOffset + offset + 1] / 255;
+    const srcB = source[sourceOffset + offset + 2] / 255;
     const srcAByte = source[sourceOffset + offset + 3];
     const srcA = srcAByte / 255;
     const outA = srcA + bgA * (1 - srcA);
@@ -1311,11 +1369,21 @@ function compositeRowBackground(
       output[target + 3] = 0;
       continue;
     }
-    output[target] = Math.round((srcR * srcA + background[0] * bgA * (1 - srcA)) / outA);
-    output[target + 1] = Math.round((srcG * srcA + background[1] * bgA * (1 - srcA)) / outA);
-    output[target + 2] = Math.round((srcB * srcA + background[2] * bgA * (1 - srcA)) / outA);
-    output[target + 3] = Math.round(outA * 255);
+    output[target] = toByte(
+      ((srcR + (background[0] / 255) * bgA * (1 - srcA)) / outA) * 255,
+    );
+    output[target + 1] = toByte(
+      ((srcG + (background[1] / 255) * bgA * (1 - srcA)) / outA) * 255,
+    );
+    output[target + 2] = toByte(
+      ((srcB + (background[2] / 255) * bgA * (1 - srcA)) / outA) * 255,
+    );
+    output[target + 3] = toByte(outA * 255);
   }
+}
+
+function toByte(value) {
+  return Math.min(255, Math.max(0, Math.round(value)));
 }
 
 function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
@@ -1327,16 +1395,9 @@ function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
     const sourceStart = (height - 1 - y) * rowBytes;
     raw[rawOffset] = 0;
     if (background) {
-      compositeRowBackground(
-        raw,
-        rawOffset + 1,
-        rgba,
-        sourceStart,
-        rowBytes,
-        background,
-      );
+      writeOpaqueBackgroundRow(raw, rawOffset + 1, rgba, sourceStart, rowBytes, background);
     } else {
-      rgba.copy(raw, rawOffset + 1, sourceStart, sourceStart + rowBytes);
+      copyPremultipliedRowToPng(raw, rawOffset + 1, rgba, sourceStart, rowBytes);
     }
   }
 
@@ -1620,6 +1681,14 @@ function positiveNumberOrDefault(value, fallback) {
 function numberOrDefault(value, fallback) {
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
+}
+
+function optionalAlpha(value) {
+  return value == null ? null : clamp01(value);
+}
+
+function resolveLayerAlpha(layerAlpha, globalAlpha) {
+  return layerAlpha == null ? globalAlpha : layerAlpha;
 }
 
 function normalizeExportStrategy(value) {

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -584,7 +584,10 @@ function parseLayerPayload(wasmModule, content, offsetX, offsetY, frameOptions) 
       arcTessellationQuality,
     );
   } else {
-    if (!preserveArcRegions) {
+    if (
+      !preserveArcRegions ||
+      arcTessellationQuality !== DEFAULT_ARC_TESSELLATION_QUALITY
+    ) {
       throw new Error("Gerber parse options require an updated WASM module.");
     }
     payload = parseDefault(content, offsetX, offsetY);
@@ -1079,6 +1082,40 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
     height,
     getFullFrameRenderTargetCount(layerCount),
   );
+  const rowStride = getPngRowStride(width, pngChannels);
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = pngColorType;
+  header[10] = 0;
+  header[11] = 0;
+  header[12] = 0;
+
+  if (plan.layers.length === 0 || !plan.view) {
+    const blankTileHeight = getBlankStreamTileHeight(
+      width,
+      height,
+      maxBandBytes,
+      pngChannels,
+    );
+    const deflatedChunks = await deflatePngRows(async (writeRow) => {
+      await writeBlankPngRows(
+        writeRow,
+        width,
+        height,
+        blankTileHeight,
+        background,
+        pngChannels,
+      );
+    });
+    return Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      pngChunk("IHDR", header),
+      ...deflatedChunks.map((chunk) => pngChunk("IDAT", chunk)),
+      pngChunk("IEND", Buffer.alloc(0)),
+    ]);
+  }
 
   const shouldTryFullFrame =
     strategy === "full-frame" ||
@@ -1134,29 +1171,8 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
   const renderGl = renderer.rendererOptions.gl
     ? gl
     : renderer.createExportContext(width, tileHeight);
-  const rowStride = getPngRowStride(width, pngChannels);
-  const header = Buffer.alloc(13);
-  header.writeUInt32BE(width, 0);
-  header.writeUInt32BE(height, 4);
-  header[8] = 8;
-  header[9] = pngColorType;
-  header[10] = 0;
-  header[11] = 0;
-  header[12] = 0;
 
   const deflatedChunks = await deflatePngRows(async (writeRow) => {
-    if (plan.layers.length === 0 || !plan.view) {
-      await writeBlankPngRows(
-        writeRow,
-        width,
-        height,
-        tileHeight,
-        background,
-        pngChannels,
-      );
-      return;
-    }
-
     const renderContext = createProcessorForPlan(
       renderer,
       plan,
@@ -1845,13 +1861,31 @@ function getStreamTileHeight(
   return Math.max(1, Math.floor(tileHeight));
 }
 
+function getBlankStreamTileHeight(width, height, maxBandBytes, pngChannels) {
+  const rowStride = getPngRowStride(width, pngChannels);
+  const tileHeight = Math.min(height, Math.floor(maxBandBytes / rowStride));
+  if (!Number.isFinite(tileHeight) || tileHeight < 1) {
+    throw new Error(
+      `PNG export rows exceed the ${formatByteCount(maxBandBytes)} stream band limit at ${width}px wide.`,
+    );
+  }
+  return Math.max(1, Math.floor(tileHeight));
+}
+
 function getMaxRenderDimension(gl) {
-  const maxRenderbufferSize =
-    typeof gl.getParameter === "function"
-      ? Number(gl.getParameter(gl.MAX_RENDERBUFFER_SIZE))
-      : Number.POSITIVE_INFINITY;
-  return Number.isFinite(maxRenderbufferSize) && maxRenderbufferSize > 0
-    ? maxRenderbufferSize
+  return Math.min(
+    getGlNumericParameter(gl, gl.MAX_RENDERBUFFER_SIZE),
+    getGlNumericParameter(gl, gl.MAX_TEXTURE_SIZE),
+  );
+}
+
+function getGlNumericParameter(gl, parameter) {
+  if (parameter == null || typeof gl.getParameter !== "function") {
+    return Number.POSITIVE_INFINITY;
+  }
+  const value = Number(gl.getParameter(parameter));
+  return Number.isFinite(value) && value > 0
+    ? value
     : Number.POSITIVE_INFINITY;
 }
 

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -1033,6 +1033,7 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
         const renderTileY =
           currentTileHeight === tileHeight ? tileY : Math.max(0, height - tileHeight);
         const sourceRowOffset = tileY - renderTileY;
+        const readY = tileHeight - sourceRowOffset - currentTileHeight;
         renderContext.processor.render_tile(
           renderContext.activeLayerIds,
           renderContext.colorData,
@@ -1051,9 +1052,9 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
         gl.finish?.();
         gl.readPixels(
           0,
-          0,
+          readY,
           width,
-          tileHeight,
+          currentTileHeight,
           gl.RGBA,
           gl.UNSIGNED_BYTE,
           tilePixels,
@@ -1062,9 +1063,7 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
           writeRow,
           tilePixels,
           width,
-          tileHeight,
           currentTileHeight,
-          sourceRowOffset,
           rowStride,
           background,
         );
@@ -1237,10 +1236,7 @@ async function writeBlankPngRows(writeRow, width, height, tileHeight, background
   }
   for (let y = 0; y < height; y += tileHeight) {
     const currentTileHeight = Math.min(tileHeight, height - y);
-    for (let row = 0; row < currentTileHeight; row += 1) {
-      const start = row * rowStride;
-      await writeRow(band.subarray(start, start + rowStride));
-    }
+    await writeRow(band.subarray(0, currentTileHeight * rowStride));
   }
 }
 
@@ -1248,25 +1244,23 @@ async function writeTileRows(
   writeRow,
   tilePixels,
   width,
-  tileHeight,
   rowCount,
-  sourceRowOffset,
   rowStride,
   background,
 ) {
-  const row = Buffer.allocUnsafe(rowStride);
+  const band = Buffer.allocUnsafe(rowStride * rowCount);
   const sourceRowBytes = width * 4;
   for (let y = 0; y < rowCount; y += 1) {
-    row[0] = 0;
-    const sourceRow = sourceRowOffset + y;
-    const sourceStart = (tileHeight - 1 - sourceRow) * sourceRowBytes;
+    const rowStart = y * rowStride;
+    band[rowStart] = 0;
+    const sourceStart = (rowCount - 1 - y) * sourceRowBytes;
     if (background) {
-      writeOpaqueBackgroundRow(row, 1, tilePixels, sourceStart, sourceRowBytes, background);
+      writeOpaqueBackgroundRow(band, rowStart + 1, tilePixels, sourceStart, sourceRowBytes, background);
     } else {
-      copyPremultipliedRowToPng(row, 1, tilePixels, sourceStart, sourceRowBytes);
+      copyPremultipliedRowToPng(band, rowStart + 1, tilePixels, sourceStart, sourceRowBytes);
     }
-    await writeRow(row);
   }
+  await writeRow(band);
 }
 
 function writeOpaqueBackgroundRow(
@@ -1292,6 +1286,17 @@ function writeOpaqueBackgroundRow(
   const bgR = background[0];
   const bgG = background[1];
   const bgB = background[2];
+  if (bgR === 0 && bgG === 0 && bgB === 0) {
+    for (let offset = 0; offset < byteLength; offset += 4) {
+      const target = outputOffset + offset;
+      output[target] = source[sourceOffset + offset];
+      output[target + 1] = source[sourceOffset + offset + 1];
+      output[target + 2] = source[sourceOffset + offset + 2];
+      output[target + 3] = 255;
+    }
+    return;
+  }
+
   for (let offset = 0; offset < byteLength; offset += 4) {
     const srcA = source[sourceOffset + offset + 3];
     const inverseA = 255 - srcA;

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -258,7 +258,7 @@ export class NodeGerberRenderer {
     return {
       layerId,
       name: prepared.name || `Layer ${layerId}`,
-      content: null,
+      content: prepared.content,
       parsedLayer: prepared.parsedLayer,
       offsetX: prepared.offsetX,
       offsetY: prepared.offsetY,
@@ -291,6 +291,7 @@ export class NodeGerberRenderer {
       [NODE_PREPARED_LAYER]: true,
       name: options.name || sourceName || "Layer",
       sourceName,
+      content: supportsParsedLayerReuse(this.wasmModule) ? null : content,
       parsedLayer: parsed.payload,
       bounds: parsed.bounds,
       offsetX,
@@ -583,7 +584,7 @@ function parseLayerPayload(wasmModule, content, offsetX, offsetY, frameOptions) 
       arcTessellationQuality,
     );
   } else {
-    if (!preserveArcRegions || arcTessellationQuality !== 1) {
+    if (!preserveArcRegions) {
       throw new Error("Gerber parse options require an updated WASM module.");
     }
     payload = parseDefault(content, offsetX, offsetY);
@@ -1127,6 +1128,12 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
     layerCount,
     pngChannels,
   );
+  if (!renderer.rendererOptions.gl) {
+    renderer.releaseContext();
+  }
+  const renderGl = renderer.rendererOptions.gl
+    ? gl
+    : renderer.createExportContext(width, tileHeight);
   const rowStride = getPngRowStride(width, pngChannels);
   const header = Buffer.alloc(13);
   header.writeUInt32BE(width, 0);
@@ -1153,7 +1160,7 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
     const renderContext = createProcessorForPlan(
       renderer,
       plan,
-      gl,
+      renderGl,
       width,
       tileHeight,
     );
@@ -1180,14 +1187,14 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
           plan.view.offsetY,
           1,
         );
-        gl.finish?.();
-        gl.readPixels(
+        renderGl.finish?.();
+        renderGl.readPixels(
           0,
           readY,
           width,
           currentTileHeight,
-          gl.RGBA,
-          gl.UNSIGNED_BYTE,
+          renderGl.RGBA,
+          renderGl.UNSIGNED_BYTE,
           tilePixels,
         );
         await writeTileRows(
@@ -1278,15 +1285,21 @@ function createProcessorForPlan(renderer, plan, gl, width, height) {
 
 function addPlanLayerToProcessor(processor, layer) {
   if (layer.parsedLayer) {
-    if (typeof processor.add_parsed_layer !== "function") {
+    if (typeof processor.add_parsed_layer === "function") {
+      return processor.add_parsed_layer(layer.parsedLayer);
+    }
+    if (typeof layer.content !== "string") {
       throw new Error("Parsed layer reuse requires an updated WASM renderer.");
     }
-    return processor.add_parsed_layer(layer.parsedLayer);
   }
   if (typeof layer.content !== "string") {
     throw new Error("Layer content is unavailable for rendering.");
   }
   return addLayerToProcessor(processor, layer.content, layer.offsetX, layer.offsetY);
+}
+
+function supportsParsedLayerReuse(wasmModule) {
+  return typeof wasmModule.GerberProcessor?.prototype?.add_parsed_layer === "function";
 }
 
 function resizeRenderTarget(processor, gl, width, height) {

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -36,6 +36,7 @@ const DEFAULT_MAX_RENDER_TARGET_BYTES = 2 * 1024 * 1024 * 1024;
 const DEFAULT_FRAMEBUFFER_MEMORY_SAFETY_FACTOR = 2;
 const MIN_RENDER_TARGET_BYTES = 64 * 1024 * 1024;
 const MEMORY_PROBE_TIMEOUT_MS = 750;
+const PROBE_RENDER_TARGET_SIZE = 1;
 const GL_RGBA8 = 0x8058;
 const REQUIRED_WEBGL2_METHODS = [
   "createVertexArray",
@@ -569,15 +570,25 @@ function addLayerToProcessor(processor, content, offsetX, offsetY) {
 function parseLayerPayload(wasmModule, content, offsetX, offsetY, frameOptions) {
   const parseWithOptions = wasmModule.parse_gerber_layer_with_options;
   const parseDefault = wasmModule.parse_gerber_layer;
-  const payload = typeof parseWithOptions === "function"
-    ? parseWithOptions(
-        content,
-        offsetX,
-        offsetY,
-        frameOptions.preserveArcRegions !== false,
-        Number(frameOptions.arcTessellationQuality ?? 1),
-      )
-    : parseDefault(content, offsetX, offsetY);
+  const preserveArcRegions = frameOptions.preserveArcRegions !== false;
+  const arcTessellationQuality = Number(frameOptions.arcTessellationQuality ?? 1);
+  let payload;
+
+  if (typeof parseWithOptions === "function") {
+    payload = parseWithOptions(
+      content,
+      offsetX,
+      offsetY,
+      preserveArcRegions,
+      arcTessellationQuality,
+    );
+  } else {
+    if (!preserveArcRegions || arcTessellationQuality !== 1) {
+      throw new Error("Gerber parse options require an updated WASM module.");
+    }
+    payload = parseDefault(content, offsetX, offsetY);
+  }
+
   const sublayers = Array.from(payload?.sublayers ?? []);
   let bounds = null;
   for (const sublayer of sublayers) {
@@ -1097,15 +1108,8 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
   }
 
   const gl = renderer.createExportContext(
-    width,
-    getStreamTileHeight(
-      width,
-      height,
-      maxBandBytes,
-      maxRenderTargetBytes,
-      Number.POSITIVE_INFINITY,
-      layerCount,
-    ),
+    PROBE_RENDER_TARGET_SIZE,
+    PROBE_RENDER_TARGET_SIZE,
   );
   const maxDimension = getMaxRenderDimension(gl);
   if (width > maxDimension) {

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -1,8 +1,11 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { once } from "node:events";
+import { execFile as execFileCallback } from "node:child_process";
+import { readdir, readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { freemem } from "node:os";
 import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { deflateSync } from "node:zlib";
+import { createDeflate, deflateSync } from "node:zlib";
 
 const require = createRequire(import.meta.url);
 
@@ -26,6 +29,14 @@ const DEFAULT_BACKGROUND = null;
 const DEFAULT_GLOBAL_ALPHA = 0.7;
 const DEFAULT_MINIMUM_FEATURE_PIXELS = 1;
 const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
+const RGBA_BYTES_PER_PIXEL = 4;
+const DEFAULT_MAX_STREAM_BAND_BYTES = 512 * 1024 * 1024;
+const DEFAULT_MAX_FULL_FRAME_BYTES = 512 * 1024 * 1024;
+const DEFAULT_MAX_RENDER_TARGET_BYTES = 2 * 1024 * 1024 * 1024;
+const DEFAULT_FRAMEBUFFER_MEMORY_SAFETY_FACTOR = 2;
+const MIN_RENDER_TARGET_BYTES = 64 * 1024 * 1024;
+const MEMORY_PROBE_TIMEOUT_MS = 750;
+const GL_RGBA8 = 0x8058;
 const REQUIRED_WEBGL2_METHODS = [
   "createVertexArray",
   "bindVertexArray",
@@ -50,7 +61,7 @@ export async function renderGerberToPngBuffer(
     await renderer.withFrame(frameOptions, async () => {
       await renderer.renderLayers(layers, frameOptions);
     });
-    return renderer.exportPng(exportOptions);
+    return await renderer.exportPng(exportOptions);
   } finally {
     renderer.dispose();
   }
@@ -83,9 +94,10 @@ export class NodeGerberRenderer {
     this.rendererOptions = { ...rendererOptions };
     this.wasmModule = wasmModule;
     this.gl = rendererOptions.gl || null;
+    this.staleGlContexts = [];
     this.frame = null;
     this.lastFrame = null;
-    this.lastPixels = null;
+    this.lastRenderPlan = null;
     this.disposed = false;
   }
 
@@ -99,29 +111,13 @@ export class NodeGerberRenderer {
     }
 
     const normalizedFrameOptions = normalizeFrameOptions(frameOptions);
-    const gl = this.getContext(
-      normalizedFrameOptions.width,
-      normalizedFrameOptions.height,
-    );
-    const processor = new this.wasmModule.GerberProcessor();
     try {
-      if (typeof processor.init_with_size !== "function") {
-        throw new Error("Headless rendering requires an updated WASM module.");
-      }
-      processor.init_with_size(
-        gl,
-        normalizedFrameOptions.width,
-        normalizedFrameOptions.height,
-      );
-      applyProcessorOptions(processor, normalizedFrameOptions);
-
-      this.frame = new FrameState(processor, normalizedFrameOptions);
+      this.frame = new FrameState(normalizedFrameOptions);
       this.lastFrame = null;
-      this.lastPixels = null;
+      this.lastRenderPlan = null;
       await callback();
-      this.renderFrameToPixels();
+      this.prepareFrameExport();
     } finally {
-      this.disposeFrameProcessor(processor);
       this.frame = null;
     }
   }
@@ -148,7 +144,7 @@ export class NodeGerberRenderer {
 
   async exportPng(exportOptions = {}) {
     this.assertUsable();
-    if (!this.lastFrame || !this.lastPixels) {
+    if (!this.lastFrame || !this.lastRenderPlan) {
       throw new Error("No rendered frame is available for export.");
     }
 
@@ -156,12 +152,11 @@ export class NodeGerberRenderer {
       "background" in exportOptions
         ? exportOptions.background
         : this.lastFrame.background;
-    const pixels =
-      background == null
-        ? this.lastPixels
-        : compositeBackground(this.lastPixels, parseColor(background, true));
 
-    return rgbaToPngBuffer(pixels, this.lastFrame.width, this.lastFrame.height);
+    return renderPlanToPngBuffer(this, this.lastRenderPlan, {
+      ...exportOptions,
+      background,
+    });
   }
 
   dispose() {
@@ -169,15 +164,12 @@ export class NodeGerberRenderer {
     this.disposed = true;
     this.frame = null;
     this.lastFrame = null;
-    this.lastPixels = null;
+    this.lastRenderPlan = null;
 
     if (this.rendererOptions.releaseContext !== false && this.gl) {
-      try {
-        this.gl.getExtension("WEBGL_lose_context")?.loseContext();
-      } catch (_error) {
-        // Best-effort cleanup.
-      }
+      this.releaseContext();
     }
+    this.releaseStaleContexts();
   }
 
   getContext(width, height) {
@@ -195,20 +187,63 @@ export class NodeGerberRenderer {
     return this.gl;
   }
 
+  createExportContext(width, height) {
+    if (this.rendererOptions.gl) {
+      return this.getContext(width, height);
+    }
+
+    if (this.gl) {
+      this.staleGlContexts.push(this.gl);
+      this.gl = null;
+    }
+    this.gl = createNodeGlesContext(
+      width,
+      height,
+      this.rendererOptions,
+      this.rendererOptions.contextAttributes || {},
+    );
+    return this.gl;
+  }
+
+  releaseContext() {
+    if (!this.gl) return;
+    try {
+      this.gl.getExtension("WEBGL_lose_context")?.loseContext();
+    } catch (_error) {
+      // Best-effort cleanup.
+    }
+    this.gl = null;
+  }
+
+  releaseStaleContexts() {
+    for (const gl of this.staleGlContexts.splice(0)) {
+      try {
+        gl.getExtension("WEBGL_lose_context")?.loseContext();
+      } catch (_error) {
+        // Best-effort cleanup.
+      }
+    }
+  }
+
+  releaseInternalContexts() {
+    if (this.rendererOptions.gl) return;
+    this.releaseContext();
+    this.releaseStaleContexts();
+  }
+
   async createLayerRecord(layer, layerOptions) {
     const { source, options } = normalizeLayer(layer, layerOptions);
     const content = await sourceToText(source);
     const offsetX = numberOrDefault(options.offsetX, 0);
     const offsetY = numberOrDefault(options.offsetY, 0);
-    const layerId = addLayerToProcessor(
-      this.frame.processor,
+    const parsed = parseLayerPayload(
+      this.wasmModule,
       content,
       offsetX,
       offsetY,
+      this.frame.options,
     );
-    const bounds = boundaryToPlainObject(
-      this.frame.processor.get_layer_boundary(layerId),
-    );
+    const layerId = this.frame.layers.length;
     const color =
       options.color == null
         ? this.frame.nextColor()
@@ -218,22 +253,25 @@ export class NodeGerberRenderer {
     return {
       layerId,
       name: options.name || getSourceName(source) || `Layer ${layerId}`,
-      bounds,
+      content: null,
+      parsedLayer: parsed.payload,
+      offsetX,
+      offsetY,
+      bounds: parsed.bounds,
       color,
       alpha,
     };
   }
 
-  renderFrameToPixels() {
+  prepareFrameExport() {
     const frame = this.frame;
     if (!frame) {
       throw new Error("No active frame to render.");
     }
 
     if (frame.layers.length === 0) {
-      const pixelCount = frame.options.width * frame.options.height * 4;
-      this.lastPixels = Buffer.alloc(pixelCount);
       this.lastFrame = frame.toResult(null);
+      this.lastRenderPlan = frame.toRenderPlan(null);
       return;
     }
 
@@ -242,49 +280,8 @@ export class NodeGerberRenderer {
       frame.options.width,
       frame.options.height,
     );
-    const activeLayerIds = new Uint32Array(
-      frame.layers.map((layer) => layer.layerId),
-    );
-    const colorData = new Float32Array(frame.layers.length * 4);
-    for (const [index, layer] of frame.layers.entries()) {
-      const offset = index * 4;
-      colorData[offset] = layer.color[0];
-      colorData[offset + 1] = layer.color[1];
-      colorData[offset + 2] = layer.color[2];
-      colorData[offset + 3] = layer.alpha;
-    }
-
-    const globalAlpha = clamp01(numberOrDefault(frame.options.globalAlpha, 1));
-    const pixels = frame.processor.render_pixels_with_clear(
-      activeLayerIds,
-      colorData,
-      view.zoomX,
-      view.zoomY,
-      view.offsetX,
-      view.offsetY,
-      globalAlpha,
-      frame.options.clear !== false,
-    );
-
-    this.lastPixels = flipRgbaRows(
-      Buffer.from(pixels),
-      frame.options.width,
-      frame.options.height,
-    );
     this.lastFrame = frame.toResult(view);
-  }
-
-  disposeFrameProcessor(processor) {
-    try {
-      processor.clear();
-    } catch (_error) {
-      // The pixel result is already copied; cleanup failures should not hide it.
-    }
-    try {
-      processor.free?.();
-    } catch (_error) {
-      // The context may already be unrecoverable; cleanup is best-effort.
-    }
+    this.lastRenderPlan = frame.toRenderPlan(view);
   }
 
   assertUsable() {
@@ -295,8 +292,7 @@ export class NodeGerberRenderer {
 }
 
 class FrameState {
-  constructor(processor, options) {
-    this.processor = processor;
+  constructor(options) {
     this.options = options;
     this.layers = [];
     this.bounds = null;
@@ -327,6 +323,34 @@ class FrameState {
         id: layer.layerId,
         name: layer.name,
         bounds: layer.bounds,
+        color: layer.color,
+        alpha: layer.alpha,
+      })),
+    };
+  }
+
+  toRenderPlan(view) {
+    const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
+    return {
+      width: this.options.width,
+      height: this.options.height,
+      background: this.options.background,
+      bounds: this.bounds,
+      view,
+      globalAlpha,
+      maxBandBytes: this.options.maxBandBytes,
+      preserveArcRegions: this.options.preserveArcRegions,
+      arcTessellationQuality: this.options.arcTessellationQuality,
+      minimumFeaturePixels: this.options.minimumFeaturePixels,
+      maxFullFrameBytes: this.options.maxFullFrameBytes,
+      maxRenderTargetBytes: this.options.maxRenderTargetBytes,
+      framebufferMemorySafetyFactor: this.options.framebufferMemorySafetyFactor,
+      strategy: this.options.strategy,
+      layers: this.layers.map((layer) => ({
+        content: layer.content,
+        parsedLayer: layer.parsedLayer,
+        offsetX: layer.offsetX,
+        offsetY: layer.offsetY,
         color: layer.color,
         alpha: layer.alpha,
       })),
@@ -504,6 +528,29 @@ function addLayerToProcessor(processor, content, offsetX, offsetY) {
   return processor.add_layer(content);
 }
 
+function parseLayerPayload(wasmModule, content, offsetX, offsetY, frameOptions) {
+  const parseWithOptions = wasmModule.parse_gerber_layer_with_options;
+  const parseDefault = wasmModule.parse_gerber_layer;
+  const payload = typeof parseWithOptions === "function"
+    ? parseWithOptions(
+        content,
+        offsetX,
+        offsetY,
+        frameOptions.preserveArcRegions !== false,
+        Number(frameOptions.arcTessellationQuality ?? 1),
+      )
+    : parseDefault(content, offsetX, offsetY);
+  const sublayers = Array.from(payload?.sublayers ?? []);
+  let bounds = null;
+  for (const sublayer of sublayers) {
+    bounds = mergeBounds(bounds, boundaryToPlainObject(sublayer.boundary));
+  }
+  if (!bounds) {
+    throw new Error("File does not contain valid Gerber data (no geometry found)");
+  }
+  return { payload, bounds };
+}
+
 function normalizeFrameOptions(frameOptions) {
   if (frameOptions.clear === false) {
     throw new Error(
@@ -530,6 +577,26 @@ function normalizeFrameOptions(frameOptions) {
       DEFAULT_MINIMUM_FEATURE_PIXELS,
     ),
     globalAlpha: numberOrDefault(frameOptions.globalAlpha, DEFAULT_GLOBAL_ALPHA),
+    maxBandBytes: positiveIntegerOrDefault(
+      frameOptions.maxBandBytes,
+      DEFAULT_MAX_STREAM_BAND_BYTES,
+    ),
+    maxFullFrameBytes: positiveIntegerOrDefault(
+      frameOptions.maxFullFrameBytes,
+      DEFAULT_MAX_FULL_FRAME_BYTES,
+    ),
+    maxRenderTargetBytes:
+      frameOptions.maxRenderTargetBytes == null
+        ? null
+        : positiveIntegerOrDefault(
+            frameOptions.maxRenderTargetBytes,
+            DEFAULT_MAX_RENDER_TARGET_BYTES,
+          ),
+    framebufferMemorySafetyFactor: positiveNumberOrDefault(
+      frameOptions.framebufferMemorySafetyFactor,
+      DEFAULT_FRAMEBUFFER_MEMORY_SAFETY_FACTOR,
+    ),
+    strategy: normalizeExportStrategy(frameOptions.strategy),
     colors: DEFAULT_COLORS.map((color) => [...color]),
   };
 }
@@ -846,52 +913,432 @@ function parseCssChannel(value) {
   return Math.min(255, Math.max(0, Math.round(Number(trimmed))));
 }
 
-function compositeBackground(pixels, background) {
-  const output = Buffer.from(pixels);
-  const bgA = background[3] / 255;
-  for (let index = 0; index < output.length; index += 4) {
-    const srcA = output[index + 3] / 255;
-    const outA = srcA + bgA * (1 - srcA);
-    if (outA <= 0) {
-      output[index] = 0;
-      output[index + 1] = 0;
-      output[index + 2] = 0;
-      output[index + 3] = 0;
-      continue;
+async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
+  const width = positiveIntegerOrDefault(plan.width, DEFAULT_WIDTH);
+  const height = positiveIntegerOrDefault(plan.height, DEFAULT_HEIGHT);
+  const strategy = normalizeExportStrategy(exportOptions.strategy || plan.strategy);
+  const background =
+    exportOptions.background == null
+      ? null
+      : parseColor(exportOptions.background, true);
+  const maxBandBytes = positiveIntegerOrDefault(
+    exportOptions.maxBandBytes,
+    plan.maxBandBytes || DEFAULT_MAX_STREAM_BAND_BYTES,
+  );
+  const maxFullFrameBytes = positiveIntegerOrDefault(
+    exportOptions.maxFullFrameBytes,
+    plan.maxFullFrameBytes || DEFAULT_MAX_FULL_FRAME_BYTES,
+  );
+  const maxRenderTargetBytes = await resolveMaxRenderTargetBytes(
+    exportOptions,
+    plan,
+  );
+  const framebufferMemorySafetyFactor = positiveNumberOrDefault(
+    exportOptions.framebufferMemorySafetyFactor,
+    plan.framebufferMemorySafetyFactor || DEFAULT_FRAMEBUFFER_MEMORY_SAFETY_FACTOR,
+  );
+  const layerCount = Math.max(1, plan.layers.length);
+  const fullFrameEstimate = estimateFullFrameBytes(
+    width,
+    height,
+    framebufferMemorySafetyFactor,
+  );
+  const fullFrameRenderTargetEstimate = estimateRenderTargetBytes(
+    width,
+    height,
+    getFullFrameRenderTargetCount(layerCount),
+  );
+
+  const shouldTryFullFrame =
+    strategy === "full-frame" ||
+    (strategy === "auto" &&
+      fullFrameEstimate <= maxFullFrameBytes &&
+      fullFrameRenderTargetEstimate <= maxRenderTargetBytes);
+  if (shouldTryFullFrame) {
+    assertRenderTargetBudget(
+      fullFrameRenderTargetEstimate,
+      maxRenderTargetBytes,
+      width,
+      height,
+    );
+    try {
+      return renderPlanToFullFramePngBuffer(
+        renderer,
+        plan,
+        width,
+        height,
+        background,
+      );
+    } catch (error) {
+      if (strategy === "full-frame") {
+        throw error;
+      }
+      renderer.releaseInternalContexts();
+    }
+  }
+
+  const gl = renderer.createExportContext(
+    width,
+    getStreamTileHeight(
+      width,
+      height,
+      maxBandBytes,
+      maxRenderTargetBytes,
+      Number.POSITIVE_INFINITY,
+      layerCount,
+    ),
+  );
+  const maxDimension = getMaxRenderDimension(gl);
+  if (width > maxDimension) {
+    throw new Error(
+      `PNG export width ${width}px exceeds this renderer's ${maxDimension}px render limit.`,
+    );
+  }
+
+  const tileHeight = getStreamTileHeight(
+    width,
+    height,
+    maxBandBytes,
+    maxRenderTargetBytes,
+    maxDimension,
+    layerCount,
+  );
+  const rowStride = getPngRowStride(width);
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 6;
+  header[10] = 0;
+  header[11] = 0;
+  header[12] = 0;
+
+  const deflatedChunks = await deflatePngRows(async (writeRow) => {
+    if (plan.layers.length === 0 || !plan.view) {
+      await writeBlankPngRows(writeRow, width, height, tileHeight, background);
+      return;
     }
 
-    output[index] = Math.round(
-      (output[index] * srcA + background[0] * bgA * (1 - srcA)) / outA,
+    const renderContext = createProcessorForPlan(
+      renderer,
+      plan,
+      gl,
+      width,
+      tileHeight,
     );
-    output[index + 1] = Math.round(
-      (output[index + 1] * srcA + background[1] * bgA * (1 - srcA)) / outA,
-    );
-    output[index + 2] = Math.round(
-      (output[index + 2] * srcA + background[2] * bgA * (1 - srcA)) / outA,
-    );
-    output[index + 3] = Math.round(outA * 255);
-  }
-  return output;
+    const tilePixels = new Uint8Array(width * tileHeight * 4);
+    try {
+      for (let tileY = 0; tileY < height; tileY += tileHeight) {
+        const currentTileHeight = Math.min(tileHeight, height - tileY);
+        if (currentTileHeight !== tileHeight) {
+          resizeRenderTarget(renderContext.processor, gl, width, currentTileHeight);
+        }
+        renderContext.processor.render_tile(
+          renderContext.activeLayerIds,
+          renderContext.colorData,
+          width,
+          height,
+          0,
+          tileY,
+          width,
+          currentTileHeight,
+          plan.view.zoomX,
+          plan.view.zoomY,
+          plan.view.offsetX,
+          plan.view.offsetY,
+          plan.globalAlpha,
+        );
+        gl.finish?.();
+        gl.readPixels(
+          0,
+          0,
+          width,
+          currentTileHeight,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          tilePixels,
+        );
+        await writeTileRows(
+          writeRow,
+          tilePixels,
+          width,
+          currentTileHeight,
+          rowStride,
+          background,
+        );
+      }
+    } finally {
+      disposeProcessor(renderContext.processor);
+    }
+  });
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk("IHDR", header),
+    ...deflatedChunks.map((chunk) => pngChunk("IDAT", chunk)),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
 }
 
-function flipRgbaRows(pixels, width, height) {
-  const rowSize = width * 4;
-  const output = Buffer.allocUnsafe(pixels.length);
-  for (let y = 0; y < height; y += 1) {
-    const sourceStart = (height - 1 - y) * rowSize;
-    const targetStart = y * rowSize;
-    pixels.copy(output, targetStart, sourceStart, sourceStart + rowSize);
+function renderPlanToFullFramePngBuffer(
+  renderer,
+  plan,
+  width,
+  height,
+  background,
+) {
+  const gl = renderer.createExportContext(width, height);
+  const maxDimension = getMaxRenderDimension(gl);
+  if (width > maxDimension || height > maxDimension) {
+    throw new Error(
+      `PNG export size ${width}x${height}px exceeds this renderer's ${maxDimension}px render limit.`,
+    );
   }
-  return output;
+
+  const renderContext = createProcessorForPlan(renderer, plan, gl, width, height);
+  try {
+    const pixels = plan.layers.length === 0 || !plan.view
+      ? new Uint8Array(width * height * 4)
+      : renderContext.processor.render_pixels_with_clear(
+          renderContext.activeLayerIds,
+          renderContext.colorData,
+          plan.view.zoomX,
+          plan.view.zoomY,
+          plan.view.offsetX,
+          plan.view.offsetY,
+          plan.globalAlpha,
+          true,
+        );
+    return bottomUpRgbaToPngBuffer(Buffer.from(pixels), width, height, background);
+  } finally {
+    disposeProcessor(renderContext.processor);
+  }
 }
 
-function rgbaToPngBuffer(rgba, width, height) {
-  const rowSize = width * 4;
-  const raw = Buffer.allocUnsafe((rowSize + 1) * height);
+function createProcessorForPlan(renderer, plan, gl, width, height) {
+  resizeDrawingBuffer(gl, width, height);
+  const processor = new renderer.wasmModule.GerberProcessor();
+  try {
+    if (typeof processor.init_with_size !== "function") {
+      throw new Error("Streaming PNG export requires an updated WASM module.");
+    }
+    processor.init_with_size(gl, width, height);
+    applyProcessorOptions(processor, plan);
+
+    const activeLayerIds = new Uint32Array(plan.layers.length);
+    const colorData = new Float32Array(plan.layers.length * 4);
+    for (const [index, layer] of plan.layers.entries()) {
+      activeLayerIds[index] = addPlanLayerToProcessor(processor, layer);
+      const offset = index * 4;
+      colorData[offset] = layer.color[0];
+      colorData[offset + 1] = layer.color[1];
+      colorData[offset + 2] = layer.color[2];
+      colorData[offset + 3] = layer.alpha;
+    }
+
+    return { processor, activeLayerIds, colorData };
+  } catch (error) {
+    disposeProcessor(processor);
+    throw error;
+  }
+}
+
+function addPlanLayerToProcessor(processor, layer) {
+  if (layer.parsedLayer) {
+    if (typeof processor.add_parsed_layer !== "function") {
+      throw new Error("Parsed layer reuse requires an updated WASM renderer.");
+    }
+    return processor.add_parsed_layer(layer.parsedLayer);
+  }
+  if (typeof layer.content !== "string") {
+    throw new Error("Layer content is unavailable for rendering.");
+  }
+  return addLayerToProcessor(processor, layer.content, layer.offsetX, layer.offsetY);
+}
+
+function resizeRenderTarget(processor, gl, width, height) {
+  const didResize = resizeDrawingBuffer(gl, width, height);
+  if (!didResize) return;
+  if (typeof processor.resize_to !== "function") {
+    throw new Error("Streaming PNG export requires renderer resize support.");
+  }
+  processor.resize_to(width, height);
+}
+
+function resizeDrawingBuffer(gl, width, height) {
+  if (gl.drawingBufferWidth === width && gl.drawingBufferHeight === height) {
+    return false;
+  }
+  if (typeof gl.drawingBufferStorage === "function") {
+    gl.drawingBufferStorage(gl.RGBA8 || GL_RGBA8, width, height);
+    return true;
+  }
+  const canvas = gl.canvas;
+  if (canvas && "width" in canvas && "height" in canvas) {
+    if (canvas.width === width && canvas.height === height) {
+      return false;
+    }
+    canvas.width = width;
+    canvas.height = height;
+    return true;
+  }
+  if (gl.drawingBufferWidth !== width || gl.drawingBufferHeight !== height) {
+    throw new Error("The WebGL context cannot be resized for streaming PNG export.");
+  }
+  return false;
+}
+
+function disposeProcessor(processor) {
+  try {
+    processor.clear();
+  } catch (_error) {
+    // Best-effort cleanup.
+  }
+  try {
+    processor.free?.();
+  } catch (_error) {
+    // Best-effort cleanup.
+  }
+}
+
+async function deflatePngRows(writeRows) {
+  const deflate = createDeflate();
+  const chunks = [];
+  const done = new Promise((resolve, reject) => {
+    deflate.once("end", resolve);
+    deflate.once("error", reject);
+  });
+  deflate.on("data", (chunk) => {
+    chunks.push(Buffer.from(chunk));
+  });
+
+  try {
+    await writeRows(async (row) => {
+      if (!deflate.write(row)) {
+        await Promise.race([once(deflate, "drain"), done]);
+      }
+    });
+    deflate.end();
+    await done;
+  } catch (error) {
+    deflate.destroy();
+    throw error;
+  }
+  return chunks;
+}
+
+async function writeBlankPngRows(writeRow, width, height, tileHeight, background) {
+  const rowStride = getPngRowStride(width);
+  const band = Buffer.alloc(rowStride * tileHeight);
+  if (background) {
+    fillBandBackground(band, width, tileHeight, rowStride, background);
+  }
+  for (let y = 0; y < height; y += tileHeight) {
+    const currentTileHeight = Math.min(tileHeight, height - y);
+    for (let row = 0; row < currentTileHeight; row += 1) {
+      const start = row * rowStride;
+      await writeRow(band.subarray(start, start + rowStride));
+    }
+  }
+}
+
+async function writeTileRows(
+  writeRow,
+  tilePixels,
+  width,
+  tileHeight,
+  rowStride,
+  background,
+) {
+  const row = Buffer.allocUnsafe(rowStride);
+  const sourceRowBytes = width * 4;
+  for (let y = 0; y < tileHeight; y += 1) {
+    row[0] = 0;
+    const sourceStart = (tileHeight - 1 - y) * sourceRowBytes;
+    if (background) {
+      compositeRowBackground(
+        row,
+        1,
+        tilePixels,
+        sourceStart,
+        sourceRowBytes,
+        background,
+      );
+    } else {
+      row.set(
+        tilePixels.subarray(sourceStart, sourceStart + sourceRowBytes),
+        1,
+      );
+    }
+    await writeRow(row);
+  }
+}
+
+function fillBandBackground(band, width, height, rowStride, background) {
   for (let y = 0; y < height; y += 1) {
-    const rawOffset = y * (rowSize + 1);
+    const rowStart = y * rowStride;
+    band[rowStart] = 0;
+    for (let x = 0; x < width; x += 1) {
+      const offset = rowStart + 1 + x * 4;
+      band[offset] = background[0];
+      band[offset + 1] = background[1];
+      band[offset + 2] = background[2];
+      band[offset + 3] = background[3];
+    }
+  }
+}
+
+function compositeRowBackground(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+  background,
+) {
+  const bgA = background[3] / 255;
+  for (let offset = 0; offset < byteLength; offset += 4) {
+    const srcR = source[sourceOffset + offset];
+    const srcG = source[sourceOffset + offset + 1];
+    const srcB = source[sourceOffset + offset + 2];
+    const srcAByte = source[sourceOffset + offset + 3];
+    const srcA = srcAByte / 255;
+    const outA = srcA + bgA * (1 - srcA);
+    const target = outputOffset + offset;
+    if (outA <= 0) {
+      output[target] = 0;
+      output[target + 1] = 0;
+      output[target + 2] = 0;
+      output[target + 3] = 0;
+      continue;
+    }
+    output[target] = Math.round((srcR * srcA + background[0] * bgA * (1 - srcA)) / outA);
+    output[target + 1] = Math.round((srcG * srcA + background[1] * bgA * (1 - srcA)) / outA);
+    output[target + 2] = Math.round((srcB * srcA + background[2] * bgA * (1 - srcA)) / outA);
+    output[target + 3] = Math.round(outA * 255);
+  }
+}
+
+function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
+  const rowBytes = width * 4;
+  const rowStride = getPngRowStride(width);
+  const raw = Buffer.allocUnsafe(rowStride * height);
+  for (let y = 0; y < height; y += 1) {
+    const rawOffset = y * rowStride;
+    const sourceStart = (height - 1 - y) * rowBytes;
     raw[rawOffset] = 0;
-    rgba.copy(raw, rawOffset + 1, y * rowSize, (y + 1) * rowSize);
+    if (background) {
+      compositeRowBackground(
+        raw,
+        rawOffset + 1,
+        rgba,
+        sourceStart,
+        rowBytes,
+        background,
+      );
+    } else {
+      rgba.copy(raw, rawOffset + 1, sourceStart, sourceStart + rowBytes);
+    }
   }
 
   const header = Buffer.alloc(13);
@@ -909,6 +1356,207 @@ function rgbaToPngBuffer(rgba, width, height) {
     pngChunk("IDAT", deflateSync(raw)),
     pngChunk("IEND", Buffer.alloc(0)),
   ]);
+}
+
+function getPngRowStride(width) {
+  return 1 + width * RGBA_BYTES_PER_PIXEL;
+}
+
+function estimateFullFrameBytes(width, height, safetyFactor) {
+  const pixelBytes = width * height * RGBA_BYTES_PER_PIXEL;
+  return pixelBytes * safetyFactor;
+}
+
+async function resolveMaxRenderTargetBytes(exportOptions, plan) {
+  if (exportOptions.maxRenderTargetBytes != null) {
+    return positiveIntegerOrDefault(
+      exportOptions.maxRenderTargetBytes,
+      DEFAULT_MAX_RENDER_TARGET_BYTES,
+    );
+  }
+
+  if (plan.maxRenderTargetBytes != null) {
+    return positiveIntegerOrDefault(
+      plan.maxRenderTargetBytes,
+      DEFAULT_MAX_RENDER_TARGET_BYTES,
+    );
+  }
+
+  return probeRenderTargetBudgetBytes();
+}
+
+async function probeRenderTargetBudgetBytes() {
+  const limits = [DEFAULT_MAX_RENDER_TARGET_BYTES];
+  const freeRamBytes = Number(freemem());
+  if (Number.isFinite(freeRamBytes) && freeRamBytes > 0) {
+    limits.push(Math.floor(freeRamBytes * 0.5));
+  }
+
+  const freeVramBytes = await probeFreeVramBytes();
+  if (Number.isFinite(freeVramBytes) && freeVramBytes > 0) {
+    limits.push(Math.floor(freeVramBytes * 0.75));
+  }
+
+  return Math.max(MIN_RENDER_TARGET_BYTES, Math.min(...limits));
+}
+
+async function probeFreeVramBytes() {
+  const probes = [
+    probeNvidiaFreeVramBytes(),
+    probeLinuxDrmFreeVramBytes(),
+    probeRocmFreeVramBytes(),
+  ];
+  const results = await Promise.allSettled(probes);
+  const values = results
+    .filter((result) => result.status === "fulfilled")
+    .map((result) => result.value)
+    .filter((value) => Number.isFinite(value) && value > 0);
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+async function probeNvidiaFreeVramBytes() {
+  const stdout = await execFileText("nvidia-smi", [
+    "--query-gpu=memory.free",
+    "--format=csv,noheader,nounits",
+  ]);
+  const values = stdout
+    .split(/\r?\n/)
+    .map((line) => Number(line.trim()))
+    .filter((value) => Number.isFinite(value) && value > 0)
+    .map((mib) => mib * 1024 * 1024);
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+async function probeLinuxDrmFreeVramBytes() {
+  const entries = await readdir("/sys/class/drm", { withFileTypes: true });
+  const values = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && /^card\d+$/.test(entry.name))
+      .map(async (entry) => {
+        const base = `/sys/class/drm/${entry.name}/device`;
+        const [total, used] = await Promise.all([
+          readIntegerFile(`${base}/mem_info_vram_total`),
+          readIntegerFile(`${base}/mem_info_vram_used`),
+        ]);
+        if (total == null || used == null || total <= used) return null;
+        return total - used;
+      }),
+  );
+  const finiteValues = values.filter((value) => Number.isFinite(value) && value > 0);
+  return finiteValues.length > 0 ? Math.max(...finiteValues) : null;
+}
+
+async function probeRocmFreeVramBytes() {
+  const stdout = await execFileText("rocm-smi", ["--showmeminfo", "vram"]);
+  const freeValues = [];
+  const usedValues = [];
+  const totalValues = [];
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const value = Number(line.match(/(-?\d+)\s*$/)?.[1]);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    if (/free/i.test(line)) {
+      freeValues.push(value);
+    } else if (/used/i.test(line)) {
+      usedValues.push(value);
+    } else if (/total/i.test(line)) {
+      totalValues.push(value);
+    }
+  }
+
+  if (freeValues.length > 0) {
+    return Math.max(...freeValues);
+  }
+  const computed = totalValues
+    .map((total, index) => {
+      const used = usedValues[index];
+      return Number.isFinite(used) && total > used ? total - used : null;
+    })
+    .filter((value) => Number.isFinite(value) && value > 0);
+  return computed.length > 0 ? Math.max(...computed) : null;
+}
+
+async function readIntegerFile(path) {
+  try {
+    const content = await readFile(path, "utf8");
+    const value = Number(content.trim());
+    return Number.isFinite(value) ? value : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function execFileText(command, args) {
+  return new Promise((resolve, reject) => {
+    execFileCallback(
+      command,
+      args,
+      {
+        encoding: "utf8",
+        timeout: MEMORY_PROBE_TIMEOUT_MS,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+function estimateRenderTargetBytes(width, height, targetCount) {
+  return width * height * RGBA_BYTES_PER_PIXEL * Math.max(1, targetCount);
+}
+
+function getFullFrameRenderTargetCount(layerCount) {
+  return Math.max(1, Math.floor(numberOrDefault(layerCount, 1))) + 2;
+}
+
+function getStreamRenderTargetCount(layerCount) {
+  return Math.max(1, Math.floor(numberOrDefault(layerCount, 1))) + 1;
+}
+
+function assertRenderTargetBudget(estimatedBytes, maxRenderTargetBytes, width, height) {
+  if (estimatedBytes <= maxRenderTargetBytes) return;
+  throw new Error(
+    `PNG export render targets exceed the ${formatByteCount(maxRenderTargetBytes)} per-render limit at ${width} x ${height}px.`,
+  );
+}
+
+function getStreamTileHeight(
+  width,
+  height,
+  maxBandBytes,
+  maxRenderTargetBytes,
+  maxDimension = Number.POSITIVE_INFINITY,
+  layerCount = 1,
+) {
+  const rowStride = getPngRowStride(width);
+  const byBandBytes = Math.floor(maxBandBytes / rowStride);
+  const targetCount = getStreamRenderTargetCount(layerCount);
+  const byRenderTargetBytes = Math.floor(
+    maxRenderTargetBytes / (width * RGBA_BYTES_PER_PIXEL * targetCount),
+  );
+  const tileHeight = Math.min(height, maxDimension, byBandBytes, byRenderTargetBytes);
+  if (!Number.isFinite(tileHeight) || tileHeight < 1) {
+    throw new Error(
+      `PNG export tile is too large for ${width}px rows under the ${formatByteCount(maxRenderTargetBytes)} per-render limit.`,
+    );
+  }
+  return Math.max(1, Math.floor(tileHeight));
+}
+
+function getMaxRenderDimension(gl) {
+  const maxRenderbufferSize =
+    typeof gl.getParameter === "function"
+      ? Number(gl.getParameter(gl.MAX_RENDERBUFFER_SIZE))
+      : Number.POSITIVE_INFINITY;
+  return Number.isFinite(maxRenderbufferSize) && maxRenderbufferSize > 0
+    ? maxRenderbufferSize
+    : Number.POSITIVE_INFINITY;
 }
 
 function pngChunk(type, data) {
@@ -942,6 +1590,17 @@ function crc32(buffer) {
   return (c ^ 0xffffffff) >>> 0;
 }
 
+function formatByteCount(bytes) {
+  const units = ["bytes", "KiB", "MiB", "GiB"];
+  let value = Number(bytes);
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
 function positiveIntegerOrDefault(value, fallback) {
   const number = Number(value);
   if (Number.isFinite(number) && number > 0) {
@@ -950,9 +1609,27 @@ function positiveIntegerOrDefault(value, fallback) {
   return Math.max(1, Math.round(Number(fallback) || 1));
 }
 
+function positiveNumberOrDefault(value, fallback) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number > 0) {
+    return number;
+  }
+  const fallbackNumber = Number(fallback);
+  return Number.isFinite(fallbackNumber) && fallbackNumber > 0 ? fallbackNumber : 1;
+}
+
 function numberOrDefault(value, fallback) {
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
+}
+
+function normalizeExportStrategy(value) {
+  if (value == null) return "auto";
+  const strategy = String(value);
+  if (strategy === "auto" || strategy === "full-frame" || strategy === "stream") {
+    return strategy;
+  }
+  throw new TypeError("strategy must be 'auto', 'full-frame', or 'stream'.");
 }
 
 function finiteOrThrow(value, name) {

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -45,6 +45,7 @@ const REQUIRED_WEBGL2_METHODS = [
   "vertexAttribDivisor",
   "readPixels",
 ];
+const NODE_PREPARED_LAYER = Symbol("wasm-gerber-renderer.nodePreparedLayer");
 
 export async function createNodeGerberRenderer(rendererOptions = {}) {
   return NodeGerberRenderer.create(rendererOptions);
@@ -142,6 +143,16 @@ export class NodeGerberRenderer {
     return renderLayersBestEffort(this, normalizeLayerList(layers), options);
   }
 
+  async loadLayer(layer, layerOptions = {}) {
+    this.assertUsable();
+    return this.createPreparedLayer(layer, layerOptions);
+  }
+
+  async loadLayers(layers, options = {}) {
+    this.assertUsable();
+    return loadLayersBestEffort(this, normalizeLayerList(layers), options);
+  }
+
   async exportPng(exportOptions = {}) {
     this.assertUsable();
     if (!this.lastFrame || !this.lastRenderPlan) {
@@ -231,34 +242,61 @@ export class NodeGerberRenderer {
   }
 
   async createLayerRecord(layer, layerOptions) {
+    const prepared = isPreparedNodeLayer(layer)
+      ? mergePreparedLayerOptions(layer, layerOptions)
+      : await this.createPreparedLayer(layer, {
+          ...this.frame.options,
+          ...layerOptions,
+        });
+    const layerId = this.frame.layers.length;
+    const color =
+      prepared.color == null
+        ? this.frame.nextColor()
+        : normalizeColor(prepared.color, this.frame.options.colors[0]);
+
+    return {
+      layerId,
+      name: prepared.name || `Layer ${layerId}`,
+      content: null,
+      parsedLayer: prepared.parsedLayer,
+      offsetX: prepared.offsetX,
+      offsetY: prepared.offsetY,
+      bounds: prepared.bounds,
+      color,
+      alpha: prepared.alpha,
+    };
+  }
+
+  async createPreparedLayer(layer, layerOptions = {}) {
+    if (isPreparedNodeLayer(layer)) {
+      return mergePreparedLayerOptions(layer, layerOptions);
+    }
+
     const { source, options } = normalizeLayer(layer, layerOptions);
     const content = await sourceToText(source);
     const offsetX = numberOrDefault(options.offsetX, 0);
     const offsetY = numberOrDefault(options.offsetY, 0);
+    const parseOptions = normalizeParseOptions(options);
     const parsed = parseLayerPayload(
       this.wasmModule,
       content,
       offsetX,
       offsetY,
-      this.frame.options,
+      parseOptions,
     );
-    const layerId = this.frame.layers.length;
-    const color =
-      options.color == null
-        ? this.frame.nextColor()
-        : normalizeColor(options.color, this.frame.options.colors[0]);
-    const alpha = optionalAlpha(options.alpha);
+    const sourceName = getSourceName(source);
 
     return {
-      layerId,
-      name: options.name || getSourceName(source) || `Layer ${layerId}`,
-      content: null,
+      [NODE_PREPARED_LAYER]: true,
+      name: options.name || sourceName || "Layer",
+      sourceName,
       parsedLayer: parsed.payload,
+      bounds: parsed.bounds,
       offsetX,
       offsetY,
-      bounds: parsed.bounds,
-      color,
-      alpha,
+      color: options.color,
+      alpha: optionalAlpha(options.alpha),
+      parseOptions,
     };
   }
 
@@ -558,6 +596,7 @@ function normalizeFrameOptions(frameOptions) {
     );
   }
 
+  const parseOptions = normalizeParseOptions(frameOptions);
   return {
     width: positiveIntegerOrDefault(frameOptions.width, DEFAULT_WIDTH),
     height: positiveIntegerOrDefault(frameOptions.height, DEFAULT_HEIGHT),
@@ -567,11 +606,8 @@ function normalizeFrameOptions(frameOptions) {
     fit: frameOptions.fit !== false,
     padding: numberOrDefault(frameOptions.padding, 0),
     view: frameOptions.view || null,
-    preserveArcRegions: frameOptions.preserveArcRegions !== false,
-    arcTessellationQuality: numberOrDefault(
-      frameOptions.arcTessellationQuality,
-      DEFAULT_ARC_TESSELLATION_QUALITY,
-    ),
+    preserveArcRegions: parseOptions.preserveArcRegions,
+    arcTessellationQuality: parseOptions.arcTessellationQuality,
     minimumFeaturePixels: numberOrDefault(
       frameOptions.minimumFeaturePixels,
       DEFAULT_MINIMUM_FEATURE_PIXELS,
@@ -598,6 +634,16 @@ function normalizeFrameOptions(frameOptions) {
     ),
     strategy: normalizeExportStrategy(frameOptions.strategy),
     colors: DEFAULT_COLORS.map((color) => [...color]),
+  };
+}
+
+function normalizeParseOptions(options = {}) {
+  return {
+    preserveArcRegions: options.preserveArcRegions !== false,
+    arcTessellationQuality: numberOrDefault(
+      options.arcTessellationQuality,
+      DEFAULT_ARC_TESSELLATION_QUALITY,
+    ),
   };
 }
 
@@ -644,6 +690,46 @@ async function renderLayersBestEffort(renderer, layers, options = {}) {
   return { renderedCount, failures };
 }
 
+async function loadLayersBestEffort(renderer, layers, options = {}) {
+  const layerErrorMode = options.layerErrorMode || "skip";
+  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
+    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
+  }
+
+  const { layerErrorMode: _mode, onLayerError, ...layerOptions } = options;
+  const failures = [];
+  const preparedLayers = [];
+
+  for (const layer of layers) {
+    try {
+      preparedLayers.push(await renderer.loadLayer(layer, layerOptions));
+    } catch (error) {
+      const failure = {
+        layer,
+        name: getLayerFailureName(layer),
+        error,
+      };
+      failures.push(failure);
+      if (typeof onLayerError === "function") {
+        onLayerError(failure);
+      }
+      if (layerErrorMode === "throw") {
+        throw error;
+      }
+    }
+  }
+
+  if (preparedLayers.length === 0 && failures.length > 0) {
+    throw failures[0].error;
+  }
+
+  return {
+    layers: preparedLayers,
+    loadedCount: preparedLayers.length,
+    failures,
+  };
+}
+
 function normalizeLayer(layer, layerOptions = {}) {
   if (isPathLayerConfig(layer)) {
     const { path, ...inlineOptions } = layer;
@@ -686,6 +772,37 @@ function isLayerConfig(value) {
     !isBlob(value) &&
     !isArrayBufferLike(value)
   );
+}
+
+function isPreparedNodeLayer(value) {
+  return Boolean(value?.[NODE_PREPARED_LAYER]);
+}
+
+function mergePreparedLayerOptions(preparedLayer, layerOptions = {}) {
+  const offsetX = numberOrDefault(preparedLayer.offsetX, 0);
+  const offsetY = numberOrDefault(preparedLayer.offsetY, 0);
+  if (
+    ("offsetX" in layerOptions && numberOrDefault(layerOptions.offsetX, 0) !== offsetX) ||
+    ("offsetY" in layerOptions && numberOrDefault(layerOptions.offsetY, 0) !== offsetY)
+  ) {
+    throw new Error("Prepared layer offsets are fixed. Load the layer again to change offsets.");
+  }
+
+  return {
+    ...preparedLayer,
+    name:
+      "name" in layerOptions && layerOptions.name != null
+        ? String(layerOptions.name)
+        : preparedLayer.name,
+    color:
+      "color" in layerOptions
+        ? layerOptions.color
+        : preparedLayer.color,
+    alpha:
+      "alpha" in layerOptions
+        ? optionalAlpha(layerOptions.alpha)
+        : preparedLayer.alpha,
+  };
 }
 
 async function sourceToText(source) {

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -921,6 +921,8 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
     exportOptions.background == null
       ? null
       : parseColor(exportOptions.background, true);
+  const pngColorType = getPngColorType(background);
+  const pngChannels = getPngChannelCount(pngColorType);
   const maxBandBytes = positiveIntegerOrDefault(
     exportOptions.maxBandBytes,
     plan.maxBandBytes || DEFAULT_MAX_STREAM_BAND_BYTES,
@@ -1002,20 +1004,28 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
     maxRenderTargetBytes,
     maxDimension,
     layerCount,
+    pngChannels,
   );
-  const rowStride = getPngRowStride(width);
+  const rowStride = getPngRowStride(width, pngChannels);
   const header = Buffer.alloc(13);
   header.writeUInt32BE(width, 0);
   header.writeUInt32BE(height, 4);
   header[8] = 8;
-  header[9] = 6;
+  header[9] = pngColorType;
   header[10] = 0;
   header[11] = 0;
   header[12] = 0;
 
   const deflatedChunks = await deflatePngRows(async (writeRow) => {
     if (plan.layers.length === 0 || !plan.view) {
-      await writeBlankPngRows(writeRow, width, height, tileHeight, background);
+      await writeBlankPngRows(
+        writeRow,
+        width,
+        height,
+        tileHeight,
+        background,
+        pngChannels,
+      );
       return;
     }
 
@@ -1066,6 +1076,7 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
           currentTileHeight,
           rowStride,
           background,
+          pngChannels,
         );
       }
     } finally {
@@ -1228,11 +1239,18 @@ async function deflatePngRows(writeRows) {
   return chunks;
 }
 
-async function writeBlankPngRows(writeRow, width, height, tileHeight, background) {
-  const rowStride = getPngRowStride(width);
+async function writeBlankPngRows(
+  writeRow,
+  width,
+  height,
+  tileHeight,
+  background,
+  channels,
+) {
+  const rowStride = getPngRowStride(width, channels);
   const band = Buffer.alloc(rowStride * tileHeight);
   if (background) {
-    fillBandBackground(band, width, tileHeight, rowStride, background);
+    fillBandBackground(band, width, tileHeight, rowStride, background, channels);
   }
   for (let y = 0; y < height; y += tileHeight) {
     const currentTileHeight = Math.min(tileHeight, height - y);
@@ -1247,6 +1265,7 @@ async function writeTileRows(
   rowCount,
   rowStride,
   background,
+  channels,
 ) {
   const band = Buffer.allocUnsafe(rowStride * rowCount);
   const sourceRowBytes = width * 4;
@@ -1255,7 +1274,25 @@ async function writeTileRows(
     band[rowStart] = 0;
     const sourceStart = (rowCount - 1 - y) * sourceRowBytes;
     if (background) {
-      writeOpaqueBackgroundRow(band, rowStart + 1, tilePixels, sourceStart, sourceRowBytes, background);
+      if (channels === 3) {
+        writeOpaqueBackgroundRgbRow(
+          band,
+          rowStart + 1,
+          tilePixels,
+          sourceStart,
+          sourceRowBytes,
+          background,
+        );
+      } else {
+        writeOpaqueBackgroundRgbaRow(
+          band,
+          rowStart + 1,
+          tilePixels,
+          sourceStart,
+          sourceRowBytes,
+          background,
+        );
+      }
     } else {
       copyPremultipliedRowToPng(band, rowStart + 1, tilePixels, sourceStart, sourceRowBytes);
     }
@@ -1263,7 +1300,7 @@ async function writeTileRows(
   await writeRow(band);
 }
 
-function writeOpaqueBackgroundRow(
+function writeOpaqueBackgroundRgbaRow(
   output,
   outputOffset,
   source,
@@ -1308,16 +1345,47 @@ function writeOpaqueBackgroundRow(
   }
 }
 
-function fillBandBackground(band, width, height, rowStride, background) {
+function writeOpaqueBackgroundRgbRow(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+  background,
+) {
+  const bgR = background[0];
+  const bgG = background[1];
+  const bgB = background[2];
+  if (bgR === 0 && bgG === 0 && bgB === 0) {
+    for (let offset = 0, target = outputOffset; offset < byteLength; offset += 4, target += 3) {
+      output[target] = source[sourceOffset + offset];
+      output[target + 1] = source[sourceOffset + offset + 1];
+      output[target + 2] = source[sourceOffset + offset + 2];
+    }
+    return;
+  }
+
+  for (let offset = 0, target = outputOffset; offset < byteLength; offset += 4, target += 3) {
+    const srcA = source[sourceOffset + offset + 3];
+    const inverseA = 255 - srcA;
+    output[target] = source[sourceOffset + offset] + Math.round((bgR * inverseA) / 255);
+    output[target + 1] = source[sourceOffset + offset + 1] + Math.round((bgG * inverseA) / 255);
+    output[target + 2] = source[sourceOffset + offset + 2] + Math.round((bgB * inverseA) / 255);
+  }
+}
+
+function fillBandBackground(band, width, height, rowStride, background, channels) {
   for (let y = 0; y < height; y += 1) {
     const rowStart = y * rowStride;
     band[rowStart] = 0;
     for (let x = 0; x < width; x += 1) {
-      const offset = rowStart + 1 + x * 4;
+      const offset = rowStart + 1 + x * channels;
       band[offset] = background[0];
       band[offset + 1] = background[1];
       band[offset + 2] = background[2];
-      band[offset + 3] = background[3];
+      if (channels === 4) {
+        band[offset + 3] = background[3];
+      }
     }
   }
 }
@@ -1392,15 +1460,35 @@ function toByte(value) {
 }
 
 function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
+  const pngColorType = getPngColorType(background);
+  const pngChannels = getPngChannelCount(pngColorType);
   const rowBytes = width * 4;
-  const rowStride = getPngRowStride(width);
+  const rowStride = getPngRowStride(width, pngChannels);
   const raw = Buffer.allocUnsafe(rowStride * height);
   for (let y = 0; y < height; y += 1) {
     const rawOffset = y * rowStride;
     const sourceStart = (height - 1 - y) * rowBytes;
     raw[rawOffset] = 0;
     if (background) {
-      writeOpaqueBackgroundRow(raw, rawOffset + 1, rgba, sourceStart, rowBytes, background);
+      if (pngChannels === 3) {
+        writeOpaqueBackgroundRgbRow(
+          raw,
+          rawOffset + 1,
+          rgba,
+          sourceStart,
+          rowBytes,
+          background,
+        );
+      } else {
+        writeOpaqueBackgroundRgbaRow(
+          raw,
+          rawOffset + 1,
+          rgba,
+          sourceStart,
+          rowBytes,
+          background,
+        );
+      }
     } else {
       copyPremultipliedRowToPng(raw, rawOffset + 1, rgba, sourceStart, rowBytes);
     }
@@ -1410,7 +1498,7 @@ function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
   header.writeUInt32BE(width, 0);
   header.writeUInt32BE(height, 4);
   header[8] = 8;
-  header[9] = 6;
+  header[9] = pngColorType;
   header[10] = 0;
   header[11] = 0;
   header[12] = 0;
@@ -1423,8 +1511,16 @@ function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
   ]);
 }
 
-function getPngRowStride(width) {
-  return 1 + width * RGBA_BYTES_PER_PIXEL;
+function getPngColorType(background) {
+  return background && background[3] === 255 ? 2 : 6;
+}
+
+function getPngChannelCount(colorType) {
+  return colorType === 2 ? 3 : RGBA_BYTES_PER_PIXEL;
+}
+
+function getPngRowStride(width, channels = RGBA_BYTES_PER_PIXEL) {
+  return 1 + width * channels;
 }
 
 function estimateFullFrameBytes(width, height, safetyFactor) {
@@ -1598,8 +1694,9 @@ function getStreamTileHeight(
   maxRenderTargetBytes,
   maxDimension = Number.POSITIVE_INFINITY,
   layerCount = 1,
+  pngChannels = RGBA_BYTES_PER_PIXEL,
 ) {
-  const rowStride = getPngRowStride(width);
+  const rowStride = getPngRowStride(width, pngChannels);
   const byBandBytes = Math.floor(maxBandBytes / rowStride);
   const targetCount = getStreamRenderTargetCount(layerCount);
   const byRenderTargetBytes = Math.floor(

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -193,8 +193,7 @@ export class NodeGerberRenderer {
     }
 
     if (this.gl) {
-      this.staleGlContexts.push(this.gl);
-      this.gl = null;
+      this.releaseContext();
     }
     this.gl = createNodeGlesContext(
       width,
@@ -1214,7 +1213,7 @@ async function deflatePngRows(writeRows) {
 
   try {
     await writeRows(async (row) => {
-      if (!deflate.write(row)) {
+      if (!deflate.write(Buffer.from(row))) {
         await Promise.race([once(deflate, "drain"), done]);
       }
     });


### PR DESCRIPTION
## Summary
- Improve Node PNG export memory handling with full-frame rendering when safe and streamed tiles when render targets would exceed memory limits.
- Reduce repeated PNG export work by avoiding partial-tile resize, batching PNG row writes by band, and using opaque-background fast paths.
- Emit RGB PNGs for opaque backgrounds while keeping transparent and translucent outputs on RGBA.
- Add reusable parsed Node layers with `loadLayer` / `loadLayers` so repeated renders can reuse parsed Gerber geometry across frames.
- Add Node/CLI render-target memory controls, including `--max-render-target-bytes` and best-effort RAM/VRAM probing.
- Tighten streaming export cleanup so fallback contexts and partially initialized processors are released promptly.

## API Impact
- New Node APIs: `renderer.loadLayer(layer, layerOptions)` and `renderer.loadLayers(layers, options)`.
- Prepared layer parse options and offsets are fixed at load time; color, alpha, and name can still be overridden when rendering a frame.
- Opaque-background PNG exports now use PNG color type 2 (RGB); transparent or translucent exports keep color type 6 (RGBA).

## Validation
- `npm --prefix packages/wasm-gerber-renderer run check`
- `git diff --check`
- CLI smoke render with `--max-render-target-bytes 2g`
- Node streaming export smoke test
- Repeated `exportPng({ strategy: "stream" })` smoke test on a long-lived renderer
- Node RGB/RGBA export smoke test: opaque background produced `colorType=2`, transparent output produced `colorType=6`
- Prepared layer smoke test: `loadLayers` once, then repeated FHD/4K `withFrame` + `exportPng` renders