### PR TITLE
Add prebuilt WASM release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,24 @@ jobs:
           echo "path=${artifact_dir}/${tarball}" >> "$GITHUB_OUTPUT"
           echo "name=${tarball}" >> "$GITHUB_OUTPUT"
 
+      - name: Pack prebuilt WASM artifact
+        id: wasm-artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifact_dir="${RUNNER_TEMP}/wasm-package"
+          artifact_name="wasm-pkg-${{ steps.release.outputs.tag }}.tar.gz"
+          artifact_path="${artifact_dir}/${artifact_name}"
+          mkdir -p "$artifact_dir"
+
+          test -f wasm/pkg/wasm_gerber_processor.js
+          test -f wasm/pkg/wasm_gerber_processor_bg.wasm
+          tar -czf "$artifact_path" -C wasm/pkg .
+
+          echo "path=${artifact_path}" >> "$GITHUB_OUTPUT"
+          echo "name=${artifact_name}" >> "$GITHUB_OUTPUT"
+
       - name: Publish to npmjs
         if: steps.release.outputs.npmjs_exists != 'true'
         working-directory: ${{ env.PACKAGE_DIR }}
@@ -212,10 +230,11 @@ jobs:
 
           tag="${{ steps.release.outputs.tag }}"
           title="${{ steps.release.outputs.package_name }} ${{ steps.release.outputs.version }}"
-          artifact="${{ steps.package-artifact.outputs.path }}"
+          package_artifact="${{ steps.package-artifact.outputs.path }}"
+          wasm_artifact="${{ steps.wasm-artifact.outputs.path }}"
 
           if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" "$artifact" --clobber
+            gh release upload "$tag" "$package_artifact" "$wasm_artifact" --clobber
           else
-            gh release create "$tag" "$artifact" --title "$title" --generate-notes
+            gh release create "$tag" "$package_artifact" "$wasm_artifact" --title "$title" --generate-notes
           fi

--- a/README.md
+++ b/README.md
@@ -26,26 +26,51 @@ Website:
 - Ruler measurements with mm/inch unit switching
 - Screenshot export with resolution options, including ruler overlays
 
-## Requirements
+## Quick Start
+
+This uses the prebuilt WASM package from the latest GitHub Release. It only
+requires `bash`, `curl`, `sed`, `tar`, and a static file server such as Python 3.
+
+```bash
+set -euo pipefail
+
+git clone https://github.com/dsafdsaf132/wasm-gerber-viewer.git
+cd wasm-gerber-viewer
+
+version="$(
+  curl -fsSL https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases/latest |
+  sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+)"
+test -n "$version"
+
+mkdir -p wasm/pkg
+curl -fsSL \
+  "https://github.com/dsafdsaf132/wasm-gerber-viewer/releases/download/${version}/wasm-pkg-${version}.tar.gz" |
+  tar -xz -C wasm/pkg
+
+python3 -m http.server 8000
+```
+
+Open `http://localhost:8000` and upload Gerber files.
+
+## Building
+
+Use this when you need to rebuild the WASM package locally instead of using the
+prebuilt release artifact.
+
+Requirements:
 
 - **Rust stable** - install with [rustup](https://rustup.rs/)
 - **wasm-pack** - `cargo install wasm-pack`
 - **Python 3** or another static file server
 - **Modern WebGL2 browser** - Chrome, Firefox, Safari, or Edge
 
-## Quick Start
-
 ```bash
-git clone https://github.com/dsafdsaf132/wasm-gerber-viewer.git
-cd wasm-gerber-viewer
-
 rustup target add wasm32-unknown-unknown
 wasm-pack build wasm --target web --out-dir pkg --release
 
 python3 -m http.server 8000
 ```
-
-Open `http://localhost:8000` and upload Gerber files.
 
 ## npm Package
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Website:
 
 ## Quick Start
 
+<details>
+<summary>Bash</summary>
+
 ```bash
 set -euo pipefail
 
@@ -54,6 +57,38 @@ python3 -m http.server 8000
 ```
 
 Open `http://localhost:8000` and upload Gerber files.
+
+</details>
+
+<details>
+<summary>PowerShell</summary>
+
+```powershell
+git clone https://github.com/dsafdsaf132/wasm-gerber-viewer.git
+Set-Location wasm-gerber-viewer
+
+$release = Invoke-RestMethod `
+  -Uri "https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases"
+$asset = $release |
+  ForEach-Object { $_.assets } |
+  Where-Object { $_.name -match '^wasm-pkg-v.*\.tar\.gz$' } |
+  Select-Object -First 1
+if (-not $asset) { throw "No prebuilt WASM release asset found." }
+
+$version = $asset.browser_download_url -replace '^.*/download/([^/]+)/.*$', '$1'
+git checkout $version
+
+New-Item -ItemType Directory -Force wasm/pkg | Out-Null
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile wasm-pkg.tar.gz
+tar -xzf wasm-pkg.tar.gz -C wasm/pkg
+Remove-Item wasm-pkg.tar.gz
+
+py -3 -m http.server 8000
+```
+
+Open `http://localhost:8000` and upload Gerber files.
+
+</details>
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,21 @@ set -euo pipefail
 git clone https://github.com/dsafdsaf132/wasm-gerber-viewer.git
 cd wasm-gerber-viewer
 
-version="$(
-  curl -fsSL https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases/latest |
-  sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+wasm_url="$(
+  curl -fsSL https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases |
+  sed -n '/"browser_download_url": .*\/wasm-pkg-v.*\.tar\.gz"/ {
+    s/.*"browser_download_url": *"\([^"]*\)".*/\1/p
+    q
+  }'
 )"
+test -n "$wasm_url"
+
+version="$(printf '%s\n' "$wasm_url" | sed -n 's#.*/download/\([^/]*\)/.*#\1#p')"
 test -n "$version"
+git checkout "$version"
 
 mkdir -p wasm/pkg
-curl -fsSL \
-  "https://github.com/dsafdsaf132/wasm-gerber-viewer/releases/download/${version}/wasm-pkg-${version}.tar.gz" |
-  tar -xz -C wasm/pkg
+curl -fsSL "$wasm_url" | tar -xz -C wasm/pkg
 
 python3 -m http.server 8000
 ```

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ Website:
 
 ## Quick Start
 
-This uses the prebuilt WASM package from the latest GitHub Release. It only
-requires `bash`, `curl`, `sed`, `tar`, and a static file server such as Python 3.
-
 ```bash
 set -euo pipefail
 
@@ -62,14 +59,10 @@ Requirements:
 
 - **Rust stable** - install with [rustup](https://rustup.rs/)
 - **wasm-pack** - `cargo install wasm-pack`
-- **Python 3** or another static file server
-- **Modern WebGL2 browser** - Chrome, Firefox, Safari, or Edge
 
 ```bash
 rustup target add wasm32-unknown-unknown
 wasm-pack build wasm --target web --out-dir pkg --release
-
-python3 -m http.server 8000
 ```
 
 ## npm Package


### PR DESCRIPTION
## Summary
- add a versioned prebuilt WASM archive to the release workflow
- update Quick Start to download the latest versioned WASM asset with bash, curl, sed, and tar
- move Rust/wasm-pack requirements into a Building section

## Validation
- npm run check --prefix packages/wasm-gerber-renderer
- git diff --check