### PR TITLE
[codex] Add renderer flip options

### DIFF
--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -250,6 +250,8 @@ the first layer error.
 - `background`: output background. Defaults to `null` for transparent output. Accepts CSS color strings or `[r, g, b, a]`.
 - `fit`: fits all loaded layer bounds into the output frame. Defaults to `true`.
 - `padding`: pixel padding applied when `fit` is enabled. Defaults to `0`.
+- `flipX`: mirrors the output horizontally around the frame center. Defaults to `false`.
+- `flipY`: mirrors the output vertically around the frame center. Defaults to `false`.
 - `view`: manual `{ zoomX, zoomY, offsetX, offsetY }`; takes precedence over `fit`.
 - `preserveArcRegions`: keeps exact region arcs. Defaults to `true`; set `false` to approximate region arcs.
 - `arcTessellationQuality`: arc approximation quality, `0` low, `1` normal, `2` high. Defaults to `1`.
@@ -328,6 +330,8 @@ CLI options:
 - `--max-render-target-bytes <size>`: per-render target memory cap. Accepts bytes or suffixes like `512m` and `2g`.
 - `--approx-region-arcs`: converts region arcs to line segments before rendering.
 - `--arc-quality <0|1|2>`: approximate arc quality. Defaults to `1`.
+- `--flip-x`: mirrors the output horizontally.
+- `--flip-y`: mirrors the output vertically.
 - `--no-fit`: disables fit-to-view.
 - `--skill`: prints [package usage notes](SKILL.md) for AI agents.
 - `-h, --help`: prints CLI usage and exits.

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -64,6 +64,8 @@ Useful CLI options:
 - `--max-render-target-bytes <size>` caps per-render target memory, e.g. `512m` or `2g`.
 - `--approx-region-arcs` uses faster approximate region arcs.
 - `--arc-quality <0|1|2>` controls approximate arc quality.
+- `--flip-x` mirrors the output horizontally.
+- `--flip-y` mirrors the output vertically.
 - `--no-fit` disables automatic fit-to-view.
 - `--skill` prints package usage notes for AI agents.
 
@@ -255,6 +257,7 @@ Use `onLayerError` to report skipped layers. Use `layerErrorMode: "throw"` when 
 - `background`: `null` for transparent output or a color string/RGBA array.
 - `fit`: defaults to `true`.
 - `padding`: fit-to-view padding in pixels.
+- `flipX`, `flipY`: mirror the output around the frame center.
 - `view`: manual `{ zoomX, zoomY, offsetX, offsetY }`.
 - `globalAlpha`: opacity multiplier for all layers.
 - `minimumFeaturePixels`: minimum visible line/arc width.

--- a/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
+++ b/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
@@ -18,6 +18,8 @@ Options:
   --max-render-target-bytes <size> Per-render target memory cap, e.g. 2g, 512m
   --approx-region-arcs             Approximate region arcs before rendering (default: false)
   --arc-quality <0|1|2>            Approx arc quality: low, normal, high (default: 1)
+  --flip-x                         Mirror the output horizontally
+  --flip-y                         Mirror the output vertically
   --no-fit                         Use identity view instead of fit view (default: fit enabled)
   --skill                          Print AI usage notes
   -h, --help                       Show this help
@@ -96,6 +98,10 @@ function parseArgs(args) {
       frameOptions.preserveArcRegions = false;
     } else if (arg === "--arc-quality") {
       frameOptions.arcTessellationQuality = readNonNegativeInteger(args, ++index, arg);
+    } else if (arg === "--flip-x") {
+      frameOptions.flipX = true;
+    } else if (arg === "--flip-y") {
+      frameOptions.flipY = true;
     } else if (arg === "--no-fit") {
       frameOptions.fit = false;
     } else if (arg.startsWith("-")) {

--- a/packages/wasm-gerber-renderer/index.d.ts
+++ b/packages/wasm-gerber-renderer/index.d.ts
@@ -34,6 +34,8 @@ export type FrameOptions = {
   background?: null | string | RGBAColor;
   fit?: boolean;
   padding?: number;
+  flipX?: boolean;
+  flipY?: boolean;
   view?: {
     zoomX: number;
     zoomY: number;

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -1,20 +1,24 @@
-const DEFAULT_WASM_MODULE_URLS = [
-  new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
-  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
-];
-
-const DEFAULT_COLORS = [
-  [1.0, 0.0, 0.0],
-  [0.0, 1.0, 0.0],
-  [0.0, 0.0, 1.0],
-  [1.0, 0.0, 1.0],
-  [1.0, 1.0, 0.0],
-  [0.0, 1.0, 1.0],
-];
-const DEFAULT_BACKGROUND = null;
-const DEFAULT_GLOBAL_ALPHA = 0.7;
-const DEFAULT_MINIMUM_FEATURE_PIXELS = 1;
-const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
+import {
+  DEFAULT_BACKGROUND,
+  FrameState,
+  addLayerToProcessor,
+  applyProcessorOptions,
+  boundaryToPlainObject,
+  clamp01,
+  createBaseFrameOptions,
+  getSourceName,
+  loadWasmJsModule,
+  normalizeColor,
+  normalizeLayer,
+  normalizeLayerList,
+  numberOrDefault,
+  optionalAlpha,
+  positiveIntegerOrDefault,
+  renderLayersBestEffort,
+  resolveFrameView,
+  resolveLayerAlpha,
+  sourceToText,
+} from "./shared.js";
 
 export async function createGerberRenderer(canvas, rendererOptions = {}) {
   return GerberRenderer.create(canvas, rendererOptions);
@@ -106,7 +110,7 @@ export class GerberRenderer {
       processor.init(this.getContext());
       applyProcessorOptions(processor, normalizedFrameOptions);
 
-      this.frame = new FrameState(processor, normalizedFrameOptions);
+      this.frame = new FrameState(normalizedFrameOptions, { processor });
       await callback();
       this.renderFrame();
     } finally {
@@ -224,7 +228,12 @@ export class GerberRenderer {
       return;
     }
 
-    const view = resolveFrameView(frame, this.canvas);
+    const view = resolveFrameView(
+      frame.options,
+      frame.bounds,
+      this.canvas.width,
+      this.canvas.height,
+    );
     const activeLayerIds = new Uint32Array(frame.layers.map((layer) => layer.layerId));
     const globalAlpha = clamp01(numberOrDefault(frame.options.globalAlpha, 1));
 
@@ -330,99 +339,9 @@ export class GerberRenderer {
   }
 }
 
-class FrameState {
-  constructor(processor, options) {
-    this.processor = processor;
-    this.options = options;
-    this.layers = [];
-    this.bounds = null;
-    this.nextColorIndex = 0;
-  }
-
-  addLayer(layer) {
-    this.layers.push(layer);
-    this.bounds = mergeBounds(this.bounds, layer.bounds);
-  }
-
-  nextColor() {
-    const color = this.options.colors[
-      this.nextColorIndex % this.options.colors.length
-    ];
-    this.nextColorIndex += 1;
-    return [...color];
-  }
-
-  toResult(view) {
-    const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
-    return {
-      width: this.options.width,
-      height: this.options.height,
-      background: this.options.background,
-      bounds: this.bounds,
-      view,
-      layers: this.layers.map((layer) => ({
-        id: layer.layerId,
-        name: layer.name,
-        bounds: layer.bounds,
-        color: layer.color,
-        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
-      })),
-    };
-  }
-}
-
 async function loadWasmModule(rendererOptions) {
-  if (rendererOptions.wasmModule) {
-    return rendererOptions.wasmModule;
-  }
-
-  const wasmModuleUrls = rendererOptions.wasmModuleUrl
-    ? [rendererOptions.wasmModuleUrl]
-    : DEFAULT_WASM_MODULE_URLS;
-  const errors = [];
-
-  for (const wasmModuleUrl of wasmModuleUrls) {
-    try {
-      return await import(String(wasmModuleUrl));
-    } catch (error) {
-      errors.push({ wasmModuleUrl, error });
-    }
-  }
-
-  const attemptedUrls = wasmModuleUrls.map(String).join(", ");
-  throw new Error(
-    `Failed to load wasm-gerber renderer module from ${attemptedUrls}. ` +
-      "Run npm run build:wasm before using the package.",
-    { cause: errors[0]?.error },
-  );
-}
-
-function applyProcessorOptions(processor, frameOptions) {
-  if (typeof processor.set_preserve_arc_regions === "function") {
-    processor.set_preserve_arc_regions(frameOptions.preserveArcRegions !== false);
-  }
-  if (
-    typeof processor.set_arc_tessellation_quality === "function" &&
-    frameOptions.arcTessellationQuality != null
-  ) {
-    processor.set_arc_tessellation_quality(frameOptions.arcTessellationQuality);
-  }
-  if (
-    typeof processor.set_minimum_feature_pixels === "function" &&
-    frameOptions.minimumFeaturePixels != null
-  ) {
-    processor.set_minimum_feature_pixels(frameOptions.minimumFeaturePixels);
-  }
-}
-
-function addLayerToProcessor(processor, content, offsetX, offsetY) {
-  if (offsetX !== 0 || offsetY !== 0) {
-    if (typeof processor.add_layer_with_offset !== "function") {
-      throw new Error("Layer offsets require an updated WASM renderer.");
-    }
-    return processor.add_layer_with_offset(content, offsetX, offsetY);
-  }
-  return processor.add_layer(content);
+  const { wasmModule } = await loadWasmJsModule(rendererOptions);
+  return wasmModule;
 }
 
 function normalizeFrameOptions(frameOptions) {
@@ -430,248 +349,8 @@ function normalizeFrameOptions(frameOptions) {
     width: frameOptions.width,
     height: frameOptions.height,
     clear: frameOptions.clear !== false,
-    background:
-      "background" in frameOptions ? frameOptions.background : DEFAULT_BACKGROUND,
-    fit: frameOptions.fit !== false,
-    padding: numberOrDefault(frameOptions.padding, 0),
-    view: frameOptions.view || null,
-    preserveArcRegions: frameOptions.preserveArcRegions !== false,
-    arcTessellationQuality: numberOrDefault(
-      frameOptions.arcTessellationQuality,
-      DEFAULT_ARC_TESSELLATION_QUALITY,
-    ),
-    minimumFeaturePixels: numberOrDefault(
-      frameOptions.minimumFeaturePixels,
-      DEFAULT_MINIMUM_FEATURE_PIXELS,
-    ),
-    globalAlpha: numberOrDefault(frameOptions.globalAlpha, DEFAULT_GLOBAL_ALPHA),
-    colors: DEFAULT_COLORS.map((color) => [...color]),
+    ...createBaseFrameOptions(frameOptions),
   };
-}
-
-function normalizeLayerList(layers) {
-  if (layers == null) {
-    return [];
-  }
-  if (typeof FileList !== "undefined" && layers instanceof FileList) {
-    return Array.from(layers);
-  }
-  return Array.isArray(layers) ? layers : [layers];
-}
-
-async function renderLayersBestEffort(renderer, layers, options = {}) {
-  const layerErrorMode = options.layerErrorMode || "skip";
-  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
-    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
-  }
-
-  const failures = [];
-  let renderedCount = 0;
-
-  for (const layer of layers) {
-    try {
-      await renderer.renderLayer(layer);
-      renderedCount += 1;
-    } catch (error) {
-      const failure = {
-        layer,
-        name: getLayerFailureName(layer),
-        error,
-      };
-      failures.push(failure);
-      if (typeof options.onLayerError === "function") {
-        options.onLayerError(failure);
-      }
-      if (layerErrorMode === "throw") {
-        throw error;
-      }
-    }
-  }
-
-  if (renderedCount === 0 && failures.length > 0) {
-    throw failures[0].error;
-  }
-
-  return { renderedCount, failures };
-}
-
-function normalizeLayer(layer, layerOptions = {}) {
-  if (isLayerConfig(layer)) {
-    const { source, ...inlineOptions } = layer;
-    if (source == null) {
-      throw new TypeError("Layer config requires a source.");
-    }
-    return {
-      source,
-      options: { ...inlineOptions, ...layerOptions },
-    };
-  }
-
-  return {
-    source: layer,
-    options: { ...layerOptions },
-  };
-}
-
-function isLayerConfig(value) {
-  return (
-    value &&
-    typeof value === "object" &&
-    "source" in value &&
-    !isBlob(value) &&
-    !isArrayBufferLike(value)
-  );
-}
-
-async function sourceToText(source) {
-  if (typeof source === "string") {
-    return source;
-  }
-  if (isBlob(source)) {
-    return source.text();
-  }
-  if (source instanceof ArrayBuffer) {
-    return new TextDecoder().decode(source);
-  }
-  if (ArrayBuffer.isView(source)) {
-    return new TextDecoder().decode(
-      source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength),
-    );
-  }
-
-  throw new TypeError(
-    "Layer source must be a string, File, Blob, ArrayBuffer, or Uint8Array.",
-  );
-}
-
-function getSourceName(source) {
-  if (source && typeof source === "object" && "name" in source) {
-    return String(source.name);
-  }
-  return "";
-}
-
-function getLayerFailureName(layer) {
-  if (layer && typeof layer === "object") {
-    if ("name" in layer && layer.name) {
-      return String(layer.name);
-    }
-    if ("source" in layer) {
-      return getSourceName(layer.source);
-    }
-  }
-  return getSourceName(layer) || "Layer";
-}
-
-function isBlob(value) {
-  return typeof Blob !== "undefined" && value instanceof Blob;
-}
-
-function isArrayBufferLike(value) {
-  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
-}
-
-function resolveFrameView(frame, canvas) {
-  if (frame.options.view) {
-    return {
-      zoomX: finiteOrThrow(frame.options.view.zoomX, "view.zoomX"),
-      zoomY: finiteOrThrow(frame.options.view.zoomY, "view.zoomY"),
-      offsetX: finiteOrThrow(frame.options.view.offsetX, "view.offsetX"),
-      offsetY: finiteOrThrow(frame.options.view.offsetY, "view.offsetY"),
-    };
-  }
-
-  if (frame.options.fit === false) {
-    return { zoomX: 1, zoomY: 1, offsetX: 0, offsetY: 0 };
-  }
-
-  if (!frame.bounds) {
-    throw new Error("Cannot fit an empty Gerber frame.");
-  }
-
-  return calculateFitView(
-    frame.bounds,
-    canvas.width,
-    canvas.height,
-    frame.options.padding,
-  );
-}
-
-function calculateFitView(bounds, width, height, padding) {
-  const minX = Number(bounds.minX);
-  const maxX = Number(bounds.maxX);
-  const minY = Number(bounds.minY);
-  const maxY = Number(bounds.maxY);
-  if (![minX, maxX, minY, maxY].every(Number.isFinite)) {
-    throw new Error("Cannot fit Gerber layer because bounds are invalid.");
-  }
-
-  const boundsWidth = Math.max(0, maxX - minX);
-  const boundsHeight = Math.max(0, maxY - minY);
-  const centerX = (minX + maxX) / 2;
-  const centerY = (minY + maxY) / 2;
-  const aspect = width / height;
-  const viewWidth = aspect > 1 ? 2 * aspect : 2;
-  const viewHeight = aspect > 1 ? 2 : 2 / aspect;
-  const usableWidth = viewWidth * Math.max(1, width - padding * 2) / width;
-  const usableHeight = viewHeight * Math.max(1, height - padding * 2) / height;
-
-  let zoom = 2;
-  if (boundsWidth > 0 && boundsHeight > 0) {
-    zoom = Math.min(usableWidth / boundsWidth, usableHeight / boundsHeight);
-  } else if (boundsWidth > 0) {
-    zoom = usableWidth / boundsWidth;
-  } else if (boundsHeight > 0) {
-    zoom = usableHeight / boundsHeight;
-  }
-
-  return {
-    zoomX: zoom,
-    zoomY: zoom,
-    offsetX: -centerX * zoom,
-    offsetY: -centerY * zoom,
-  };
-}
-
-function boundaryToPlainObject(boundary) {
-  return {
-    minX: readBoundaryNumber(boundary, "min_x", "minX"),
-    maxX: readBoundaryNumber(boundary, "max_x", "maxX"),
-    minY: readBoundaryNumber(boundary, "min_y", "minY"),
-    maxY: readBoundaryNumber(boundary, "max_y", "maxY"),
-  };
-}
-
-function mergeBounds(first, second) {
-  if (!second) return first;
-  if (!first) return { ...second };
-  return {
-    minX: Math.min(first.minX, second.minX),
-    maxX: Math.max(first.maxX, second.maxX),
-    minY: Math.min(first.minY, second.minY),
-    maxY: Math.max(first.maxY, second.maxY),
-  };
-}
-
-function normalizeColor(color, fallback = DEFAULT_COLORS[0]) {
-  const input = color == null ? fallback : color;
-  if (!input || (!Array.isArray(input) && !ArrayBuffer.isView(input))) {
-    return fallback == null ? null : [...fallback];
-  }
-  if (input.length < 3) {
-    return fallback == null ? null : [...fallback];
-  }
-  const fallbackColor = fallback || DEFAULT_COLORS[0];
-  return [
-    clamp01(numberOrDefault(input[0], fallbackColor[0])),
-    clamp01(numberOrDefault(input[1], fallbackColor[1])),
-    clamp01(numberOrDefault(input[2], fallbackColor[2])),
-  ];
-}
-
-function readBoundaryNumber(boundary, snakeName, camelName) {
-  const value = boundary[snakeName] ?? boundary[camelName];
-  return Number(typeof value === "function" ? value.call(boundary) : value);
 }
 
 function normalizeCssColor(color) {
@@ -724,37 +403,4 @@ function clearCanvas(gl, canvas) {
   gl.viewport(0, 0, canvas.width, canvas.height);
   gl.clearColor(0, 0, 0, 0);
   gl.clear(gl.COLOR_BUFFER_BIT);
-}
-
-function positiveIntegerOrDefault(value, fallback) {
-  const number = Number(value);
-  if (Number.isFinite(number) && number > 0) {
-    return Math.max(1, Math.round(number));
-  }
-  return Math.max(1, Math.round(Number(fallback) || 1));
-}
-
-function numberOrDefault(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : fallback;
-}
-
-function optionalAlpha(value) {
-  return value == null ? null : clamp01(value);
-}
-
-function resolveLayerAlpha(layerAlpha, globalAlpha) {
-  return layerAlpha == null ? globalAlpha : layerAlpha;
-}
-
-function finiteOrThrow(value, name) {
-  const number = Number(value);
-  if (!Number.isFinite(number)) {
-    throw new TypeError(`${name} must be finite.`);
-  }
-  return number;
-}
-
-function clamp01(value) {
-  return Math.min(1, Math.max(0, numberOrDefault(value, 0)));
 }

--- a/packages/wasm-gerber-renderer/node.d.ts
+++ b/packages/wasm-gerber-renderer/node.d.ts
@@ -68,6 +68,8 @@ export type NodeFrameOptions = {
   background?: null | string | RGBAColor;
   fit?: boolean;
   padding?: number;
+  flipX?: boolean;
+  flipY?: boolean;
   view?: {
     zoomX: number;
     zoomY: number;

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -6,29 +6,38 @@ import { freemem } from "node:os";
 import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createDeflate, deflateSync } from "node:zlib";
+import {
+  DEFAULT_ARC_TESSELLATION_QUALITY,
+  FrameState,
+  addLayerToProcessor,
+  applyProcessorOptions,
+  boundaryToPlainObject,
+  clamp01,
+  createBaseFrameOptions,
+  getSourceName,
+  loadLayersBestEffort,
+  loadWasmJsModule,
+  mergeBounds,
+  normalizeColor,
+  normalizeLayer,
+  normalizeLayerList,
+  normalizeParseOptions,
+  numberOrDefault,
+  optionalAlpha,
+  parseColor,
+  positiveIntegerOrDefault,
+  positiveNumberOrDefault,
+  renderLayersBestEffort,
+  resolveFrameView,
+  resolveLayerAlpha,
+  sourceToText,
+  toByte,
+} from "./shared.js";
 
 const require = createRequire(import.meta.url);
 
-const DEFAULT_WASM_MODULE_URLS = [
-  new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
-  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
-];
-
-const DEFAULT_COLORS = [
-  [1.0, 0.0, 0.0],
-  [0.0, 1.0, 0.0],
-  [0.0, 0.0, 1.0],
-  [1.0, 0.0, 1.0],
-  [1.0, 1.0, 0.0],
-  [0.0, 1.0, 1.0],
-];
-
 const DEFAULT_WIDTH = 1200;
 const DEFAULT_HEIGHT = 800;
-const DEFAULT_BACKGROUND = null;
-const DEFAULT_GLOBAL_ALPHA = 0.7;
-const DEFAULT_MINIMUM_FEATURE_PIXELS = 1;
-const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
 const RGBA_BYTES_PER_PIXEL = 4;
 const DEFAULT_MAX_STREAM_BAND_BYTES = 512 * 1024 * 1024;
 const DEFAULT_MAX_FULL_FRAME_BYTES = 512 * 1024 * 1024;
@@ -114,7 +123,7 @@ export class NodeGerberRenderer {
 
     const normalizedFrameOptions = normalizeFrameOptions(frameOptions);
     try {
-      this.frame = new FrameState(normalizedFrameOptions);
+      this.frame = new NodeFrameState(normalizedFrameOptions);
       this.lastFrame = null;
       this.lastRenderPlan = null;
       await callback();
@@ -253,7 +262,9 @@ export class NodeGerberRenderer {
     const color =
       prepared.color == null
         ? this.frame.nextColor()
-        : normalizeColor(prepared.color, this.frame.options.colors[0]);
+        : normalizeColor(prepared.color, this.frame.options.colors[0], {
+            allowString: true,
+          });
 
     return {
       layerId,
@@ -273,8 +284,15 @@ export class NodeGerberRenderer {
       return mergePreparedLayerOptions(layer, layerOptions);
     }
 
-    const { source, options } = normalizeLayer(layer, layerOptions);
-    const content = await sourceToText(source);
+    const { source, options } = normalizeLayer(layer, layerOptions, {
+      allowPathConfig: true,
+    });
+    const content = await sourceToText(source, {
+      fileUrlToPath: fileURLToPath,
+      readPathText: (path) => readFile(path, "utf8"),
+      sourceDescription:
+        "a string, File, Blob, ArrayBuffer, Uint8Array, URL, or path config",
+    });
     const offsetX = numberOrDefault(options.offsetX, 0);
     const offsetY = numberOrDefault(options.offsetY, 0);
     const parseOptions = normalizeParseOptions(options);
@@ -315,7 +333,8 @@ export class NodeGerberRenderer {
     }
 
     const view = resolveFrameView(
-      frame,
+      frame.options,
+      frame.bounds,
       frame.options.width,
       frame.options.height,
     );
@@ -330,45 +349,7 @@ export class NodeGerberRenderer {
   }
 }
 
-class FrameState {
-  constructor(options) {
-    this.options = options;
-    this.layers = [];
-    this.bounds = null;
-    this.nextColorIndex = 0;
-  }
-
-  addLayer(layer) {
-    this.layers.push(layer);
-    this.bounds = mergeBounds(this.bounds, layer.bounds);
-  }
-
-  nextColor() {
-    const color = this.options.colors[
-      this.nextColorIndex % this.options.colors.length
-    ];
-    this.nextColorIndex += 1;
-    return [...color];
-  }
-
-  toResult(view) {
-    const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
-    return {
-      width: this.options.width,
-      height: this.options.height,
-      background: this.options.background,
-      bounds: this.bounds,
-      view,
-      layers: this.layers.map((layer) => ({
-        id: layer.layerId,
-        name: layer.name,
-        bounds: layer.bounds,
-        color: layer.color,
-        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
-      })),
-    };
-  }
-
+class NodeFrameState extends FrameState {
   toRenderPlan(view) {
     const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
     return {
@@ -399,37 +380,10 @@ class FrameState {
 }
 
 async function loadWasmModule(rendererOptions) {
-  if (rendererOptions.wasmModule) {
-    return {
-      wasmModule: rendererOptions.wasmModule,
-      wasmModuleUrl: rendererOptions.wasmModuleUrl
-        ? toUrl(rendererOptions.wasmModuleUrl)
-        : null,
-    };
-  }
-
-  const wasmModuleUrls = rendererOptions.wasmModuleUrl
-    ? [toUrl(rendererOptions.wasmModuleUrl)]
-    : DEFAULT_WASM_MODULE_URLS;
-  const errors = [];
-
-  for (const wasmModuleUrl of wasmModuleUrls) {
-    try {
-      return {
-        wasmModule: await import(String(wasmModuleUrl)),
-        wasmModuleUrl,
-      };
-    } catch (error) {
-      errors.push({ wasmModuleUrl, error });
-    }
-  }
-
-  const attemptedUrls = wasmModuleUrls.map(String).join(", ");
-  throw new Error(
-    `Failed to load wasm-gerber renderer module from ${attemptedUrls}. ` +
-      "Run npm run build:wasm before using the Node renderer.",
-    { cause: errors[0]?.error },
-  );
+  return loadWasmJsModule(rendererOptions, {
+    normalizeUrl: toUrl,
+    hint: "Run npm run build:wasm before using the Node renderer.",
+  });
 }
 
 async function initializeWasmModule(wasmModule, wasmModuleUrl, rendererOptions) {
@@ -540,34 +494,6 @@ function validateWebGl2Context(gl) {
   }
 }
 
-function applyProcessorOptions(processor, frameOptions) {
-  if (typeof processor.set_preserve_arc_regions === "function") {
-    processor.set_preserve_arc_regions(frameOptions.preserveArcRegions !== false);
-  }
-  if (
-    typeof processor.set_arc_tessellation_quality === "function" &&
-    frameOptions.arcTessellationQuality != null
-  ) {
-    processor.set_arc_tessellation_quality(frameOptions.arcTessellationQuality);
-  }
-  if (
-    typeof processor.set_minimum_feature_pixels === "function" &&
-    frameOptions.minimumFeaturePixels != null
-  ) {
-    processor.set_minimum_feature_pixels(frameOptions.minimumFeaturePixels);
-  }
-}
-
-function addLayerToProcessor(processor, content, offsetX, offsetY) {
-  if (offsetX !== 0 || offsetY !== 0) {
-    if (typeof processor.add_layer_with_offset !== "function") {
-      throw new Error("Layer offsets require an updated WASM renderer.");
-    }
-    return processor.add_layer_with_offset(content, offsetX, offsetY);
-  }
-  return processor.add_layer(content);
-}
-
 function parseLayerPayload(wasmModule, content, offsetX, offsetY, frameOptions) {
   const parseWithOptions = wasmModule.parse_gerber_layer_with_options;
   const parseDefault = wasmModule.parse_gerber_layer;
@@ -611,23 +537,11 @@ function normalizeFrameOptions(frameOptions) {
     );
   }
 
-  const parseOptions = normalizeParseOptions(frameOptions);
   return {
     width: positiveIntegerOrDefault(frameOptions.width, DEFAULT_WIDTH),
     height: positiveIntegerOrDefault(frameOptions.height, DEFAULT_HEIGHT),
     clear: true,
-    background:
-      "background" in frameOptions ? frameOptions.background : DEFAULT_BACKGROUND,
-    fit: frameOptions.fit !== false,
-    padding: numberOrDefault(frameOptions.padding, 0),
-    view: frameOptions.view || null,
-    preserveArcRegions: parseOptions.preserveArcRegions,
-    arcTessellationQuality: parseOptions.arcTessellationQuality,
-    minimumFeaturePixels: numberOrDefault(
-      frameOptions.minimumFeaturePixels,
-      DEFAULT_MINIMUM_FEATURE_PIXELS,
-    ),
-    globalAlpha: numberOrDefault(frameOptions.globalAlpha, DEFAULT_GLOBAL_ALPHA),
+    ...createBaseFrameOptions(frameOptions),
     maxBandBytes: positiveIntegerOrDefault(
       frameOptions.maxBandBytes,
       DEFAULT_MAX_STREAM_BAND_BYTES,
@@ -648,145 +562,7 @@ function normalizeFrameOptions(frameOptions) {
       DEFAULT_FRAMEBUFFER_MEMORY_SAFETY_FACTOR,
     ),
     strategy: normalizeExportStrategy(frameOptions.strategy),
-    colors: DEFAULT_COLORS.map((color) => [...color]),
   };
-}
-
-function normalizeParseOptions(options = {}) {
-  return {
-    preserveArcRegions: options.preserveArcRegions !== false,
-    arcTessellationQuality: numberOrDefault(
-      options.arcTessellationQuality,
-      DEFAULT_ARC_TESSELLATION_QUALITY,
-    ),
-  };
-}
-
-function normalizeLayerList(layers) {
-  if (layers == null) {
-    return [];
-  }
-  return Array.isArray(layers) ? layers : [layers];
-}
-
-async function renderLayersBestEffort(renderer, layers, options = {}) {
-  const layerErrorMode = options.layerErrorMode || "skip";
-  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
-    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
-  }
-
-  const failures = [];
-  let renderedCount = 0;
-
-  for (const layer of layers) {
-    try {
-      await renderer.renderLayer(layer);
-      renderedCount += 1;
-    } catch (error) {
-      const failure = {
-        layer,
-        name: getLayerFailureName(layer),
-        error,
-      };
-      failures.push(failure);
-      if (typeof options.onLayerError === "function") {
-        options.onLayerError(failure);
-      }
-      if (layerErrorMode === "throw") {
-        throw error;
-      }
-    }
-  }
-
-  if (renderedCount === 0 && failures.length > 0) {
-    throw failures[0].error;
-  }
-
-  return { renderedCount, failures };
-}
-
-async function loadLayersBestEffort(renderer, layers, options = {}) {
-  const layerErrorMode = options.layerErrorMode || "skip";
-  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
-    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
-  }
-
-  const { layerErrorMode: _mode, onLayerError, ...layerOptions } = options;
-  const failures = [];
-  const preparedLayers = [];
-
-  for (const layer of layers) {
-    try {
-      preparedLayers.push(await renderer.loadLayer(layer, layerOptions));
-    } catch (error) {
-      const failure = {
-        layer,
-        name: getLayerFailureName(layer),
-        error,
-      };
-      failures.push(failure);
-      if (typeof onLayerError === "function") {
-        onLayerError(failure);
-      }
-      if (layerErrorMode === "throw") {
-        throw error;
-      }
-    }
-  }
-
-  if (preparedLayers.length === 0 && failures.length > 0) {
-    throw failures[0].error;
-  }
-
-  return {
-    layers: preparedLayers,
-    loadedCount: preparedLayers.length,
-    failures,
-  };
-}
-
-function normalizeLayer(layer, layerOptions = {}) {
-  if (isPathLayerConfig(layer)) {
-    const { path, ...inlineOptions } = layer;
-    return {
-      source: { path },
-      options: { ...inlineOptions, ...layerOptions },
-    };
-  }
-  if (isLayerConfig(layer)) {
-    const { source, ...inlineOptions } = layer;
-    if (source == null) {
-      throw new TypeError("Layer config requires a source.");
-    }
-    return {
-      source,
-      options: { ...inlineOptions, ...layerOptions },
-    };
-  }
-
-  return {
-    source: layer,
-    options: { ...layerOptions },
-  };
-}
-
-function isPathLayerConfig(value) {
-  return (
-    value &&
-    typeof value === "object" &&
-    "path" in value &&
-    !("source" in value)
-  );
-}
-
-function isLayerConfig(value) {
-  return (
-    value &&
-    typeof value === "object" &&
-    "source" in value &&
-    !isBlob(value) &&
-    !isArrayBufferLike(value)
-  );
 }
 
 function isPreparedNodeLayer(value) {
@@ -818,231 +594,6 @@ function mergePreparedLayerOptions(preparedLayer, layerOptions = {}) {
         ? optionalAlpha(layerOptions.alpha)
         : preparedLayer.alpha,
   };
-}
-
-async function sourceToText(source) {
-  if (typeof source === "string") {
-    return source;
-  }
-  if (source instanceof URL) {
-    return readFile(fileURLToPath(source), "utf8");
-  }
-  if (source && typeof source === "object" && "path" in source) {
-    return readFile(String(source.path), "utf8");
-  }
-  if (isBlob(source)) {
-    return source.text();
-  }
-  if (source instanceof ArrayBuffer) {
-    return new TextDecoder().decode(source);
-  }
-  if (ArrayBuffer.isView(source)) {
-    return new TextDecoder().decode(
-      source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength),
-    );
-  }
-
-  throw new TypeError(
-    "Layer source must be a string, File, Blob, ArrayBuffer, Uint8Array, URL, or path config.",
-  );
-}
-
-function getSourceName(source) {
-  if (source && typeof source === "object" && "name" in source) {
-    return String(source.name);
-  }
-  if (source && typeof source === "object" && "path" in source) {
-    return basename(String(source.path));
-  }
-  if (source instanceof URL && source.protocol === "file:") {
-    return basename(fileURLToPath(source));
-  }
-  return "";
-}
-
-function getLayerFailureName(layer) {
-  if (layer && typeof layer === "object") {
-    if ("name" in layer && layer.name) {
-      return String(layer.name);
-    }
-    if ("path" in layer) {
-      return basename(String(layer.path));
-    }
-    if ("source" in layer) {
-      return getSourceName(layer.source);
-    }
-  }
-  return getSourceName(layer) || "Layer";
-}
-
-function isBlob(value) {
-  return typeof Blob !== "undefined" && value instanceof Blob;
-}
-
-function isArrayBufferLike(value) {
-  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
-}
-
-function resolveFrameView(frame, width, height) {
-  if (frame.options.view) {
-    return {
-      zoomX: finiteOrThrow(frame.options.view.zoomX, "view.zoomX"),
-      zoomY: finiteOrThrow(frame.options.view.zoomY, "view.zoomY"),
-      offsetX: finiteOrThrow(frame.options.view.offsetX, "view.offsetX"),
-      offsetY: finiteOrThrow(frame.options.view.offsetY, "view.offsetY"),
-    };
-  }
-
-  if (frame.options.fit === false) {
-    return { zoomX: 1, zoomY: 1, offsetX: 0, offsetY: 0 };
-  }
-
-  if (!frame.bounds) {
-    throw new Error("Cannot fit an empty Gerber frame.");
-  }
-
-  return calculateFitView(frame.bounds, width, height, frame.options.padding);
-}
-
-function calculateFitView(bounds, width, height, padding) {
-  const minX = Number(bounds.minX);
-  const maxX = Number(bounds.maxX);
-  const minY = Number(bounds.minY);
-  const maxY = Number(bounds.maxY);
-  if (![minX, maxX, minY, maxY].every(Number.isFinite)) {
-    throw new Error("Cannot fit Gerber layer because bounds are invalid.");
-  }
-
-  const boundsWidth = Math.max(0, maxX - minX);
-  const boundsHeight = Math.max(0, maxY - minY);
-  const centerX = (minX + maxX) / 2;
-  const centerY = (minY + maxY) / 2;
-  const aspect = width / height;
-  const viewWidth = aspect > 1 ? 2 * aspect : 2;
-  const viewHeight = aspect > 1 ? 2 : 2 / aspect;
-  const usableWidth = viewWidth * Math.max(1, width - padding * 2) / width;
-  const usableHeight = viewHeight * Math.max(1, height - padding * 2) / height;
-
-  let zoom = 2;
-  if (boundsWidth > 0 && boundsHeight > 0) {
-    zoom = Math.min(usableWidth / boundsWidth, usableHeight / boundsHeight);
-  } else if (boundsWidth > 0) {
-    zoom = usableWidth / boundsWidth;
-  } else if (boundsHeight > 0) {
-    zoom = usableHeight / boundsHeight;
-  }
-
-  return {
-    zoomX: zoom,
-    zoomY: zoom,
-    offsetX: -centerX * zoom,
-    offsetY: -centerY * zoom,
-  };
-}
-
-function boundaryToPlainObject(boundary) {
-  return {
-    minX: readBoundaryNumber(boundary, "min_x", "minX"),
-    maxX: readBoundaryNumber(boundary, "max_x", "maxX"),
-    minY: readBoundaryNumber(boundary, "min_y", "minY"),
-    maxY: readBoundaryNumber(boundary, "max_y", "maxY"),
-  };
-}
-
-function readBoundaryNumber(boundary, snakeName, camelName) {
-  const value = boundary[snakeName] ?? boundary[camelName];
-  return Number(typeof value === "function" ? value.call(boundary) : value);
-}
-
-function mergeBounds(first, second) {
-  if (!second) return first;
-  if (!first) return { ...second };
-  return {
-    minX: Math.min(first.minX, second.minX),
-    maxX: Math.max(first.maxX, second.maxX),
-    minY: Math.min(first.minY, second.minY),
-    maxY: Math.max(first.maxY, second.maxY),
-  };
-}
-
-function normalizeColor(color, fallback = DEFAULT_COLORS[0]) {
-  const input = color == null ? fallback : color;
-  if (typeof input === "string") {
-    return parseColor(input).slice(0, 3).map((value) => value / 255);
-  }
-  if (!input || (!Array.isArray(input) && !ArrayBuffer.isView(input))) {
-    return fallback == null ? null : [...fallback];
-  }
-  if (input.length < 3) {
-    return fallback == null ? null : [...fallback];
-  }
-  const fallbackColor = fallback || DEFAULT_COLORS[0];
-  return [
-    clamp01(numberOrDefault(input[0], fallbackColor[0])),
-    clamp01(numberOrDefault(input[1], fallbackColor[1])),
-    clamp01(numberOrDefault(input[2], fallbackColor[2])),
-  ];
-}
-
-function parseColor(color, allowAlpha = false) {
-  if (Array.isArray(color) || ArrayBuffer.isView(color)) {
-    if (color.length < 3) {
-      throw new TypeError("Color arrays must have at least three channels.");
-    }
-    return [
-      Math.round(clamp01(color[0]) * 255),
-      Math.round(clamp01(color[1]) * 255),
-      Math.round(clamp01(color[2]) * 255),
-      Math.round(clamp01(color.length >= 4 ? color[3] : 1) * 255),
-    ];
-  }
-
-  if (typeof color !== "string") {
-    throw new TypeError("Color must be a CSS hex/rgb string or RGBA array.");
-  }
-
-  const hex = color.trim().match(/^#([0-9a-f]{3,8})$/i);
-  if (hex) {
-    const value = hex[1];
-    if (value.length === 3 || value.length === 4) {
-      return [
-        parseInt(value[0] + value[0], 16),
-        parseInt(value[1] + value[1], 16),
-        parseInt(value[2] + value[2], 16),
-        value.length === 4 && allowAlpha ? parseInt(value[3] + value[3], 16) : 255,
-      ];
-    }
-    if (value.length === 6 || value.length === 8) {
-      return [
-        parseInt(value.slice(0, 2), 16),
-        parseInt(value.slice(2, 4), 16),
-        parseInt(value.slice(4, 6), 16),
-        value.length === 8 && allowAlpha ? parseInt(value.slice(6, 8), 16) : 255,
-      ];
-    }
-  }
-
-  const rgb = color
-    .trim()
-    .match(/^rgba?\(([^,]+),([^,]+),([^,]+)(?:,([^,]+))?\)$/i);
-  if (rgb) {
-    return [
-      parseCssChannel(rgb[1]),
-      parseCssChannel(rgb[2]),
-      parseCssChannel(rgb[3]),
-      rgb[4] && allowAlpha ? Math.round(clamp01(Number(rgb[4])) * 255) : 255,
-    ];
-  }
-
-  throw new TypeError(`Unsupported color format: ${color}`);
-}
-
-function parseCssChannel(value) {
-  const trimmed = value.trim();
-  if (trimmed.endsWith("%")) {
-    return Math.round(clamp01(Number(trimmed.slice(0, -1)) / 100) * 255);
-  }
-  return Math.min(255, Math.max(0, Math.round(Number(trimmed))));
 }
 
 async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
@@ -1605,10 +1156,6 @@ function compositePremultipliedRowBackground(
   }
 }
 
-function toByte(value) {
-  return Math.min(255, Math.max(0, Math.round(value)));
-}
-
 function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
   const pngColorType = getPngColorType(background);
   const pngChannels = getPngChannelCount(pngColorType);
@@ -1931,36 +1478,6 @@ function formatByteCount(bytes) {
   return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
 }
 
-function positiveIntegerOrDefault(value, fallback) {
-  const number = Number(value);
-  if (Number.isFinite(number) && number > 0) {
-    return Math.max(1, Math.round(number));
-  }
-  return Math.max(1, Math.round(Number(fallback) || 1));
-}
-
-function positiveNumberOrDefault(value, fallback) {
-  const number = Number(value);
-  if (Number.isFinite(number) && number > 0) {
-    return number;
-  }
-  const fallbackNumber = Number(fallback);
-  return Number.isFinite(fallbackNumber) && fallbackNumber > 0 ? fallbackNumber : 1;
-}
-
-function numberOrDefault(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : fallback;
-}
-
-function optionalAlpha(value) {
-  return value == null ? null : clamp01(value);
-}
-
-function resolveLayerAlpha(layerAlpha, globalAlpha) {
-  return layerAlpha == null ? globalAlpha : layerAlpha;
-}
-
 function normalizeExportStrategy(value) {
   if (value == null) return "auto";
   const strategy = String(value);
@@ -1968,18 +1485,6 @@ function normalizeExportStrategy(value) {
     return strategy;
   }
   throw new TypeError("strategy must be 'auto', 'full-frame', or 'stream'.");
-}
-
-function finiteOrThrow(value, name) {
-  const number = Number(value);
-  if (!Number.isFinite(number)) {
-    throw new TypeError(`${name} must be finite.`);
-  }
-  return number;
-}
-
-function clamp01(value) {
-  return Math.min(1, Math.max(0, numberOrDefault(value, 0)));
 }
 
 function toUrl(value) {

--- a/packages/wasm-gerber-renderer/package.json
+++ b/packages/wasm-gerber-renderer/package.json
@@ -31,6 +31,7 @@
     "index.d.ts",
     "node.js",
     "node.d.ts",
+    "shared.js",
     "README.md",
     "SKILL.md",
     "LICENSE",
@@ -43,7 +44,7 @@
     "prepack": "npm run build:wasm && npm run stage:wasm",
     "postpack": "npm run clean:wasm",
     "prepublishOnly": "npm run check",
-    "check": "node --check index.js && node --check node.js && node --check bin/wasm-gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs",
+    "check": "node --check index.js && node --check node.js && node --check shared.js && node --check bin/wasm-gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs",
     "verify:publish": "npm run check && npm pack --dry-run"
   },
   "license": "MIT",

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -1,0 +1,591 @@
+export const DEFAULT_WASM_MODULE_URLS = [
+  new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
+  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
+];
+
+export const DEFAULT_COLORS = [
+  [1.0, 0.0, 0.0],
+  [0.0, 1.0, 0.0],
+  [0.0, 0.0, 1.0],
+  [1.0, 0.0, 1.0],
+  [1.0, 1.0, 0.0],
+  [0.0, 1.0, 1.0],
+];
+
+export const DEFAULT_BACKGROUND = null;
+export const DEFAULT_GLOBAL_ALPHA = 0.7;
+export const DEFAULT_MINIMUM_FEATURE_PIXELS = 1;
+export const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
+
+export class FrameState {
+  constructor(options, extra = {}) {
+    Object.assign(this, extra);
+    this.options = options;
+    this.layers = [];
+    this.bounds = null;
+    this.nextColorIndex = 0;
+  }
+
+  addLayer(layer) {
+    this.layers.push(layer);
+    this.bounds = mergeBounds(this.bounds, layer.bounds);
+  }
+
+  nextColor() {
+    const color = this.options.colors[
+      this.nextColorIndex % this.options.colors.length
+    ];
+    this.nextColorIndex += 1;
+    return [...color];
+  }
+
+  toResult(view) {
+    const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
+    return {
+      width: this.options.width,
+      height: this.options.height,
+      background: this.options.background,
+      bounds: this.bounds,
+      view,
+      layers: this.layers.map((layer) => ({
+        id: layer.layerId,
+        name: layer.name,
+        bounds: layer.bounds,
+        color: layer.color,
+        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
+      })),
+    };
+  }
+}
+
+export function createBaseFrameOptions(frameOptions = {}) {
+  return {
+    background:
+      "background" in frameOptions ? frameOptions.background : DEFAULT_BACKGROUND,
+    fit: frameOptions.fit !== false,
+    padding: numberOrDefault(frameOptions.padding, 0),
+    view: frameOptions.view || null,
+    flipX: frameOptions.flipX === true,
+    flipY: frameOptions.flipY === true,
+    preserveArcRegions: frameOptions.preserveArcRegions !== false,
+    arcTessellationQuality: numberOrDefault(
+      frameOptions.arcTessellationQuality,
+      DEFAULT_ARC_TESSELLATION_QUALITY,
+    ),
+    minimumFeaturePixels: numberOrDefault(
+      frameOptions.minimumFeaturePixels,
+      DEFAULT_MINIMUM_FEATURE_PIXELS,
+    ),
+    globalAlpha: numberOrDefault(frameOptions.globalAlpha, DEFAULT_GLOBAL_ALPHA),
+    colors: DEFAULT_COLORS.map((color) => [...color]),
+  };
+}
+
+export async function loadWasmJsModule(rendererOptions, options = {}) {
+  const {
+    normalizeUrl = (value) => value,
+    hint = "Run npm run build:wasm before using the package.",
+  } = options;
+
+  if (rendererOptions.wasmModule) {
+    return {
+      wasmModule: rendererOptions.wasmModule,
+      wasmModuleUrl: rendererOptions.wasmModuleUrl
+        ? normalizeUrl(rendererOptions.wasmModuleUrl)
+        : null,
+    };
+  }
+
+  const wasmModuleUrls = rendererOptions.wasmModuleUrl
+    ? [normalizeUrl(rendererOptions.wasmModuleUrl)]
+    : DEFAULT_WASM_MODULE_URLS;
+  const errors = [];
+
+  for (const wasmModuleUrl of wasmModuleUrls) {
+    try {
+      return {
+        wasmModule: await import(String(wasmModuleUrl)),
+        wasmModuleUrl,
+      };
+    } catch (error) {
+      errors.push({ wasmModuleUrl, error });
+    }
+  }
+
+  const attemptedUrls = wasmModuleUrls.map(String).join(", ");
+  throw new Error(
+    `Failed to load wasm-gerber renderer module from ${attemptedUrls}. ${hint}`,
+    { cause: errors[0]?.error },
+  );
+}
+
+export function applyProcessorOptions(processor, frameOptions) {
+  if (typeof processor.set_preserve_arc_regions === "function") {
+    processor.set_preserve_arc_regions(frameOptions.preserveArcRegions !== false);
+  }
+  if (
+    typeof processor.set_arc_tessellation_quality === "function" &&
+    frameOptions.arcTessellationQuality != null
+  ) {
+    processor.set_arc_tessellation_quality(frameOptions.arcTessellationQuality);
+  }
+  if (
+    typeof processor.set_minimum_feature_pixels === "function" &&
+    frameOptions.minimumFeaturePixels != null
+  ) {
+    processor.set_minimum_feature_pixels(frameOptions.minimumFeaturePixels);
+  }
+}
+
+export function addLayerToProcessor(processor, content, offsetX, offsetY) {
+  if (offsetX !== 0 || offsetY !== 0) {
+    if (typeof processor.add_layer_with_offset !== "function") {
+      throw new Error("Layer offsets require an updated WASM renderer.");
+    }
+    return processor.add_layer_with_offset(content, offsetX, offsetY);
+  }
+  return processor.add_layer(content);
+}
+
+export function normalizeParseOptions(options = {}) {
+  return {
+    preserveArcRegions: options.preserveArcRegions !== false,
+    arcTessellationQuality: numberOrDefault(
+      options.arcTessellationQuality,
+      DEFAULT_ARC_TESSELLATION_QUALITY,
+    ),
+  };
+}
+
+export function normalizeLayerList(layers) {
+  if (layers == null) {
+    return [];
+  }
+  if (typeof FileList !== "undefined" && layers instanceof FileList) {
+    return Array.from(layers);
+  }
+  return Array.isArray(layers) ? layers : [layers];
+}
+
+export async function renderLayersBestEffort(renderer, layers, options = {}) {
+  const layerErrorMode = options.layerErrorMode || "skip";
+  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
+    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
+  }
+
+  const failures = [];
+  let renderedCount = 0;
+
+  for (const layer of layers) {
+    try {
+      await renderer.renderLayer(layer);
+      renderedCount += 1;
+    } catch (error) {
+      const failure = {
+        layer,
+        name: getLayerFailureName(layer),
+        error,
+      };
+      failures.push(failure);
+      if (typeof options.onLayerError === "function") {
+        options.onLayerError(failure);
+      }
+      if (layerErrorMode === "throw") {
+        throw error;
+      }
+    }
+  }
+
+  if (renderedCount === 0 && failures.length > 0) {
+    throw failures[0].error;
+  }
+
+  return { renderedCount, failures };
+}
+
+export async function loadLayersBestEffort(renderer, layers, options = {}) {
+  const layerErrorMode = options.layerErrorMode || "skip";
+  if (layerErrorMode !== "skip" && layerErrorMode !== "throw") {
+    throw new TypeError("layerErrorMode must be 'skip' or 'throw'.");
+  }
+
+  const { layerErrorMode: _mode, onLayerError, ...layerOptions } = options;
+  const failures = [];
+  const preparedLayers = [];
+
+  for (const layer of layers) {
+    try {
+      preparedLayers.push(await renderer.loadLayer(layer, layerOptions));
+    } catch (error) {
+      const failure = {
+        layer,
+        name: getLayerFailureName(layer),
+        error,
+      };
+      failures.push(failure);
+      if (typeof onLayerError === "function") {
+        onLayerError(failure);
+      }
+      if (layerErrorMode === "throw") {
+        throw error;
+      }
+    }
+  }
+
+  if (preparedLayers.length === 0 && failures.length > 0) {
+    throw failures[0].error;
+  }
+
+  return {
+    layers: preparedLayers,
+    loadedCount: preparedLayers.length,
+    failures,
+  };
+}
+
+export function normalizeLayer(layer, layerOptions = {}, options = {}) {
+  if (options.allowPathConfig && isPathLayerConfig(layer)) {
+    const { path, ...inlineOptions } = layer;
+    return {
+      source: { path },
+      options: { ...inlineOptions, ...layerOptions },
+    };
+  }
+  if (isLayerConfig(layer)) {
+    const { source, ...inlineOptions } = layer;
+    if (source == null) {
+      throw new TypeError("Layer config requires a source.");
+    }
+    return {
+      source,
+      options: { ...inlineOptions, ...layerOptions },
+    };
+  }
+
+  return {
+    source: layer,
+    options: { ...layerOptions },
+  };
+}
+
+export async function sourceToText(source, options = {}) {
+  const {
+    fileUrlToPath,
+    readPathText,
+    sourceDescription = "a string, File, Blob, ArrayBuffer, or Uint8Array",
+  } = options;
+
+  if (typeof source === "string") {
+    return source;
+  }
+  if (source instanceof URL && typeof readPathText === "function") {
+    return readPathText(fileUrlToPath ? fileUrlToPath(source) : source.pathname);
+  }
+  if (
+    source &&
+    typeof source === "object" &&
+    "path" in source &&
+    typeof readPathText === "function"
+  ) {
+    return readPathText(String(source.path));
+  }
+  if (isBlob(source)) {
+    return source.text();
+  }
+  if (source instanceof ArrayBuffer) {
+    return new TextDecoder().decode(source);
+  }
+  if (ArrayBuffer.isView(source)) {
+    return new TextDecoder().decode(
+      source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength),
+    );
+  }
+
+  throw new TypeError(`Layer source must be ${sourceDescription}.`);
+}
+
+export function getSourceName(source) {
+  if (source && typeof source === "object" && "name" in source) {
+    return String(source.name);
+  }
+  if (source && typeof source === "object" && "path" in source) {
+    return fileBasename(String(source.path));
+  }
+  if (source instanceof URL && source.protocol === "file:") {
+    return fileBasename(source.pathname);
+  }
+  return "";
+}
+
+export function getLayerFailureName(layer) {
+  if (layer && typeof layer === "object") {
+    if ("name" in layer && layer.name) {
+      return String(layer.name);
+    }
+    if ("path" in layer) {
+      return fileBasename(String(layer.path));
+    }
+    if ("source" in layer) {
+      return getSourceName(layer.source);
+    }
+  }
+  return getSourceName(layer) || "Layer";
+}
+
+export function resolveFrameView(frameOptions, bounds, width, height) {
+  let view;
+  if (frameOptions.view) {
+    view = {
+      zoomX: finiteOrThrow(frameOptions.view.zoomX, "view.zoomX"),
+      zoomY: finiteOrThrow(frameOptions.view.zoomY, "view.zoomY"),
+      offsetX: finiteOrThrow(frameOptions.view.offsetX, "view.offsetX"),
+      offsetY: finiteOrThrow(frameOptions.view.offsetY, "view.offsetY"),
+    };
+    return applyFrameFlip(view, frameOptions);
+  }
+
+  if (frameOptions.fit === false) {
+    view = { zoomX: 1, zoomY: 1, offsetX: 0, offsetY: 0 };
+    return applyFrameFlip(view, frameOptions);
+  }
+
+  if (!bounds) {
+    throw new Error("Cannot fit an empty Gerber frame.");
+  }
+
+  view = calculateFitView(bounds, width, height, frameOptions.padding);
+  return applyFrameFlip(view, frameOptions);
+}
+
+export function boundaryToPlainObject(boundary) {
+  return {
+    minX: readBoundaryNumber(boundary, "min_x", "minX"),
+    maxX: readBoundaryNumber(boundary, "max_x", "maxX"),
+    minY: readBoundaryNumber(boundary, "min_y", "minY"),
+    maxY: readBoundaryNumber(boundary, "max_y", "maxY"),
+  };
+}
+
+export function readBoundaryNumber(boundary, snakeName, camelName) {
+  const value = boundary[snakeName] ?? boundary[camelName];
+  return Number(typeof value === "function" ? value.call(boundary) : value);
+}
+
+export function mergeBounds(first, second) {
+  if (!second) return first;
+  if (!first) return { ...second };
+  return {
+    minX: Math.min(first.minX, second.minX),
+    maxX: Math.max(first.maxX, second.maxX),
+    minY: Math.min(first.minY, second.minY),
+    maxY: Math.max(first.maxY, second.maxY),
+  };
+}
+
+export function normalizeColor(color, fallback = DEFAULT_COLORS[0], options = {}) {
+  const input = color == null ? fallback : color;
+  if (typeof input === "string" && options.allowString) {
+    return parseColor(input).slice(0, 3).map((value) => value / 255);
+  }
+  if (!input || (!Array.isArray(input) && !ArrayBuffer.isView(input))) {
+    return fallback == null ? null : [...fallback];
+  }
+  if (input.length < 3) {
+    return fallback == null ? null : [...fallback];
+  }
+  const fallbackColor = fallback || DEFAULT_COLORS[0];
+  return [
+    clamp01(numberOrDefault(input[0], fallbackColor[0])),
+    clamp01(numberOrDefault(input[1], fallbackColor[1])),
+    clamp01(numberOrDefault(input[2], fallbackColor[2])),
+  ];
+}
+
+export function parseColor(color, allowAlpha = false) {
+  if (Array.isArray(color) || ArrayBuffer.isView(color)) {
+    if (color.length < 3) {
+      throw new TypeError("Color arrays must have at least three channels.");
+    }
+    return [
+      Math.round(clamp01(color[0]) * 255),
+      Math.round(clamp01(color[1]) * 255),
+      Math.round(clamp01(color[2]) * 255),
+      Math.round(clamp01(color.length >= 4 ? color[3] : 1) * 255),
+    ];
+  }
+
+  if (typeof color !== "string") {
+    throw new TypeError("Color must be a CSS hex/rgb string or RGBA array.");
+  }
+
+  const hex = color.trim().match(/^#([0-9a-f]{3,8})$/i);
+  if (hex) {
+    const value = hex[1];
+    if (value.length === 3 || value.length === 4) {
+      return [
+        parseInt(value[0] + value[0], 16),
+        parseInt(value[1] + value[1], 16),
+        parseInt(value[2] + value[2], 16),
+        value.length === 4 && allowAlpha ? parseInt(value[3] + value[3], 16) : 255,
+      ];
+    }
+    if (value.length === 6 || value.length === 8) {
+      return [
+        parseInt(value.slice(0, 2), 16),
+        parseInt(value.slice(2, 4), 16),
+        parseInt(value.slice(4, 6), 16),
+        value.length === 8 && allowAlpha ? parseInt(value.slice(6, 8), 16) : 255,
+      ];
+    }
+  }
+
+  const rgb = color
+    .trim()
+    .match(/^rgba?\(([^,]+),([^,]+),([^,]+)(?:,([^,]+))?\)$/i);
+  if (rgb) {
+    return [
+      parseCssChannel(rgb[1]),
+      parseCssChannel(rgb[2]),
+      parseCssChannel(rgb[3]),
+      rgb[4] && allowAlpha ? Math.round(clamp01(Number(rgb[4])) * 255) : 255,
+    ];
+  }
+
+  throw new TypeError(`Unsupported color format: ${color}`);
+}
+
+export function positiveIntegerOrDefault(value, fallback) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number > 0) {
+    return Math.max(1, Math.round(number));
+  }
+  return Math.max(1, Math.round(Number(fallback) || 1));
+}
+
+export function positiveNumberOrDefault(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+export function numberOrDefault(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+export function optionalAlpha(value) {
+  return value == null ? null : clamp01(value);
+}
+
+export function resolveLayerAlpha(layerAlpha, globalAlpha) {
+  return layerAlpha == null ? globalAlpha : layerAlpha;
+}
+
+export function clamp01(value) {
+  return Math.min(1, Math.max(0, numberOrDefault(value, 0)));
+}
+
+export function toByte(value) {
+  return Math.min(255, Math.max(0, Math.round(value)));
+}
+
+export function toUrl(value) {
+  return value instanceof URL ? value : new URL(String(value), import.meta.url);
+}
+
+function isPathLayerConfig(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    "path" in value &&
+    !("source" in value)
+  );
+}
+
+function isLayerConfig(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    "source" in value &&
+    !isBlob(value) &&
+    !isArrayBufferLike(value)
+  );
+}
+
+function isBlob(value) {
+  return typeof Blob !== "undefined" && value instanceof Blob;
+}
+
+function isArrayBufferLike(value) {
+  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+}
+
+function calculateFitView(bounds, width, height, padding) {
+  const minX = Number(bounds.minX);
+  const maxX = Number(bounds.maxX);
+  const minY = Number(bounds.minY);
+  const maxY = Number(bounds.maxY);
+  if (![minX, maxX, minY, maxY].every(Number.isFinite)) {
+    throw new Error("Cannot fit Gerber layer because bounds are invalid.");
+  }
+
+  const boundsWidth = Math.max(0, maxX - minX);
+  const boundsHeight = Math.max(0, maxY - minY);
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+  const aspect = width / height;
+  const viewWidth = aspect > 1 ? 2 * aspect : 2;
+  const viewHeight = aspect > 1 ? 2 : 2 / aspect;
+  const usableWidth = viewWidth * Math.max(1, width - padding * 2) / width;
+  const usableHeight = viewHeight * Math.max(1, height - padding * 2) / height;
+
+  let zoom = 2;
+  if (boundsWidth > 0 && boundsHeight > 0) {
+    zoom = Math.min(usableWidth / boundsWidth, usableHeight / boundsHeight);
+  } else if (boundsWidth > 0) {
+    zoom = usableWidth / boundsWidth;
+  } else if (boundsHeight > 0) {
+    zoom = usableHeight / boundsHeight;
+  }
+
+  return {
+    zoomX: zoom,
+    zoomY: zoom,
+    offsetX: -centerX * zoom,
+    offsetY: -centerY * zoom,
+  };
+}
+
+function applyFrameFlip(view, frameOptions) {
+  return {
+    zoomX: frameOptions.flipX ? -view.zoomX : view.zoomX,
+    zoomY: frameOptions.flipY ? -view.zoomY : view.zoomY,
+    offsetX: frameOptions.flipX ? -view.offsetX : view.offsetX,
+    offsetY: frameOptions.flipY ? -view.offsetY : view.offsetY,
+  };
+}
+
+function parseCssChannel(value) {
+  const trimmed = value.trim();
+  if (trimmed.endsWith("%")) {
+    return Math.round(clamp01(Number(trimmed.slice(0, -1)) / 100) * 255);
+  }
+  return Math.min(255, Math.max(0, Math.round(Number(trimmed))));
+}
+
+function finiteOrThrow(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new TypeError(`${name} must be finite.`);
+  }
+  return number;
+}
+
+function fileBasename(path) {
+  const cleanPath = String(path).replace(/\\/g, "/");
+  const name = cleanPath.slice(cleanPath.lastIndexOf("/") + 1);
+  try {
+    return decodeURIComponent(name);
+  } catch (_error) {
+    return name;
+  }
+}


### PR DESCRIPTION
## Summary
- add `flipX` / `flipY` frame options and `--flip-x` / `--flip-y` CLI flags
- mirror fitted or manual views around the output frame center
- move shared browser/Node renderer helpers into `shared.js` to reduce duplicated view, layer, color, and option handling
- update README, SKILL, and package file list/check script for the shared module

## Validation
- `npm --prefix packages/wasm-gerber-renderer run check`
- `git diff --check`
- CLI flip render smoke test
- Node API flip render smoke test
- browser/node entry import smoke test
- `npm pack --dry-run --ignore-scripts` from `packages/wasm-gerber-renderer`
