### PR TITLE
[codex] Add prebuilt viewer release bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,28 @@ jobs:
           echo "path=${artifact_path}" >> "$GITHUB_OUTPUT"
           echo "name=${artifact_name}" >> "$GITHUB_OUTPUT"
 
+      - name: Pack prebuilt viewer artifact
+        id: viewer-artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifact_dir="${RUNNER_TEMP}/viewer-package"
+          artifact_name="wasm-gerber-viewer-${{ steps.release.outputs.tag }}.tar.gz"
+          package_root="${artifact_dir}/wasm-gerber-viewer-${{ steps.release.outputs.tag }}"
+          artifact_path="${artifact_dir}/${artifact_name}"
+          mkdir -p "${package_root}/wasm"
+
+          test -f wasm/pkg/wasm_gerber_processor.js
+          test -f wasm/pkg/wasm_gerber_processor_bg.wasm
+          cp index.html LICENSE "${package_root}/"
+          cp -R css js vendor "${package_root}/"
+          cp -R wasm/pkg "${package_root}/wasm/pkg"
+          tar -czf "$artifact_path" -C "$artifact_dir" "wasm-gerber-viewer-${{ steps.release.outputs.tag }}"
+
+          echo "path=${artifact_path}" >> "$GITHUB_OUTPUT"
+          echo "name=${artifact_name}" >> "$GITHUB_OUTPUT"
+
       - name: Publish to npmjs
         if: steps.release.outputs.npmjs_exists != 'true'
         working-directory: ${{ env.PACKAGE_DIR }}
@@ -232,9 +254,10 @@ jobs:
           title="${{ steps.release.outputs.package_name }} ${{ steps.release.outputs.version }}"
           package_artifact="${{ steps.package-artifact.outputs.path }}"
           wasm_artifact="${{ steps.wasm-artifact.outputs.path }}"
+          viewer_artifact="${{ steps.viewer-artifact.outputs.path }}"
 
           if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" "$package_artifact" "$wasm_artifact" --clobber
+            gh release upload "$tag" "$package_artifact" "$wasm_artifact" "$viewer_artifact" --clobber
           else
-            gh release create "$tag" "$package_artifact" "$wasm_artifact" --title "$title" --generate-notes
+            gh release create "$tag" "$package_artifact" "$wasm_artifact" "$viewer_artifact" --title "$title" --generate-notes
           fi

--- a/README.md
+++ b/README.md
@@ -34,25 +34,18 @@ Website:
 ```bash
 set -euo pipefail
 
-git clone https://github.com/dsafdsaf132/wasm-gerber-viewer.git
-cd wasm-gerber-viewer
-
-release_json="$(curl -fsSL https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases)"
-wasm_url="$(
+release_json="$(curl -fsSL https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases/latest)"
+viewer_url="$(
   printf '%s\n' "$release_json" |
-  sed -n '/"browser_download_url": .*\/wasm-pkg-v.*\.tar\.gz"/ {
+  sed -n '/"browser_download_url": .*\/wasm-gerber-viewer-.*\.tar\.gz"/ {
     s/.*"browser_download_url": *"\([^"]*\)".*/\1/p
     q
   }'
 )"
-test -n "$wasm_url"
+test -n "$viewer_url"
 
-version="$(printf '%s\n' "$wasm_url" | sed -n 's#.*/download/\([^/]*\)/.*#\1#p')"
-test -n "$version"
-git checkout "$version"
-
-mkdir -p wasm/pkg
-curl -fsSL "$wasm_url" | tar -xz -C wasm/pkg
+curl -fsSL "$viewer_url" | tar -xz
+cd wasm-gerber-viewer-*
 
 python3 -m http.server 8000
 ```
@@ -65,24 +58,17 @@ Open `http://localhost:8000` and upload Gerber files.
 <summary>PowerShell</summary>
 
 ```powershell
-git clone https://github.com/dsafdsaf132/wasm-gerber-viewer.git
-Set-Location wasm-gerber-viewer
-
 $release = Invoke-RestMethod `
-  -Uri "https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases"
-$asset = $release |
-  ForEach-Object { $_.assets } |
-  Where-Object { $_.name -match '^wasm-pkg-v.*\.tar\.gz$' } |
+  -Uri "https://api.github.com/repos/dsafdsaf132/wasm-gerber-viewer/releases/latest"
+$asset = $release.assets |
+  Where-Object { $_.name -match '^wasm-gerber-viewer-.*\.tar\.gz$' } |
   Select-Object -First 1
-if (-not $asset) { throw "No prebuilt WASM release asset found." }
+if (-not $asset) { throw "No prebuilt viewer release asset found." }
 
-$version = $asset.browser_download_url -replace '^.*/download/([^/]+)/.*$', '$1'
-git checkout $version
-
-New-Item -ItemType Directory -Force wasm/pkg | Out-Null
-Invoke-WebRequest -Uri $asset.browser_download_url -OutFile wasm-pkg.tar.gz
-tar -xzf wasm-pkg.tar.gz -C wasm/pkg
-Remove-Item wasm-pkg.tar.gz
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile viewer.tar.gz
+tar -xzf viewer.tar.gz
+Remove-Item viewer.tar.gz
+Set-Location ((Get-ChildItem -Directory -Filter "wasm-gerber-viewer-*" | Select-Object -First 1).FullName)
 
 if (Get-Command py -ErrorAction SilentlyContinue) {
   py -3 -m http.server 8000


### PR DESCRIPTION
## Summary
- Add a prebuilt viewer release asset named `wasm-gerber-viewer-<tag>.tar.gz`.
- Keep the existing `wasm-pkg-<tag>.tar.gz` release asset.
- Update Quick Start to download the latest prebuilt viewer bundle directly instead of cloning and downloading `wasm/pkg` separately.

## Notes
The viewer bundle includes only the runnable viewer files: `index.html`, `css/`, `js/`, `vendor/`, `wasm/pkg/`, and `LICENSE`. It intentionally excludes `demo/` and development sources.

The renderer npm package already excludes `demo/` through its `files` allowlist.

## Validation
- `git diff --check`
- `npm run check --prefix packages/wasm-gerber-renderer`
- Locally packed a viewer tarball and verified `demo/` is absent while `wasm/pkg/wasm_gerber_processor_bg.wasm` is present.
