### PR TITLE
[codex] Add renderer PNG stream exports

### DIFF
--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -157,13 +157,13 @@ rendering from the filesystem.
 
 - `renderGerberToCanvas(canvas, layers, frameOptions)`: one-shot batch render into an existing WebGL2-capable canvas. `layers` may be a single `GerberLayer`, an array, or a `FileList`. Failed layers are skipped by default.
 - `renderGerberToPng(canvas, layers, frameOptions, exportOptions)`: one-shot browser render that returns a PNG `Blob`.
-- `renderGerberToPngStream(canvas, writable, layers, frameOptions, exportOptions)`: one-shot browser render that writes PNG chunks to a `WritableStream`. Requires browser `CompressionStream` support.
+- `renderGerberToPngStream(canvas, writable, layers, frameOptions, exportOptions)`: one-shot browser render that writes PNG chunks to a `WritableStream` and closes it. Requires browser `CompressionStream` support.
 - `createGerberRenderer(canvas, rendererOptions)`: creates a reusable renderer for multiple frames or layers.
 - `renderer.withFrame(frameOptions, callback)`: starts a frame, applies canvas/view options, runs the callback, and presents rendered layers after it resolves.
 - `renderer.renderLayer(layer, layerOptions)`: adds one layer to the active frame and returns its numeric layer ID. Must be called inside `withFrame()`. This strict API rejects on failure.
 - `renderer.renderLayers(layers, options)`: adds multiple layers and returns `{ renderedCount, failures }`. Failed layers are skipped by default; use `layerErrorMode: "throw"` for strict behavior.
 - `renderer.exportPng(exportOptions)`: exports the last browser frame as a PNG `Blob`.
-- `renderer.exportPngStream(writable, exportOptions)`: exports the last browser frame to a `WritableStream` without assembling a `Blob`.
+- `renderer.exportPngStream(writable, exportOptions)`: exports the last browser frame to a `WritableStream` and closes it without assembling a `Blob`.
 - `renderer.dispose()`: releases the WebGL context.
 
 ## Node.js Usage
@@ -196,7 +196,7 @@ await renderGerberToPngFile(
 
 - `createNodeGerberRenderer(rendererOptions)`: creates a reusable headless renderer backed by a native WebGL2/GLES context.
 - `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that returns PNG bytes as a `Uint8Array`.
-- `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that streams PNG bytes to `outputPath`. Parent directories must already exist.
+- `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that streams PNG bytes to a temporary file, then replaces `outputPath` after success. Parent directories must already exist.
 - `renderGerberToPngStream(writable, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that writes PNG chunks to a Node writable stream.
 - `fileLayer(path, options)`: creates a path-backed Node layer config. `options` accepts `name`, `color`, `alpha`, `offsetX`, and `offsetY`.
 - `packageRoot()`: returns the installed package directory path.
@@ -207,7 +207,7 @@ await renderGerberToPngFile(
 - `renderer.renderLayers(layers, options)`: adds multiple layers and returns `{ renderedCount, failures }`. Failed layers are skipped by default; use `layerErrorMode: "throw"` for strict behavior.
 - `renderer.exportPng(exportOptions)`: exports the last Node frame as PNG bytes in memory.
 - `renderer.exportPngStream(writable, exportOptions)`: exports the last Node frame to a writable stream.
-- `renderer.exportPngFile(outputPath, exportOptions)`: exports the last Node frame directly to a file.
+- `renderer.exportPngFile(outputPath, exportOptions)`: exports the last Node frame through a temporary file, then replaces `outputPath` after success.
 - `renderer.dispose()`: releases the GLES context.
 
 Use prepared layers when rendering the same Gerber inputs more than once:

--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -5,7 +5,7 @@ WebGL2 Gerber renderer powered by the `wasm-gerber-viewer` Rust/WASM parser and 
 The package provides:
 
 - Browser canvas rendering from Gerber source strings, `File`, `Blob`, `ArrayBuffer`, or `Uint8Array` inputs
-- Node.js PNG rendering through a headless WebGL2 context
+- Node.js PNG rendering through a headless WebGL2 context, including direct file/stream output
 - A `gerber-renderer` CLI for rendering Gerber files or `.tar.gz`/`.tgz` archives to PNG
 - Bundled `wasm-bindgen` output generated during packaging
 
@@ -157,11 +157,13 @@ rendering from the filesystem.
 
 - `renderGerberToCanvas(canvas, layers, frameOptions)`: one-shot batch render into an existing WebGL2-capable canvas. `layers` may be a single `GerberLayer`, an array, or a `FileList`. Failed layers are skipped by default.
 - `renderGerberToPng(canvas, layers, frameOptions, exportOptions)`: one-shot browser render that returns a PNG `Blob`.
+- `renderGerberToPngStream(canvas, writable, layers, frameOptions, exportOptions)`: one-shot browser render that writes PNG chunks to a `WritableStream`. Requires browser `CompressionStream` support.
 - `createGerberRenderer(canvas, rendererOptions)`: creates a reusable renderer for multiple frames or layers.
 - `renderer.withFrame(frameOptions, callback)`: starts a frame, applies canvas/view options, runs the callback, and presents rendered layers after it resolves.
 - `renderer.renderLayer(layer, layerOptions)`: adds one layer to the active frame and returns its numeric layer ID. Must be called inside `withFrame()`. This strict API rejects on failure.
 - `renderer.renderLayers(layers, options)`: adds multiple layers and returns `{ renderedCount, failures }`. Failed layers are skipped by default; use `layerErrorMode: "throw"` for strict behavior.
 - `renderer.exportPng(exportOptions)`: exports the last browser frame as a PNG `Blob`.
+- `renderer.exportPngStream(writable, exportOptions)`: exports the last browser frame to a `WritableStream` without assembling a `Blob`.
 - `renderer.dispose()`: releases the WebGL context.
 
 ## Node.js Usage
@@ -194,7 +196,8 @@ await renderGerberToPngFile(
 
 - `createNodeGerberRenderer(rendererOptions)`: creates a reusable headless renderer backed by a native WebGL2/GLES context.
 - `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that returns PNG bytes as a `Uint8Array`.
-- `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that writes PNG bytes to `outputPath`. Parent directories must already exist.
+- `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that streams PNG bytes to `outputPath`. Parent directories must already exist.
+- `renderGerberToPngStream(writable, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that writes PNG chunks to a Node writable stream.
 - `fileLayer(path, options)`: creates a path-backed Node layer config. `options` accepts `name`, `color`, `alpha`, `offsetX`, and `offsetY`.
 - `packageRoot()`: returns the installed package directory path.
 - `renderer.loadLayer(layer, layerOptions)`: parses a Node layer once and returns a prepared layer that can be reused across frames.
@@ -202,7 +205,9 @@ await renderGerberToPngFile(
 - `renderer.withFrame(frameOptions, callback)`: starts a headless render frame and stores rendered pixels after the callback resolves.
 - `renderer.renderLayer(layer, layerOptions)`: adds one layer to the active frame and returns its numeric layer ID. Must be called inside `withFrame()`. This strict API rejects on failure.
 - `renderer.renderLayers(layers, options)`: adds multiple layers and returns `{ renderedCount, failures }`. Failed layers are skipped by default; use `layerErrorMode: "throw"` for strict behavior.
-- `renderer.exportPng(exportOptions)`: exports the last Node frame as PNG bytes.
+- `renderer.exportPng(exportOptions)`: exports the last Node frame as PNG bytes in memory.
+- `renderer.exportPngStream(writable, exportOptions)`: exports the last Node frame to a writable stream.
+- `renderer.exportPngFile(outputPath, exportOptions)`: exports the last Node frame directly to a file.
 - `renderer.dispose()`: releases the GLES context.
 
 Use prepared layers when rendering the same Gerber inputs more than once:
@@ -236,9 +241,9 @@ Load the layer again to change those options. Per-frame color and alpha can be
 overridden in `renderLayer(preparedLayer, layerOptions)`.
 
 Batch APIs (`renderGerberToCanvas`, `renderGerberToPng`,
-`renderGerberToPngBuffer`, `renderGerberToPngFile`, and `renderLayers`) render
-all valid layers they can load. If every layer fails, the operation rejects with
-the first layer error.
+`renderGerberToPngStream`, `renderGerberToPngBuffer`,
+`renderGerberToPngFile`, and `renderLayers`) render all valid layers they can
+load. If every layer fails, the operation rejects with the first layer error.
 
 ## API Options
 
@@ -274,6 +279,7 @@ the first layer error.
 - `type`: browser-only export MIME type. Defaults to `image/png`; Node always writes PNG.
 - `quality`: browser-only encoder quality passed to `canvas.toBlob`.
 - `background`: export background override. Use `null` to keep transparency. Defaults to the last frame background.
+- `maxBandBytes`: approximate row-buffer budget for streamed PNG export. Node also uses it for high-resolution tiled rendering.
 
 `rendererOptions` control renderer creation:
 

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -99,6 +99,9 @@ await renderGerberToPngFile(
 );
 ```
 
+`renderGerberToPngFile()` streams PNG bytes directly to the output file. Use
+`renderGerberToPngBuffer()` only when the whole PNG must be kept in memory.
+
 For PNG bytes instead of a file:
 
 ```js
@@ -156,6 +159,10 @@ const blob = await renderGerberToPng(canvas, file, {
   padding: 32,
 });
 ```
+
+For browser file streaming, pass a `WritableStream` to `renderer.exportPngStream()`
+or `renderGerberToPngStream()`. This requires `CompressionStream` support and
+avoids building a PNG `Blob`.
 
 ## Reusable Renderer
 
@@ -244,6 +251,7 @@ Batch APIs skip failed layers by default and continue rendering valid layers:
 - `renderGerberToPng`
 - `renderGerberToPngBuffer`
 - `renderGerberToPngFile`
+- `renderGerberToPngStream`
 - `renderer.renderLayers`
 - `renderer.loadLayers`
 

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -99,8 +99,9 @@ await renderGerberToPngFile(
 );
 ```
 
-`renderGerberToPngFile()` streams PNG bytes directly to the output file. Use
-`renderGerberToPngBuffer()` only when the whole PNG must be kept in memory.
+`renderGerberToPngFile()` streams PNG bytes to a temporary file and replaces
+the output after success. Use `renderGerberToPngBuffer()` only when the whole
+PNG must be kept in memory.
 
 For PNG bytes instead of a file:
 
@@ -161,8 +162,8 @@ const blob = await renderGerberToPng(canvas, file, {
 ```
 
 For browser file streaming, pass a `WritableStream` to `renderer.exportPngStream()`
-or `renderGerberToPngStream()`. This requires `CompressionStream` support and
-avoids building a PNG `Blob`.
+or `renderGerberToPngStream()`. This requires `CompressionStream` support,
+closes the stream after `IEND`, and avoids building a PNG `Blob`.
 
 ## Reusable Renderer
 

--- a/packages/wasm-gerber-renderer/index.d.ts
+++ b/packages/wasm-gerber-renderer/index.d.ts
@@ -70,6 +70,7 @@ export type ExportOptions = {
   type?: "image/png" | string;
   quality?: number;
   background?: null | string | RGBAColor;
+  maxBandBytes?: number;
 };
 
 export type GerberCanvas = HTMLCanvasElement;
@@ -92,6 +93,14 @@ export declare function renderGerberToPng(
   exportOptions?: ExportOptions,
 ): Promise<Blob>;
 
+export declare function renderGerberToPngStream(
+  canvas: GerberCanvas,
+  writable: WritableStream<Uint8Array> | { write(chunk: Uint8Array): Promise<void> | void },
+  layers: GerberLayer | GerberLayer[] | FileList,
+  frameOptions?: FrameOptions,
+  exportOptions?: ExportOptions,
+): Promise<void>;
+
 export declare class GerberRenderer {
   withFrame(
     frameOptions: FrameOptions,
@@ -106,6 +115,11 @@ export declare class GerberRenderer {
   ): Promise<{ renderedCount: number; failures: LayerFailure[] }>;
 
   exportPng(exportOptions?: ExportOptions): Promise<Blob>;
+
+  exportPngStream(
+    writable: WritableStream<Uint8Array> | { write(chunk: Uint8Array): Promise<void> | void },
+    exportOptions?: ExportOptions,
+  ): Promise<void>;
 
   dispose(): void;
 }

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -419,7 +419,7 @@ async function streamCanvasToPng(canvas, gl, writable, background, exportOptions
 
   const width = positiveIntegerOrDefault(canvas.width, 1);
   const height = positiveIntegerOrDefault(canvas.height, 1);
-  const normalizedBackground = background == null ? null : parseColor(background, true);
+  const normalizedBackground = parseExportBackground(background);
   const pngColorType = getPngColorType(normalizedBackground);
   const pngChannels = getPngChannelCount(pngColorType);
   const rowStride = getPngRowStride(width, pngChannels);
@@ -444,6 +444,36 @@ async function streamCanvasToPng(canvas, gl, writable, background, exportOptions
   } finally {
     sink.release();
   }
+}
+
+function parseExportBackground(background) {
+  if (background == null) return null;
+  try {
+    return parseColor(background, true);
+  } catch (error) {
+    if (typeof background !== "string") {
+      throw error;
+    }
+    const resolved = resolveCssColor(background);
+    if (!resolved) {
+      throw error;
+    }
+    return parseColor(resolved, true);
+  }
+}
+
+function resolveCssColor(color) {
+  const canvas = createOutputCanvas(1, 1);
+  const context = canvas?.getContext("2d");
+  if (!context) return null;
+
+  context.fillStyle = "#010203";
+  context.fillStyle = color;
+  const first = context.fillStyle;
+  context.fillStyle = "#040506";
+  context.fillStyle = color;
+  const second = context.fillStyle;
+  return first === "#010203" && second === "#040506" ? null : first;
 }
 
 function createWebWritablePngSink(writable) {

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -1,11 +1,16 @@
 import {
   DEFAULT_BACKGROUND,
   FrameState,
+  PNG_SIGNATURE,
   addLayerToProcessor,
   applyProcessorOptions,
   boundaryToPlainObject,
   clamp01,
   createBaseFrameOptions,
+  createPngHeader,
+  getPngChannelCount,
+  getPngColorType,
+  getPngRowStride,
   getSourceName,
   loadWasmJsModule,
   normalizeColor,
@@ -13,12 +18,17 @@ import {
   normalizeLayerList,
   numberOrDefault,
   optionalAlpha,
+  parseColor,
   positiveIntegerOrDefault,
   renderLayersBestEffort,
   resolveFrameView,
   resolveLayerAlpha,
   sourceToText,
+  pngChunk,
+  writePixelRowsToPngRows,
 } from "./shared.js";
+
+const DEFAULT_STREAM_EXPORT_BAND_BYTES = 128 * 1024 * 1024;
 
 export async function createGerberRenderer(canvas, rendererOptions = {}) {
   return GerberRenderer.create(canvas, rendererOptions);
@@ -62,6 +72,34 @@ export async function renderGerberToPng(
       await renderer.renderLayers(layers, frameOptions);
     });
     return await renderer.exportPng({
+      background: frameOptions.background,
+      ...exportOptions,
+    });
+  } finally {
+    renderer.dispose();
+  }
+}
+
+export async function renderGerberToPngStream(
+  canvas,
+  writable,
+  layers,
+  frameOptions = {},
+  exportOptions = {},
+) {
+  const renderer = await createGerberRenderer(
+    canvas,
+    {
+      releaseContext: false,
+      ...(frameOptions.rendererOptions || {}),
+    },
+  );
+
+  try {
+    await renderer.withFrame(frameOptions, async () => {
+      await renderer.renderLayers(layers, frameOptions);
+    });
+    await renderer.exportPngStream(writable, {
       background: frameOptions.background,
       ...exportOptions,
     });
@@ -166,6 +204,27 @@ export class GerberRenderer {
     context.fillRect(0, 0, output.width, output.height);
     context.drawImage(this.canvas, 0, 0);
     return canvasToBlob(output, type, quality);
+  }
+
+  async exportPngStream(writable, exportOptions = {}) {
+    this.assertUsable();
+    const type = exportOptions.type || "image/png";
+    if (type !== "image/png") {
+      throw new TypeError("Streaming export only supports image/png.");
+    }
+
+    const background =
+      "background" in exportOptions
+        ? exportOptions.background
+        : (this.lastFrame?.background ?? DEFAULT_BACKGROUND);
+
+    await streamCanvasToPng(
+      this.canvas,
+      this.getContext(),
+      writable,
+      background,
+      exportOptions,
+    );
   }
 
   dispose() {
@@ -351,6 +410,159 @@ function normalizeFrameOptions(frameOptions) {
     clear: frameOptions.clear !== false,
     ...createBaseFrameOptions(frameOptions),
   };
+}
+
+async function streamCanvasToPng(canvas, gl, writable, background, exportOptions) {
+  if (typeof CompressionStream !== "function") {
+    throw new Error("Streaming PNG export requires CompressionStream support.");
+  }
+
+  const width = positiveIntegerOrDefault(canvas.width, 1);
+  const height = positiveIntegerOrDefault(canvas.height, 1);
+  const normalizedBackground = background == null ? null : parseColor(background, true);
+  const pngColorType = getPngColorType(normalizedBackground);
+  const pngChannels = getPngChannelCount(pngColorType);
+  const rowStride = getPngRowStride(width, pngChannels);
+  const sink = createWebWritablePngSink(writable);
+
+  try {
+    await sink.write(PNG_SIGNATURE);
+    await sink.write(pngChunk("IHDR", createPngHeader(width, height, pngColorType)));
+    await deflatePngRowsToWebSink(sink, async (writeRow) => {
+      await writeCanvasPixelRows(
+        writeRow,
+        gl,
+        width,
+        height,
+        rowStride,
+        normalizedBackground,
+        pngChannels,
+        exportOptions.maxBandBytes,
+      );
+    });
+    await sink.write(pngChunk("IEND", new Uint8Array(0)));
+  } finally {
+    sink.release();
+  }
+}
+
+function createWebWritablePngSink(writable) {
+  if (writable && typeof writable.getWriter === "function") {
+    const writer = writable.getWriter();
+    return {
+      write: (chunk) => writer.write(chunk),
+      release: () => writer.releaseLock(),
+    };
+  }
+  if (writable && typeof writable.write === "function") {
+    return {
+      write: (chunk) => writable.write(chunk),
+      release: () => {},
+    };
+  }
+  throw new TypeError("A WritableStream or FileSystemWritableFileStream is required.");
+}
+
+async function deflatePngRowsToWebSink(sink, writeRows) {
+  const compression = new CompressionStream("deflate");
+  const reader = compression.readable.getReader();
+  const writer = compression.writable.getWriter();
+  let pumpError = null;
+  const pump = (async () => {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await sink.write(pngChunk("IDAT", value));
+    }
+  })().catch((error) => {
+    pumpError = error;
+    throw error;
+  });
+  pump.catch(() => {});
+
+  try {
+    await writeRows(async (row) => {
+      if (pumpError) throw pumpError;
+      await writer.write(row.slice());
+      if (pumpError) throw pumpError;
+    });
+    await writer.close();
+    await pump;
+  } catch (error) {
+    try {
+      await writer.abort(error);
+    } catch (_abortError) {
+      // Preserve the original error.
+    }
+    try {
+      await reader.cancel(error);
+    } catch (_cancelError) {
+      // Preserve the original error.
+    }
+    try {
+      await pump;
+    } catch (_pumpError) {
+      // Preserve the original error.
+    }
+    throw error;
+  } finally {
+    writer.releaseLock();
+    reader.releaseLock();
+  }
+}
+
+async function writeCanvasPixelRows(
+  writeRow,
+  gl,
+  width,
+  height,
+  rowStride,
+  background,
+  pngChannels,
+  maxBandBytes,
+) {
+  const rowBytes = width * 4;
+  const rowsPerBand = getCanvasStreamBandRows(
+    width,
+    height,
+    rowStride,
+    maxBandBytes,
+  );
+  const pixels = new Uint8Array(rowBytes * rowsPerBand);
+
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  gl.finish?.();
+  for (let topY = 0; topY < height; topY += rowsPerBand) {
+    const rowCount = Math.min(rowsPerBand, height - topY);
+    const readY = height - topY - rowCount;
+    gl.readPixels(
+      0,
+      readY,
+      width,
+      rowCount,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      pixels,
+    );
+    await writePixelRowsToPngRows(
+      writeRow,
+      pixels.subarray(0, rowBytes * rowCount),
+      width,
+      rowCount,
+      rowStride,
+      background,
+      pngChannels,
+    );
+  }
+}
+
+function getCanvasStreamBandRows(width, height, rowStride, maxBandBytes) {
+  const budget = positiveIntegerOrDefault(
+    maxBandBytes,
+    DEFAULT_STREAM_EXPORT_BAND_BYTES,
+  );
+  const perRowBytes = width * 4 + rowStride;
+  return Math.max(1, Math.min(height, Math.floor(budget / perRowBytes)));
 }
 
 function normalizeCssColor(color) {

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -441,6 +441,7 @@ async function streamCanvasToPng(canvas, gl, writable, background, exportOptions
       );
     });
     await sink.write(pngChunk("IEND", new Uint8Array(0)));
+    await sink.close();
   } finally {
     sink.release();
   }
@@ -481,12 +482,14 @@ function createWebWritablePngSink(writable) {
     const writer = writable.getWriter();
     return {
       write: (chunk) => writer.write(chunk),
+      close: () => writer.close(),
       release: () => writer.releaseLock(),
     };
   }
   if (writable && typeof writable.write === "function") {
     return {
       write: (chunk) => writable.write(chunk),
+      close: () => writable.close?.(),
       release: () => {},
     };
   }

--- a/packages/wasm-gerber-renderer/node.d.ts
+++ b/packages/wasm-gerber-renderer/node.d.ts
@@ -119,6 +119,13 @@ export type NodeExportOptions = {
   strategy?: PngRenderStrategy;
 };
 
+export type NodePngWritable = {
+  write(
+    chunk: Uint8Array,
+    callback?: (error?: Error | null) => void,
+  ): boolean | void;
+};
+
 export declare function createNodeGerberRenderer(
   rendererOptions?: NodeRendererOptions,
 ): Promise<NodeGerberRenderer>;
@@ -132,6 +139,14 @@ export declare function renderGerberToPngBuffer(
 
 export declare function renderGerberToPngFile(
   outputPath: string,
+  layers: GerberNodeLayer | GerberNodeLayer[],
+  frameOptions?: NodeFrameOptions,
+  exportOptions?: NodeExportOptions,
+  rendererOptions?: NodeRendererOptions,
+): Promise<void>;
+
+export declare function renderGerberToPngStream(
+  writable: NodePngWritable,
   layers: GerberNodeLayer | GerberNodeLayer[],
   frameOptions?: NodeFrameOptions,
   exportOptions?: NodeExportOptions,
@@ -177,6 +192,13 @@ export declare class NodeGerberRenderer {
   }>;
 
   exportPng(exportOptions?: NodeExportOptions): Promise<Uint8Array>;
+
+  exportPngStream(
+    writable: NodePngWritable,
+    exportOptions?: NodeExportOptions,
+  ): Promise<void>;
+
+  exportPngFile(outputPath: string, exportOptions?: NodeExportOptions): Promise<void>;
 
   dispose(): void;
 }

--- a/packages/wasm-gerber-renderer/node.d.ts
+++ b/packages/wasm-gerber-renderer/node.d.ts
@@ -123,7 +123,7 @@ export type NodePngWritable = {
   write(
     chunk: Uint8Array,
     callback?: (error?: Error | null) => void,
-  ): boolean | void;
+  ): boolean | void | Promise<void>;
 };
 
 export declare function createNodeGerberRenderer(

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -1,7 +1,7 @@
 import { once } from "node:events";
 import { execFile as execFileCallback } from "node:child_process";
 import { createWriteStream } from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, rename, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { freemem } from "node:os";
 import { basename, dirname, resolve } from "node:path";
@@ -222,12 +222,14 @@ export class NodeGerberRenderer {
 
   async exportPngFile(outputPath, exportOptions = {}) {
     this.assertRenderedFrameAvailable();
-    const stream = createWriteStream(outputPath);
+    const tempPath = createTempOutputPath(outputPath);
+    const stream = createWriteStream(tempPath, { flags: "wx" });
     const done = finished(stream);
     try {
       await this.exportPngStream(stream, exportOptions);
       stream.end();
       await done;
+      await rename(tempPath, outputPath);
     } catch (error) {
       stream.destroy(error);
       try {
@@ -235,6 +237,7 @@ export class NodeGerberRenderer {
       } catch (_streamError) {
         // Preserve the original rendering error.
       }
+      await rm(tempPath, { force: true });
       throw error;
     }
   }
@@ -1137,6 +1140,10 @@ async function writeFullFramePixelRows(
 
 function writeNodeWritable(writable, chunk) {
   const buffer = Buffer.from(chunk);
+  if (!isNodeWritableStream(writable)) {
+    return Promise.resolve(writable.write(buffer));
+  }
+
   return new Promise((resolve, reject) => {
     const onError = (error) => {
       cleanup();
@@ -1164,6 +1171,16 @@ function writeNodeWritable(writable, chunk) {
       reject(error);
     }
   });
+}
+
+function isNodeWritableStream(writable) {
+  return typeof writable.once === "function";
+}
+
+function createTempOutputPath(outputPath) {
+  const resolvedPath = resolve(outputPath);
+  const suffix = `${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`;
+  return resolve(dirname(resolvedPath), `.${basename(resolvedPath)}.${suffix}.tmp`);
 }
 
 function estimateFullFrameBytes(width, height, safetyFactor) {

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -193,10 +193,7 @@ export class NodeGerberRenderer {
   }
 
   async exportPng(exportOptions = {}) {
-    this.assertUsable();
-    if (!this.lastFrame || !this.lastRenderPlan) {
-      throw new Error("No rendered frame is available for export.");
-    }
+    this.assertRenderedFrameAvailable();
 
     const background =
       "background" in exportOptions
@@ -210,10 +207,7 @@ export class NodeGerberRenderer {
   }
 
   async exportPngStream(writable, exportOptions = {}) {
-    this.assertUsable();
-    if (!this.lastFrame || !this.lastRenderPlan) {
-      throw new Error("No rendered frame is available for export.");
-    }
+    this.assertRenderedFrameAvailable();
 
     const background =
       "background" in exportOptions
@@ -227,6 +221,7 @@ export class NodeGerberRenderer {
   }
 
   async exportPngFile(outputPath, exportOptions = {}) {
+    this.assertRenderedFrameAvailable();
     const stream = createWriteStream(outputPath);
     const done = finished(stream);
     try {
@@ -409,6 +404,13 @@ export class NodeGerberRenderer {
   assertUsable() {
     if (this.disposed) {
       throw new Error("NodeGerberRenderer has been disposed.");
+    }
+  }
+
+  assertRenderedFrameAvailable() {
+    this.assertUsable();
+    if (!this.lastFrame || !this.lastRenderPlan) {
+      throw new Error("No rendered frame is available for export.");
     }
   }
 }
@@ -1043,38 +1045,67 @@ async function writePngDocument(sink, width, height, colorType, writeRows) {
 
 async function deflatePngRowsToSink(sink, writeRows) {
   const deflate = createDeflate();
-  let writeChain = Promise.resolve();
   let writeError = null;
+  let pendingWrites = 0;
+  let resolvePendingWrites = null;
+  let rejectWriteError = null;
+  const writeErrorSignal = new Promise((_, reject) => {
+    rejectWriteError = reject;
+  });
+  writeErrorSignal.catch(() => {});
   const done = new Promise((resolve, reject) => {
     deflate.once("end", resolve);
     deflate.once("error", reject);
   });
   deflate.on("data", (chunk) => {
     const idat = pngChunk("IDAT", Buffer.from(chunk));
-    writeChain = writeChain
-      .then(() => sink.write(idat))
+    deflate.pause();
+    pendingWrites += 1;
+    Promise.resolve(sink.write(idat))
       .catch((error) => {
         writeError = error;
-        throw error;
+        rejectWriteError(error);
+        deflate.destroy(error);
+      })
+      .finally(() => {
+        pendingWrites -= 1;
+        if (pendingWrites === 0 && resolvePendingWrites) {
+          resolvePendingWrites();
+          resolvePendingWrites = null;
+        }
+        if (!writeError) {
+          deflate.resume();
+        }
       });
-    writeChain.catch(() => {});
   });
 
   try {
     await writeRows(async (row) => {
       if (writeError) throw writeError;
       if (!deflate.write(Buffer.from(row))) {
-        await Promise.race([once(deflate, "drain"), done]);
+        await Promise.race([once(deflate, "drain"), done, writeErrorSignal]);
       }
       if (writeError) throw writeError;
     });
     deflate.end();
-    await done;
-    await writeChain;
+    await Promise.race([done, writeErrorSignal]);
+    await waitForPendingPngWrites(() => pendingWrites, (resolve) => {
+      resolvePendingWrites = resolve;
+    });
+    if (writeError) throw writeError;
   } catch (error) {
     deflate.destroy();
-    throw error;
+    throw writeError || error;
   }
+}
+
+function waitForPendingPngWrites(getPendingWrites, setResolvePendingWrites) {
+  if (getPendingWrites() === 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    setResolvePendingWrites(resolve);
+  });
 }
 
 async function writeFullFramePixelRows(

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -1,19 +1,26 @@
 import { once } from "node:events";
 import { execFile as execFileCallback } from "node:child_process";
-import { readdir, readFile, writeFile } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { freemem } from "node:os";
 import { basename, dirname, resolve } from "node:path";
+import { finished } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createDeflate, deflateSync } from "node:zlib";
+import { createDeflate } from "node:zlib";
 import {
   DEFAULT_ARC_TESSELLATION_QUALITY,
   FrameState,
+  PNG_SIGNATURE,
   addLayerToProcessor,
   applyProcessorOptions,
   boundaryToPlainObject,
   clamp01,
   createBaseFrameOptions,
+  createPngHeader,
+  getPngChannelCount,
+  getPngColorType,
+  getPngRowStride,
   getSourceName,
   loadLayersBestEffort,
   loadWasmJsModule,
@@ -31,7 +38,9 @@ import {
   resolveFrameView,
   resolveLayerAlpha,
   sourceToText,
-  toByte,
+  pngChunk,
+  writeBlankPngRows,
+  writePixelRowsToPngRows,
 } from "./shared.js";
 
 const require = createRequire(import.meta.url);
@@ -85,13 +94,33 @@ export async function renderGerberToPngFile(
   exportOptions = {},
   rendererOptions = {},
 ) {
-  const png = await renderGerberToPngBuffer(
-    layers,
-    frameOptions,
-    exportOptions,
-    rendererOptions,
-  );
-  await writeFile(outputPath, png);
+  const renderer = await createNodeGerberRenderer(rendererOptions);
+  try {
+    await renderer.withFrame(frameOptions, async () => {
+      await renderer.renderLayers(layers, frameOptions);
+    });
+    await renderer.exportPngFile(outputPath, exportOptions);
+  } finally {
+    renderer.dispose();
+  }
+}
+
+export async function renderGerberToPngStream(
+  writable,
+  layers,
+  frameOptions = {},
+  exportOptions = {},
+  rendererOptions = {},
+) {
+  const renderer = await createNodeGerberRenderer(rendererOptions);
+  try {
+    await renderer.withFrame(frameOptions, async () => {
+      await renderer.renderLayers(layers, frameOptions);
+    });
+    await renderer.exportPngStream(writable, exportOptions);
+  } finally {
+    renderer.dispose();
+  }
 }
 
 export class NodeGerberRenderer {
@@ -178,6 +207,41 @@ export class NodeGerberRenderer {
       ...exportOptions,
       background,
     });
+  }
+
+  async exportPngStream(writable, exportOptions = {}) {
+    this.assertUsable();
+    if (!this.lastFrame || !this.lastRenderPlan) {
+      throw new Error("No rendered frame is available for export.");
+    }
+
+    const background =
+      "background" in exportOptions
+        ? exportOptions.background
+        : this.lastFrame.background;
+
+    await renderPlanToPngWritable(this, this.lastRenderPlan, {
+      ...exportOptions,
+      background,
+    }, writable);
+  }
+
+  async exportPngFile(outputPath, exportOptions = {}) {
+    const stream = createWriteStream(outputPath);
+    const done = finished(stream);
+    try {
+      await this.exportPngStream(stream, exportOptions);
+      stream.end();
+      await done;
+    } catch (error) {
+      stream.destroy(error);
+      try {
+        await done;
+      } catch (_streamError) {
+        // Preserve the original rendering error.
+      }
+      throw error;
+    }
   }
 
   dispose() {
@@ -597,6 +661,24 @@ function mergePreparedLayerOptions(preparedLayer, layerOptions = {}) {
 }
 
 async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
+  const sink = new BufferPngSink();
+  await renderPlanToPngSink(renderer, plan, exportOptions, sink);
+  return sink.toBuffer();
+}
+
+async function renderPlanToPngWritable(renderer, plan, exportOptions, writable) {
+  if (!writable || typeof writable.write !== "function") {
+    throw new TypeError("A Node writable stream is required.");
+  }
+  await renderPlanToPngSink(
+    renderer,
+    plan,
+    exportOptions,
+    new NodeWritablePngSink(writable),
+  );
+}
+
+async function renderPlanToPngSink(renderer, plan, exportOptions, sink) {
   const width = positiveIntegerOrDefault(plan.width, DEFAULT_WIDTH);
   const height = positiveIntegerOrDefault(plan.height, DEFAULT_HEIGHT);
   const strategy = normalizeExportStrategy(exportOptions.strategy || plan.strategy);
@@ -633,15 +715,6 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
     height,
     getFullFrameRenderTargetCount(layerCount),
   );
-  const rowStride = getPngRowStride(width, pngChannels);
-  const header = Buffer.alloc(13);
-  header.writeUInt32BE(width, 0);
-  header.writeUInt32BE(height, 4);
-  header[8] = 8;
-  header[9] = pngColorType;
-  header[10] = 0;
-  header[11] = 0;
-  header[12] = 0;
 
   if (plan.layers.length === 0 || !plan.view) {
     const blankTileHeight = getBlankStreamTileHeight(
@@ -650,7 +723,7 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
       maxBandBytes,
       pngChannels,
     );
-    const deflatedChunks = await deflatePngRows(async (writeRow) => {
+    await writePngDocument(sink, width, height, pngColorType, async (writeRow) => {
       await writeBlankPngRows(
         writeRow,
         width,
@@ -660,12 +733,7 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
         pngChannels,
       );
     });
-    return Buffer.concat([
-      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-      pngChunk("IHDR", header),
-      ...deflatedChunks.map((chunk) => pngChunk("IDAT", chunk)),
-      pngChunk("IEND", Buffer.alloc(0)),
-    ]);
+    return;
   }
 
   const shouldTryFullFrame =
@@ -681,14 +749,22 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
       height,
     );
     try {
-      return renderPlanToFullFramePngBuffer(
+      await renderPlanToFullFramePngSink(
         renderer,
         plan,
+        sink,
         width,
         height,
         background,
+        pngColorType,
+        pngChannels,
+        maxBandBytes,
       );
+      return;
     } catch (error) {
+      if (error instanceof PngSinkWriteError) {
+        throw error.cause || error;
+      }
       if (strategy === "full-frame") {
         throw error;
       }
@@ -722,8 +798,9 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
   const renderGl = renderer.rendererOptions.gl
     ? gl
     : renderer.createExportContext(width, tileHeight);
+  const rowStride = getPngRowStride(width, pngChannels);
 
-  const deflatedChunks = await deflatePngRows(async (writeRow) => {
+  await writePngDocument(sink, width, height, pngColorType, async (writeRow) => {
     const renderContext = createProcessorForPlan(
       renderer,
       plan,
@@ -764,7 +841,7 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
           renderGl.UNSIGNED_BYTE,
           tilePixels,
         );
-        await writeTileRows(
+        await writePixelRowsToPngRows(
           writeRow,
           tilePixels,
           width,
@@ -778,21 +855,18 @@ async function renderPlanToPngBuffer(renderer, plan, exportOptions) {
       disposeProcessor(renderContext.processor);
     }
   });
-
-  return Buffer.concat([
-    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-    pngChunk("IHDR", header),
-    ...deflatedChunks.map((chunk) => pngChunk("IDAT", chunk)),
-    pngChunk("IEND", Buffer.alloc(0)),
-  ]);
 }
 
-function renderPlanToFullFramePngBuffer(
+async function renderPlanToFullFramePngSink(
   renderer,
   plan,
+  sink,
   width,
   height,
   background,
+  pngColorType,
+  pngChannels,
+  maxBandBytes,
 ) {
   const gl = renderer.createExportContext(width, height);
   const maxDimension = getMaxRenderDimension(gl);
@@ -816,7 +890,17 @@ function renderPlanToFullFramePngBuffer(
           1,
           true,
         );
-    return bottomUpRgbaToPngBuffer(Buffer.from(pixels), width, height, background);
+    await writePngDocument(sink, width, height, pngColorType, async (writeRow) => {
+      await writeFullFramePixelRows(
+        writeRow,
+        pixels,
+        width,
+        height,
+        background,
+        pngChannels,
+        maxBandBytes,
+      );
+    });
   } finally {
     disposeProcessor(renderContext.processor);
   }
@@ -914,310 +998,141 @@ function disposeProcessor(processor) {
   }
 }
 
-async function deflatePngRows(writeRows) {
+class BufferPngSink {
+  constructor() {
+    this.chunks = [];
+  }
+
+  async write(chunk) {
+    this.chunks.push(Buffer.from(chunk));
+  }
+
+  toBuffer() {
+    return Buffer.concat(this.chunks);
+  }
+}
+
+class NodeWritablePngSink {
+  constructor(writable) {
+    this.writable = writable;
+  }
+
+  async write(chunk) {
+    try {
+      await writeNodeWritable(this.writable, chunk);
+    } catch (error) {
+      throw new PngSinkWriteError(error);
+    }
+  }
+}
+
+class PngSinkWriteError extends Error {
+  constructor(cause) {
+    super(`PNG stream write failed: ${cause?.message || cause}`);
+    this.name = "PngSinkWriteError";
+    this.cause = cause;
+  }
+}
+
+async function writePngDocument(sink, width, height, colorType, writeRows) {
+  await sink.write(PNG_SIGNATURE);
+  await sink.write(pngChunk("IHDR", createPngHeader(width, height, colorType)));
+  await deflatePngRowsToSink(sink, writeRows);
+  await sink.write(pngChunk("IEND", new Uint8Array(0)));
+}
+
+async function deflatePngRowsToSink(sink, writeRows) {
   const deflate = createDeflate();
-  const chunks = [];
+  let writeChain = Promise.resolve();
+  let writeError = null;
   const done = new Promise((resolve, reject) => {
     deflate.once("end", resolve);
     deflate.once("error", reject);
   });
   deflate.on("data", (chunk) => {
-    chunks.push(Buffer.from(chunk));
+    const idat = pngChunk("IDAT", Buffer.from(chunk));
+    writeChain = writeChain
+      .then(() => sink.write(idat))
+      .catch((error) => {
+        writeError = error;
+        throw error;
+      });
+    writeChain.catch(() => {});
   });
 
   try {
     await writeRows(async (row) => {
+      if (writeError) throw writeError;
       if (!deflate.write(Buffer.from(row))) {
         await Promise.race([once(deflate, "drain"), done]);
       }
+      if (writeError) throw writeError;
     });
     deflate.end();
     await done;
+    await writeChain;
   } catch (error) {
     deflate.destroy();
     throw error;
   }
-  return chunks;
 }
 
-async function writeBlankPngRows(
+async function writeFullFramePixelRows(
   writeRow,
+  pixels,
   width,
   height,
-  tileHeight,
   background,
   channels,
+  maxBandBytes,
 ) {
   const rowStride = getPngRowStride(width, channels);
-  const band = Buffer.alloc(rowStride * tileHeight);
-  if (background) {
-    fillBandBackground(band, width, tileHeight, rowStride, background, channels);
-  }
-  for (let y = 0; y < height; y += tileHeight) {
-    const currentTileHeight = Math.min(tileHeight, height - y);
-    await writeRow(band.subarray(0, currentTileHeight * rowStride));
-  }
-}
-
-async function writeTileRows(
-  writeRow,
-  tilePixels,
-  width,
-  rowCount,
-  rowStride,
-  background,
-  channels,
-) {
-  const band = Buffer.allocUnsafe(rowStride * rowCount);
-  const sourceRowBytes = width * 4;
-  for (let y = 0; y < rowCount; y += 1) {
-    const rowStart = y * rowStride;
-    band[rowStart] = 0;
-    const sourceStart = (rowCount - 1 - y) * sourceRowBytes;
-    if (background) {
-      if (channels === 3) {
-        writeOpaqueBackgroundRgbRow(
-          band,
-          rowStart + 1,
-          tilePixels,
-          sourceStart,
-          sourceRowBytes,
-          background,
-        );
-      } else {
-        writeOpaqueBackgroundRgbaRow(
-          band,
-          rowStart + 1,
-          tilePixels,
-          sourceStart,
-          sourceRowBytes,
-          background,
-        );
-      }
-    } else {
-      copyPremultipliedRowToPng(band, rowStart + 1, tilePixels, sourceStart, sourceRowBytes);
-    }
-  }
-  await writeRow(band);
-}
-
-function writeOpaqueBackgroundRgbaRow(
-  output,
-  outputOffset,
-  source,
-  sourceOffset,
-  byteLength,
-  background,
-) {
-  if (background[3] !== 255) {
-    compositePremultipliedRowBackground(
-      output,
-      outputOffset,
-      source,
-      sourceOffset,
-      byteLength,
+  const rowsPerBand = getBlankStreamTileHeight(width, height, maxBandBytes, channels);
+  const sourceRowBytes = width * RGBA_BYTES_PER_PIXEL;
+  for (let topY = 0; topY < height; topY += rowsPerBand) {
+    const rowCount = Math.min(rowsPerBand, height - topY);
+    const sourceStart = (height - topY - rowCount) * sourceRowBytes;
+    await writePixelRowsToPngRows(
+      writeRow,
+      pixels.subarray(sourceStart, sourceStart + rowCount * sourceRowBytes),
+      width,
+      rowCount,
+      rowStride,
       background,
+      channels,
     );
-    return;
-  }
-
-  const bgR = background[0];
-  const bgG = background[1];
-  const bgB = background[2];
-  if (bgR === 0 && bgG === 0 && bgB === 0) {
-    for (let offset = 0; offset < byteLength; offset += 4) {
-      const target = outputOffset + offset;
-      output[target] = source[sourceOffset + offset];
-      output[target + 1] = source[sourceOffset + offset + 1];
-      output[target + 2] = source[sourceOffset + offset + 2];
-      output[target + 3] = 255;
-    }
-    return;
-  }
-
-  for (let offset = 0; offset < byteLength; offset += 4) {
-    const srcA = source[sourceOffset + offset + 3];
-    const inverseA = 255 - srcA;
-    const target = outputOffset + offset;
-    output[target] = source[sourceOffset + offset] + Math.round((bgR * inverseA) / 255);
-    output[target + 1] = source[sourceOffset + offset + 1] + Math.round((bgG * inverseA) / 255);
-    output[target + 2] = source[sourceOffset + offset + 2] + Math.round((bgB * inverseA) / 255);
-    output[target + 3] = 255;
   }
 }
 
-function writeOpaqueBackgroundRgbRow(
-  output,
-  outputOffset,
-  source,
-  sourceOffset,
-  byteLength,
-  background,
-) {
-  const bgR = background[0];
-  const bgG = background[1];
-  const bgB = background[2];
-  if (bgR === 0 && bgG === 0 && bgB === 0) {
-    for (let offset = 0, target = outputOffset; offset < byteLength; offset += 4, target += 3) {
-      output[target] = source[sourceOffset + offset];
-      output[target + 1] = source[sourceOffset + offset + 1];
-      output[target + 2] = source[sourceOffset + offset + 2];
-    }
-    return;
-  }
-
-  for (let offset = 0, target = outputOffset; offset < byteLength; offset += 4, target += 3) {
-    const srcA = source[sourceOffset + offset + 3];
-    const inverseA = 255 - srcA;
-    output[target] = source[sourceOffset + offset] + Math.round((bgR * inverseA) / 255);
-    output[target + 1] = source[sourceOffset + offset + 1] + Math.round((bgG * inverseA) / 255);
-    output[target + 2] = source[sourceOffset + offset + 2] + Math.round((bgB * inverseA) / 255);
-  }
-}
-
-function fillBandBackground(band, width, height, rowStride, background, channels) {
-  for (let y = 0; y < height; y += 1) {
-    const rowStart = y * rowStride;
-    band[rowStart] = 0;
-    for (let x = 0; x < width; x += 1) {
-      const offset = rowStart + 1 + x * channels;
-      band[offset] = background[0];
-      band[offset + 1] = background[1];
-      band[offset + 2] = background[2];
-      if (channels === 4) {
-        band[offset + 3] = background[3];
+function writeNodeWritable(writable, chunk) {
+  const buffer = Buffer.from(chunk);
+  return new Promise((resolve, reject) => {
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      if (typeof writable.off === "function") {
+        writable.off("error", onError);
       }
+    };
+    if (typeof writable.once === "function") {
+      writable.once("error", onError);
     }
-  }
-}
-
-function copyPremultipliedRowToPng(
-  output,
-  outputOffset,
-  source,
-  sourceOffset,
-  byteLength,
-) {
-  for (let offset = 0; offset < byteLength; offset += 4) {
-    const srcA = source[sourceOffset + offset + 3];
-    const target = outputOffset + offset;
-    output[target + 3] = srcA;
-    if (srcA === 0) {
-      output[target] = 0;
-      output[target + 1] = 0;
-      output[target + 2] = 0;
-    } else if (srcA === 255) {
-      output[target] = source[sourceOffset + offset];
-      output[target + 1] = source[sourceOffset + offset + 1];
-      output[target + 2] = source[sourceOffset + offset + 2];
-    } else {
-      const scale = 255 / srcA;
-      output[target] = toByte(source[sourceOffset + offset] * scale);
-      output[target + 1] = toByte(source[sourceOffset + offset + 1] * scale);
-      output[target + 2] = toByte(source[sourceOffset + offset + 2] * scale);
+    try {
+      writable.write(buffer, (error) => {
+        cleanup();
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    } catch (error) {
+      cleanup();
+      reject(error);
     }
-  }
-}
-
-function compositePremultipliedRowBackground(
-  output,
-  outputOffset,
-  source,
-  sourceOffset,
-  byteLength,
-  background,
-) {
-  const bgA = background[3] / 255;
-  for (let offset = 0; offset < byteLength; offset += 4) {
-    const srcR = source[sourceOffset + offset] / 255;
-    const srcG = source[sourceOffset + offset + 1] / 255;
-    const srcB = source[sourceOffset + offset + 2] / 255;
-    const srcAByte = source[sourceOffset + offset + 3];
-    const srcA = srcAByte / 255;
-    const outA = srcA + bgA * (1 - srcA);
-    const target = outputOffset + offset;
-    if (outA <= 0) {
-      output[target] = 0;
-      output[target + 1] = 0;
-      output[target + 2] = 0;
-      output[target + 3] = 0;
-      continue;
-    }
-    output[target] = toByte(
-      ((srcR + (background[0] / 255) * bgA * (1 - srcA)) / outA) * 255,
-    );
-    output[target + 1] = toByte(
-      ((srcG + (background[1] / 255) * bgA * (1 - srcA)) / outA) * 255,
-    );
-    output[target + 2] = toByte(
-      ((srcB + (background[2] / 255) * bgA * (1 - srcA)) / outA) * 255,
-    );
-    output[target + 3] = toByte(outA * 255);
-  }
-}
-
-function bottomUpRgbaToPngBuffer(rgba, width, height, background) {
-  const pngColorType = getPngColorType(background);
-  const pngChannels = getPngChannelCount(pngColorType);
-  const rowBytes = width * 4;
-  const rowStride = getPngRowStride(width, pngChannels);
-  const raw = Buffer.allocUnsafe(rowStride * height);
-  for (let y = 0; y < height; y += 1) {
-    const rawOffset = y * rowStride;
-    const sourceStart = (height - 1 - y) * rowBytes;
-    raw[rawOffset] = 0;
-    if (background) {
-      if (pngChannels === 3) {
-        writeOpaqueBackgroundRgbRow(
-          raw,
-          rawOffset + 1,
-          rgba,
-          sourceStart,
-          rowBytes,
-          background,
-        );
-      } else {
-        writeOpaqueBackgroundRgbaRow(
-          raw,
-          rawOffset + 1,
-          rgba,
-          sourceStart,
-          rowBytes,
-          background,
-        );
-      }
-    } else {
-      copyPremultipliedRowToPng(raw, rawOffset + 1, rgba, sourceStart, rowBytes);
-    }
-  }
-
-  const header = Buffer.alloc(13);
-  header.writeUInt32BE(width, 0);
-  header.writeUInt32BE(height, 4);
-  header[8] = 8;
-  header[9] = pngColorType;
-  header[10] = 0;
-  header[11] = 0;
-  header[12] = 0;
-
-  return Buffer.concat([
-    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-    pngChunk("IHDR", header),
-    pngChunk("IDAT", deflateSync(raw)),
-    pngChunk("IEND", Buffer.alloc(0)),
-  ]);
-}
-
-function getPngColorType(background) {
-  return background && background[3] === 255 ? 2 : 6;
-}
-
-function getPngChannelCount(colorType) {
-  return colorType === 2 ? 3 : RGBA_BYTES_PER_PIXEL;
-}
-
-function getPngRowStride(width, channels = RGBA_BYTES_PER_PIXEL) {
-  return 1 + width * channels;
+  });
 }
 
 function estimateFullFrameBytes(width, height, safetyFactor) {
@@ -1434,37 +1349,6 @@ function getGlNumericParameter(gl, parameter) {
   return Number.isFinite(value) && value > 0
     ? value
     : Number.POSITIVE_INFINITY;
-}
-
-function pngChunk(type, data) {
-  const typeBuffer = Buffer.from(type, "ascii");
-  const chunk = Buffer.allocUnsafe(12 + data.length);
-  chunk.writeUInt32BE(data.length, 0);
-  typeBuffer.copy(chunk, 4);
-  data.copy(chunk, 8);
-  chunk.writeUInt32BE(crc32(Buffer.concat([typeBuffer, data])), 8 + data.length);
-  return chunk;
-}
-
-let crcTable = null;
-
-function crc32(buffer) {
-  if (!crcTable) {
-    crcTable = new Uint32Array(256);
-    for (let n = 0; n < 256; n += 1) {
-      let c = n;
-      for (let k = 0; k < 8; k += 1) {
-        c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-      }
-      crcTable[n] = c >>> 0;
-    }
-  }
-
-  let c = 0xffffffff;
-  for (const byte of buffer) {
-    c = crcTable[(c ^ byte) & 0xff] ^ (c >>> 8);
-  }
-  return (c ^ 0xffffffff) >>> 0;
 }
 
 function formatByteCount(bytes) {

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -488,6 +488,299 @@ export function toByte(value) {
   return Math.min(255, Math.max(0, Math.round(value)));
 }
 
+export const PNG_SIGNATURE = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+export function createPngHeader(width, height, colorType) {
+  const header = new Uint8Array(13);
+  writeUint32(header, 0, width);
+  writeUint32(header, 4, height);
+  header[8] = 8;
+  header[9] = colorType;
+  header[10] = 0;
+  header[11] = 0;
+  header[12] = 0;
+  return header;
+}
+
+export function pngChunk(type, data) {
+  const typeBuffer = asciiBytes(type);
+  const payload = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const chunk = new Uint8Array(12 + payload.length);
+  writeUint32(chunk, 0, payload.length);
+  chunk.set(typeBuffer, 4);
+  chunk.set(payload, 8);
+  writeUint32(chunk, 8 + payload.length, crc32Bytes(typeBuffer, payload));
+  return chunk;
+}
+
+export function getPngColorType(background) {
+  return background && background[3] === 255 ? 2 : 6;
+}
+
+export function getPngChannelCount(colorType) {
+  return colorType === 2 ? 3 : 4;
+}
+
+export function getPngRowStride(width, channels = 4) {
+  return 1 + width * channels;
+}
+
+export async function writeBlankPngRows(
+  writeRow,
+  width,
+  height,
+  tileHeight,
+  background,
+  channels,
+) {
+  const rowStride = getPngRowStride(width, channels);
+  const band = new Uint8Array(rowStride * tileHeight);
+  if (background) {
+    fillBandBackground(band, width, tileHeight, rowStride, background, channels);
+  }
+  for (let y = 0; y < height; y += tileHeight) {
+    const currentTileHeight = Math.min(tileHeight, height - y);
+    await writeRow(band.subarray(0, currentTileHeight * rowStride));
+  }
+}
+
+export async function writePixelRowsToPngRows(
+  writeRow,
+  pixels,
+  width,
+  rowCount,
+  rowStride,
+  background,
+  channels,
+) {
+  const band = new Uint8Array(rowStride * rowCount);
+  const sourceRowBytes = width * 4;
+  for (let y = 0; y < rowCount; y += 1) {
+    const rowStart = y * rowStride;
+    band[rowStart] = 0;
+    const sourceStart = (rowCount - 1 - y) * sourceRowBytes;
+    if (background) {
+      if (channels === 3) {
+        writeOpaqueBackgroundRgbRow(
+          band,
+          rowStart + 1,
+          pixels,
+          sourceStart,
+          sourceRowBytes,
+          background,
+        );
+      } else {
+        writeOpaqueBackgroundRgbaRow(
+          band,
+          rowStart + 1,
+          pixels,
+          sourceStart,
+          sourceRowBytes,
+          background,
+        );
+      }
+    } else {
+      copyPremultipliedRowToPng(band, rowStart + 1, pixels, sourceStart, sourceRowBytes);
+    }
+  }
+  await writeRow(band);
+}
+
+export function fillBandBackground(band, width, height, rowStride, background, channels) {
+  for (let y = 0; y < height; y += 1) {
+    const rowStart = y * rowStride;
+    band[rowStart] = 0;
+    for (let x = 0; x < width; x += 1) {
+      const offset = rowStart + 1 + x * channels;
+      band[offset] = background[0];
+      band[offset + 1] = background[1];
+      band[offset + 2] = background[2];
+      if (channels === 4) {
+        band[offset + 3] = background[3];
+      }
+    }
+  }
+}
+
+export function writeOpaqueBackgroundRgbaRow(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+  background,
+) {
+  if (background[3] !== 255) {
+    compositePremultipliedRowBackground(
+      output,
+      outputOffset,
+      source,
+      sourceOffset,
+      byteLength,
+      background,
+    );
+    return;
+  }
+
+  const bgR = background[0];
+  const bgG = background[1];
+  const bgB = background[2];
+  if (bgR === 0 && bgG === 0 && bgB === 0) {
+    for (let offset = 0; offset < byteLength; offset += 4) {
+      const target = outputOffset + offset;
+      output[target] = source[sourceOffset + offset];
+      output[target + 1] = source[sourceOffset + offset + 1];
+      output[target + 2] = source[sourceOffset + offset + 2];
+      output[target + 3] = 255;
+    }
+    return;
+  }
+
+  for (let offset = 0; offset < byteLength; offset += 4) {
+    const srcA = source[sourceOffset + offset + 3];
+    const inverseA = 255 - srcA;
+    const target = outputOffset + offset;
+    output[target] = source[sourceOffset + offset] + Math.round((bgR * inverseA) / 255);
+    output[target + 1] = source[sourceOffset + offset + 1] + Math.round((bgG * inverseA) / 255);
+    output[target + 2] = source[sourceOffset + offset + 2] + Math.round((bgB * inverseA) / 255);
+    output[target + 3] = 255;
+  }
+}
+
+export function writeOpaqueBackgroundRgbRow(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+  background,
+) {
+  const bgR = background[0];
+  const bgG = background[1];
+  const bgB = background[2];
+  if (bgR === 0 && bgG === 0 && bgB === 0) {
+    for (let offset = 0, target = outputOffset; offset < byteLength; offset += 4, target += 3) {
+      output[target] = source[sourceOffset + offset];
+      output[target + 1] = source[sourceOffset + offset + 1];
+      output[target + 2] = source[sourceOffset + offset + 2];
+    }
+    return;
+  }
+
+  for (let offset = 0, target = outputOffset; offset < byteLength; offset += 4, target += 3) {
+    const srcA = source[sourceOffset + offset + 3];
+    const inverseA = 255 - srcA;
+    output[target] = source[sourceOffset + offset] + Math.round((bgR * inverseA) / 255);
+    output[target + 1] = source[sourceOffset + offset + 1] + Math.round((bgG * inverseA) / 255);
+    output[target + 2] = source[sourceOffset + offset + 2] + Math.round((bgB * inverseA) / 255);
+  }
+}
+
+export function copyPremultipliedRowToPng(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+) {
+  for (let offset = 0; offset < byteLength; offset += 4) {
+    const srcA = source[sourceOffset + offset + 3];
+    const target = outputOffset + offset;
+    output[target + 3] = srcA;
+    if (srcA === 0) {
+      output[target] = 0;
+      output[target + 1] = 0;
+      output[target + 2] = 0;
+    } else if (srcA === 255) {
+      output[target] = source[sourceOffset + offset];
+      output[target + 1] = source[sourceOffset + offset + 1];
+      output[target + 2] = source[sourceOffset + offset + 2];
+    } else {
+      const scale = 255 / srcA;
+      output[target] = toByte(source[sourceOffset + offset] * scale);
+      output[target + 1] = toByte(source[sourceOffset + offset + 1] * scale);
+      output[target + 2] = toByte(source[sourceOffset + offset + 2] * scale);
+    }
+  }
+}
+
+export function compositePremultipliedRowBackground(
+  output,
+  outputOffset,
+  source,
+  sourceOffset,
+  byteLength,
+  background,
+) {
+  const bgA = background[3] / 255;
+  for (let offset = 0; offset < byteLength; offset += 4) {
+    const srcR = source[sourceOffset + offset] / 255;
+    const srcG = source[sourceOffset + offset + 1] / 255;
+    const srcB = source[sourceOffset + offset + 2] / 255;
+    const srcAByte = source[sourceOffset + offset + 3];
+    const srcA = srcAByte / 255;
+    const outA = srcA + bgA * (1 - srcA);
+    const target = outputOffset + offset;
+    if (outA <= 0) {
+      output[target] = 0;
+      output[target + 1] = 0;
+      output[target + 2] = 0;
+      output[target + 3] = 0;
+      continue;
+    }
+    output[target] = toByte(
+      ((srcR + (background[0] / 255) * bgA * (1 - srcA)) / outA) * 255,
+    );
+    output[target + 1] = toByte(
+      ((srcG + (background[1] / 255) * bgA * (1 - srcA)) / outA) * 255,
+    );
+    output[target + 2] = toByte(
+      ((srcB + (background[2] / 255) * bgA * (1 - srcA)) / outA) * 255,
+    );
+    output[target + 3] = toByte(outA * 255);
+  }
+}
+
+function writeUint32(output, offset, value) {
+  output[offset] = (value >>> 24) & 0xff;
+  output[offset + 1] = (value >>> 16) & 0xff;
+  output[offset + 2] = (value >>> 8) & 0xff;
+  output[offset + 3] = value & 0xff;
+}
+
+function asciiBytes(value) {
+  const bytes = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index += 1) {
+    bytes[index] = value.charCodeAt(index) & 0x7f;
+  }
+  return bytes;
+}
+
+let crcTable = null;
+
+function crc32Bytes(first, second) {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let n = 0; n < 256; n += 1) {
+      let c = n;
+      for (let k = 0; k < 8; k += 1) {
+        c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      }
+      crcTable[n] = c >>> 0;
+    }
+  }
+
+  let c = 0xffffffff;
+  for (const bytes of [first, second]) {
+    for (const byte of bytes) {
+      c = crcTable[(c ^ byte) & 0xff] ^ (c >>> 8);
+    }
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
 export function toUrl(value) {
   return value instanceof URL ? value : new URL(String(value), import.meta.url);
 }


### PR DESCRIPTION
## Summary
- add PNG stream export APIs for browser and Node renderer entrypoints
- make Node file export stream PNG chunks directly to disk instead of materializing a full PNG buffer first
- move shared PNG chunk/row conversion helpers into the package shared module
- document stream APIs and memory-oriented export behavior

## Validation
- `npm --prefix packages/wasm-gerber-renderer run check`
- `git diff --check`
- Node render smoke test: `renderGerberToPngBuffer`, `renderGerberToPngFile`, and `renderGerberToPngStream` produced identical PNG bytes for `demo/font-test.gbr`
- CLI smoke test rendered `demo/performance-test-stars-1K.gbr` to PNG
