### PR TITLE
[codex] Normalize release artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,8 +158,12 @@ jobs:
             exit 1
           fi
 
-          echo "path=${artifact_dir}/${tarball}" >> "$GITHUB_OUTPUT"
-          echo "name=${tarball}" >> "$GITHUB_OUTPUT"
+          artifact_name="wasm-gerber-renderer-${{ steps.release.outputs.tag }}.tar.gz"
+          artifact_path="${artifact_dir}/${artifact_name}"
+          cp "${artifact_dir}/${tarball}" "$artifact_path"
+
+          echo "path=${artifact_path}" >> "$GITHUB_OUTPUT"
+          echo "name=${artifact_name}" >> "$GITHUB_OUTPUT"
 
       - name: Pack prebuilt WASM artifact
         id: wasm-artifact


### PR DESCRIPTION
## Summary
- Normalize the GitHub Release asset name for the npm renderer package to `wasm-gerber-renderer-vX.Y.Z.tar.gz`.
- Keep the package contents generated by `npm pack`, but upload a consistently named release asset alongside the viewer bundle.

## Why
The viewer release artifact already uses the `vX.Y.Z` tag format and `.tar.gz` suffix. This keeps release asset naming consistent and easier to scan.

## Validation
- `git diff --check origin/main..HEAD`
- `npm run check --prefix packages/wasm-gerber-renderer`
- Verified the latest viewer Quick Start tarball extracts and serves from `http://127.0.0.1:8001/`.
