### PR TITLE
[codex] Add drill layer rendering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -730,6 +730,24 @@ button {
   background: var(--surface-2);
 }
 
+.layer-group-heading {
+  padding: 8px 2px 2px;
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.drill-layer-item {
+  grid-template-columns: 24px minmax(0, 1fr) 32px;
+}
+
+.drill-layer-item .layer-label span {
+  line-height: 1.45;
+  white-space: pre-line;
+}
+
 .layer-item[draggable="true"] {
   cursor: grab;
 }

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             type="file"
             id="file-input"
             multiple
-            accept="text/*,application/zip,application/x-zip-compressed,.zip,.gdo,.gbr,.ger,.art,.gtl,.gbl,.gts,.gbs,.gto,.gbo,.gtp,.gbp,.cmp,.drd,.gko,.plc,.sol,.stc,.sts"
+            accept="text/*,application/zip,application/x-zip-compressed,.zip,.gdo,.gbr,.ger,.art,.gtl,.gbl,.gts,.gbs,.gto,.gbo,.gtp,.gbp,.cmp,.drd,.gko,.plc,.sol,.stc,.sts,.drl,.nc,.xnc,.xln"
           />
           <button
             type="button"

--- a/js/config.js
+++ b/js/config.js
@@ -51,3 +51,10 @@ export const GERBER_FILE_EXTENSIONS = new Set([
   ".tsk",
   ".tsm",
 ]);
+
+export const DRILL_FILE_EXTENSIONS = new Set([
+  ".drl",
+  ".nc",
+  ".xnc",
+  ".xln",
+]);

--- a/js/config.js
+++ b/js/config.js
@@ -53,6 +53,7 @@ export const GERBER_FILE_EXTENSIONS = new Set([
 ]);
 
 export const DRILL_FILE_EXTENSIONS = new Set([
+  ".drd",
   ".drl",
   ".nc",
   ".xnc",

--- a/js/config.js
+++ b/js/config.js
@@ -53,7 +53,6 @@ export const GERBER_FILE_EXTENSIONS = new Set([
 ]);
 
 export const DRILL_FILE_EXTENSIONS = new Set([
-  ".drd",
   ".drl",
   ".nc",
   ".xnc",

--- a/js/file-utils.js
+++ b/js/file-utils.js
@@ -1,4 +1,8 @@
-import { GERBER_FILE_EXTENSIONS, ZIP_MIME_TYPES } from "./config.js";
+import {
+  DRILL_FILE_EXTENSIONS,
+  GERBER_FILE_EXTENSIONS,
+  ZIP_MIME_TYPES,
+} from "./config.js";
 
 export function isZipFile(file) {
   return getFileExtension(file.name) === ".zip" || ZIP_MIME_TYPES.has(file.type);
@@ -6,6 +10,18 @@ export function isZipFile(file) {
 
 export function isSupportedGerberPath(path) {
   return GERBER_FILE_EXTENSIONS.has(getFileExtension(path));
+}
+
+export function isSupportedDrillPath(path) {
+  return DRILL_FILE_EXTENSIONS.has(getFileExtension(path));
+}
+
+export function isSupportedLayerPath(path) {
+  return isSupportedGerberPath(path) || isSupportedDrillPath(path);
+}
+
+export function getLayerSourceKind(path) {
+  return isSupportedDrillPath(path) ? "drill" : "gerber";
 }
 
 export function isArchiveMetadataPath(path) {

--- a/js/file-utils.js
+++ b/js/file-utils.js
@@ -20,8 +20,14 @@ export function isSupportedLayerPath(path) {
   return isSupportedGerberPath(path) || isSupportedDrillPath(path);
 }
 
-export function getLayerSourceKind(path) {
-  return isSupportedDrillPath(path) ? "drill" : "gerber";
+export function getLayerSourceKind(path, content = "") {
+  if (isSupportedDrillPath(path)) {
+    return "drill";
+  }
+  if (isAmbiguousDrdPath(path) && looksLikeDrillContent(content)) {
+    return "drill";
+  }
+  return "gerber";
 }
 
 export function isArchiveMetadataPath(path) {
@@ -38,6 +44,24 @@ export function getFileExtension(path) {
   }
 
   return fileName.slice(dotIndex).toLowerCase();
+}
+
+export function isAmbiguousDrdPath(path) {
+  return getFileExtension(path) === ".drd";
+}
+
+export function looksLikeDrillContent(content) {
+  const lines = String(content ?? "")
+    .split(/\r?\n/, 80)
+    .map((line) => line.trim().toUpperCase());
+  if (lines.some((line) => line === "M48")) {
+    return true;
+  }
+  const hasToolDeclaration = lines.some((line) => /^T\d+C[+\-.\d]+/.test(line));
+  const hasDrillCommand = lines.some((line) =>
+    /^(METRIC|INCH|M71|M72|G05|G90|G91|ICI,ON|ICI,OFF)\b/.test(line),
+  );
+  return hasToolDeclaration && hasDrillCommand;
 }
 
 export function getBaseFileName(path) {

--- a/js/layer-list.js
+++ b/js/layer-list.js
@@ -90,6 +90,60 @@ function createLayerItem({
   return item;
 }
 
+function createGroupHeader(title) {
+  const item = document.createElement("li");
+  item.className = "layer-group-heading";
+  item.textContent = title;
+  return item;
+}
+
+function createDrillItem({
+  layer,
+  formatBounds,
+  onVisibilityChange,
+  onToggleVisibility,
+  onDelete,
+}) {
+  const item = document.createElement("li");
+  item.className = "layer-item drill-layer-item";
+  item.dataset.layerId = layer.id;
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.className = "layer-checkbox";
+  checkbox.checked = layer.visible;
+  checkbox.addEventListener("change", () => {
+    onVisibilityChange(layer, checkbox.checked);
+  });
+
+  const label = document.createElement("label");
+  label.className = "layer-label";
+  const layerName = document.createElement("strong");
+  const layerMeta = document.createElement("span");
+  layerName.textContent = layer.name;
+  layerMeta.textContent = formatBounds(layer);
+  label.append(layerName, layerMeta);
+  label.addEventListener("click", () => {
+    checkbox.checked = !checkbox.checked;
+    onToggleVisibility(layer);
+  });
+
+  const deleteBtn = document.createElement("button");
+  deleteBtn.type = "button";
+  deleteBtn.className = "icon-button layer-delete-btn";
+  deleteBtn.setAttribute("aria-label", "Delete drill layer");
+  deleteBtn.title = "Delete drill layer";
+  const deleteIcon = document.createElement("i");
+  deleteIcon.setAttribute("data-lucide", "trash-2");
+  deleteBtn.appendChild(deleteIcon);
+  deleteBtn.addEventListener("click", () => {
+    onDelete(layer.id);
+  });
+
+  item.append(checkbox, label, deleteBtn);
+  return item;
+}
+
 export function renderLayerList({
   container,
   layers,
@@ -108,7 +162,13 @@ export function renderLayerList({
     return;
   }
 
-  for (const [index, layer] of layers.entries()) {
+  const gerberLayers = layers.filter((layer) => layer.kind !== "drill");
+  const drillLayers = layers.filter((layer) => layer.kind === "drill");
+
+  if (gerberLayers.length > 0) {
+    container.appendChild(createGroupHeader("Gerber Layers"));
+  }
+  for (const [index, layer] of gerberLayers.entries()) {
     container.appendChild(
       createLayerItem({
         layer,
@@ -117,6 +177,21 @@ export function renderLayerList({
         onDragStart,
         onDragEnd,
         onColorChange,
+        onVisibilityChange,
+        onToggleVisibility,
+        onDelete,
+      }),
+    );
+  }
+
+  if (drillLayers.length > 0) {
+    container.appendChild(createGroupHeader("Drills"));
+  }
+  for (const layer of drillLayers) {
+    container.appendChild(
+      createDrillItem({
+        layer,
+        formatBounds,
         onVisibilityChange,
         onToggleVisibility,
         onDelete,

--- a/js/main.js
+++ b/js/main.js
@@ -55,6 +55,8 @@ const ARC_TESSELLATION_QUALITY_LEVELS = {
   high: 2,
 };
 const MINIMUM_FEATURE_PIXEL_VALUES = new Set([0, 1, 2]);
+const DRILL_LAYER_KIND = "drill";
+const GERBER_LAYER_KIND = "gerber";
 
 class ParseWorkerUnavailableError extends Error {
   constructor(message) {
@@ -76,6 +78,38 @@ function isParseWorkerCapabilityErrorMessage(message) {
     normalizedMessage.includes("failed to fetch dynamically imported module") ||
     normalizedMessage.includes("wasm_gerber_processor")
   );
+}
+
+function isDrillSource(source) {
+  return source?.kind === DRILL_LAYER_KIND;
+}
+
+function isDrillLayer(layer) {
+  return layer?.kind === DRILL_LAYER_KIND;
+}
+
+function normalizeDrillMetadata(metadata = {}) {
+  const tools = Array.isArray(metadata.tools)
+    ? metadata.tools
+        .map((tool) => ({
+          code: Number(tool.code),
+          diameterMm: Number(tool.diameterMm),
+          hitCount: Number(tool.hitCount ?? 0),
+          slotCount: Number(tool.slotCount ?? 0),
+        }))
+        .filter(
+          (tool) =>
+            Number.isFinite(tool.code) &&
+            Number.isFinite(tool.diameterMm) &&
+            tool.diameterMm > 0,
+        )
+    : [];
+
+  return {
+    tools,
+    hitCount: Number(metadata.hitCount ?? 0),
+    slotCount: Number(metadata.slotCount ?? 0),
+  };
 }
 
 function getWorkerErrorEventMessage(event) {
@@ -987,16 +1021,9 @@ export class GerberViewer {
   async handleWebGlContextRestored() {
     if (this.isRestoringWebGlContext) return;
 
-    const layerSnapshot = this.layers.map((layer) => ({
-      id: layer.id,
-      name: layer.name,
-      layerId: layer.layerId,
-      bounds: layer.bounds ? { ...layer.bounds } : null,
-      visible: layer.visible,
-      color: [...layer.color],
-      sourceContent: layer.sourceContent,
-      offset: { ...normalizeLayerOffset(layer.offset) },
-    }));
+    const layerSnapshot = this.layers.map((layer) =>
+      this.createLayerRecoverySnapshot(layer),
+    );
     const viewState = this.captureCanvasViewState();
 
     this.isRestoringWebGlContext = true;
@@ -1048,14 +1075,7 @@ export class GerberViewer {
     this.resizeCanvas({ allowProcessorResize: true, preserveViewState: viewState });
 
     for (const layer of layerSnapshot) {
-      await this.addLayer(layer.name, layer.sourceContent, {
-        id: layer.id,
-        visible: layer.visible,
-        color: layer.color,
-        sourceContent: layer.sourceContent,
-        offset: layer.offset,
-        skipFatalRecovery: true,
-      });
+      await this.restoreLayerFromSnapshot(layer);
     }
   }
 
@@ -1303,18 +1323,22 @@ export class GerberViewer {
           total: layerSnapshot.length,
         });
 
-        try {
-          const parsedLayer = await this.parseLayerContent(
-            layer.sourceContent,
-            layer.offset,
-            null,
-          );
-          parsedLayers.push({ ...layer, parsedLayer });
-        } catch (error) {
-          this.handleLayerLoadError(layer.name, error);
-          throw new Error(
-            `Failed to apply options because ${layer.name} could not be parsed: ${getErrorMessage(error)}`,
-          );
+        if (layer.kind === DRILL_LAYER_KIND) {
+          parsedLayers.push({ ...layer, parsedLayer: null });
+        } else {
+          try {
+            const parsedLayer = await this.parseLayerContent(
+              layer.sourceContent,
+              layer.offset,
+              null,
+            );
+            parsedLayers.push({ ...layer, parsedLayer });
+          } catch (error) {
+            this.handleLayerLoadError(layer.name, error);
+            throw new Error(
+              `Failed to apply options because ${layer.name} could not be parsed: ${getErrorMessage(error)}`,
+            );
+          }
         }
       }
 
@@ -1334,19 +1358,28 @@ export class GerberViewer {
             total: parsedLayers.length,
           });
 
-          const layerRecord = await this.createParsedLayerRecord(
-            layer.name,
-            layer.parsedLayer,
-            {
-              id: layer.id,
-              visible: layer.visible,
-              color: layer.color,
-              sourceContent: layer.sourceContent,
-              offset: layer.offset,
-              skipFatalRecovery: true,
-            },
-            stagedProcessor,
-          );
+          const layerOptions = {
+            id: layer.id,
+            visible: layer.visible,
+            color: layer.color,
+            sourceContent: layer.sourceContent,
+            offset: layer.offset,
+            skipFatalRecovery: true,
+          };
+          const layerRecord =
+            layer.kind === DRILL_LAYER_KIND
+              ? await this.createDrillLayerRecord(
+                  layer.name,
+                  layer.sourceContent,
+                  layerOptions,
+                  stagedProcessor,
+                )
+              : await this.createParsedLayerRecord(
+                  layer.name,
+                  layer.parsedLayer,
+                  layerOptions,
+                  stagedProcessor,
+                );
           this.prepareLayerMetadata(layerRecord);
           stagedLayers.push(layerRecord);
 
@@ -1961,6 +1994,10 @@ export class GerberViewer {
 
   async loadLayerSources(layerSources, { title = "Loading files" } = {}) {
     const total = layerSources.length;
+    if (layerSources.some(isDrillSource)) {
+      return this.loadLayerSourcesSerially(layerSources, { title, total });
+    }
+
     const parseWorkerPool = this.createParseWorkerPool(total);
 
     if (!parseWorkerPool) {
@@ -2075,17 +2112,12 @@ export class GerberViewer {
       };
 
       const discardLayerRecord = (layerRecord) => {
-        if (
-          !layerRecord ||
-          layerRecord.layerId === undefined ||
-          layerRecord.layerId === null ||
-          typeof this.wasmProcessor?.remove_layer !== "function"
-        ) {
+        if (!layerRecord || typeof this.wasmProcessor?.remove_layer !== "function") {
           return;
         }
 
         try {
-          this.wasmProcessor.remove_layer(layerRecord.layerId);
+          this.removeWasmLayerRecord(layerRecord);
         } catch (error) {
           console.warn(
             `[Layer] Failed to discard pending layer ${layerRecord.name}:`,
@@ -2442,7 +2474,11 @@ export class GerberViewer {
         total,
       });
 
-      await this.addLayer(name, content, { offset: source.offset });
+      if (isDrillSource(source)) {
+        await this.addDrillLayer(name, content, { offset: source.offset });
+      } else {
+        await this.addLayer(name, content, { offset: source.offset });
+      }
       this.updateLoadingModal({
         stage: "Loaded",
         fileName: name,
@@ -2555,14 +2591,36 @@ export class GerberViewer {
   }
 
   createLayerRecoverySnapshot(layer) {
-    return {
+    const snapshot = {
       id: layer.id,
+      kind: layer.kind ?? GERBER_LAYER_KIND,
       name: layer.name,
       visible: layer.visible,
       color: layer.color ? [...layer.color] : null,
       sourceContent: layer.sourceContent,
       offset: { ...normalizeLayerOffset(layer.offset) },
     };
+    if (isDrillLayer(layer)) {
+      snapshot.drillMetadata = layer.drillMetadata;
+    }
+    return snapshot;
+  }
+
+  async restoreLayerFromSnapshot(layer) {
+    const options = {
+      id: layer.id,
+      visible: layer.visible,
+      color: layer.color,
+      sourceContent: layer.sourceContent,
+      offset: layer.offset,
+      skipFatalRecovery: true,
+    };
+
+    if (layer.kind === DRILL_LAYER_KIND) {
+      await this.addDrillLayer(layer.name, layer.sourceContent, options);
+    } else {
+      await this.addLayer(layer.name, layer.sourceContent, options);
+    }
   }
 
   preparePendingLayerRecordsForRecovery() {
@@ -2683,14 +2741,7 @@ export class GerberViewer {
 
       for (const layer of layerSnapshot) {
         try {
-          await this.addLayer(layer.name, layer.sourceContent, {
-            id: layer.id,
-            visible: layer.visible,
-            color: layer.color,
-            sourceContent: layer.sourceContent,
-            offset: layer.offset,
-            skipFatalRecovery: true,
-          });
+          await this.restoreLayerFromSnapshot(layer);
         } catch (restoreError) {
           const message = getErrorMessage(restoreError);
           console.error(`[WASM] Failed to restore layer ${layer.name}:`, restoreError);
@@ -2748,6 +2799,7 @@ export class GerberViewer {
     return {
       id: options.id ?? null,
       layerId: layerId,
+      kind: options.kind ?? GERBER_LAYER_KIND,
       name: name,
       visible: options.visible ?? true,
       color: options.color ? [...options.color] : null,
@@ -2774,6 +2826,10 @@ export class GerberViewer {
   prepareLayerMetadata(layer) {
     if (!layer.id) {
       layer.id = `layer-${this.nextLayerDomId++}`;
+    }
+    if (isDrillLayer(layer)) {
+      layer.color = null;
+      return layer;
     }
     if (layer.color) {
       layer.color = [...layer.color];
@@ -2829,6 +2885,75 @@ export class GerberViewer {
       }
 
       console.error(`[Layer] Failed to add layer ${name}:`, error);
+      throw error;
+    }
+  }
+
+  async addDrillLayer(name, content, options = {}) {
+    const layer = await this.createDrillLayerRecord(name, content, options);
+    return this.commitLayerMetadata(layer);
+  }
+
+  async createDrillLayerRecord(
+    name,
+    content,
+    options = {},
+    processor = this.wasmProcessor,
+  ) {
+    try {
+      if (!options.skipFatalRecovery) {
+        await this.waitForWasmProcessorRecovery();
+      }
+      if (!processor || this.isWebGlContextLost) {
+        throw new Error("WebGL renderer is not available");
+      }
+      if (typeof processor.add_drill_layer !== "function") {
+        throw new Error("Drill rendering requires an updated WASM module");
+      }
+
+      this.reserveWasmInputCapacity(content);
+      const offset = normalizeLayerOffset(options.offset);
+      let result;
+      if (offset.x !== 0 || offset.y !== 0) {
+        if (typeof processor.add_drill_layer_with_offset !== "function") {
+          throw new Error("Drill layer offsets require an updated WASM module");
+        }
+        result = processor.add_drill_layer_with_offset(content, offset.x, offset.y);
+      } else {
+        result = processor.add_drill_layer(content);
+      }
+      const outlineLayerId = Number(result?.outlineLayerId);
+      const fillLayerId = Number(result?.fillLayerId);
+      if (!Number.isFinite(outlineLayerId) || !Number.isFinite(fillLayerId)) {
+        throw new Error("Failed to get drill layer IDs from WASM processor");
+      }
+
+      const bounds = processor.get_layer_boundary(outlineLayerId);
+      return {
+        id: options.id ?? null,
+        kind: DRILL_LAYER_KIND,
+        name,
+        visible: options.visible ?? true,
+        color: null,
+        layerId: outlineLayerId,
+        outlineLayerId,
+        fillLayerId,
+        drillMetadata: normalizeDrillMetadata(result?.metadata),
+        sourceContent: options.sourceContent ?? content,
+        offset,
+        bounds: {
+          minX: bounds.min_x,
+          maxX: bounds.max_x,
+          minY: bounds.min_y,
+          maxY: bounds.max_y,
+        },
+      };
+    } catch (error) {
+      if (isFatalWasmRuntimeError(error) && !options.skipFatalRecovery) {
+        await this.recoverWasmProcessorAfterFatalError(name, error);
+      }
+
+      console.error(`[Layer] Failed to add drill layer ${name}:`, error);
       throw error;
     }
   }
@@ -2904,18 +3029,35 @@ export class GerberViewer {
     }
 
     try {
-      const { activeLayerIds, colorData } = this.getRenderLayerPayload();
+      const { activeLayerIds, colorData, blendModes } = this.getRenderLayerPayload();
 
       // Render with active layers
-      this.wasmProcessor.render(
-        activeLayerIds,
-        colorData,
-        this.getViewScaleX(),
-        this.getViewScaleY(),
-        this.camera.offsetX,
-        this.camera.offsetY,
-        this.globalAlpha,
-      );
+      if (blendModes.some((mode) => mode !== 0)) {
+        if (typeof this.wasmProcessor.render_with_clear_and_blend_modes !== "function") {
+          throw new Error("Drill fill rendering requires an updated WASM module");
+        }
+        this.wasmProcessor.render_with_clear_and_blend_modes(
+          activeLayerIds,
+          colorData,
+          blendModes,
+          this.getViewScaleX(),
+          this.getViewScaleY(),
+          this.camera.offsetX,
+          this.camera.offsetY,
+          this.globalAlpha,
+          true,
+        );
+      } else {
+        this.wasmProcessor.render(
+          activeLayerIds,
+          colorData,
+          this.getViewScaleX(),
+          this.getViewScaleY(),
+          this.camera.offsetX,
+          this.camera.offsetY,
+          this.globalAlpha,
+        );
+      }
       this.zoomReadout.textContent = this.formatZoom();
     } catch (error) {
       const message = getErrorMessage(error);
@@ -2930,17 +3072,44 @@ export class GerberViewer {
     const selectedLayerIds = this.getSelectedLayerIds();
     const activeLayerIds = [];
     const colorData = [];
+    const blendModes = [];
+    const backgroundColor = this.isCanvasLight ? [1, 1, 1] : [0, 0, 0];
+    const outlineColor = this.isCanvasLight ? [0, 0, 0] : [1, 1, 1];
+    const drillAlpha = this.globalAlpha > 0 ? 1 / this.globalAlpha : 0;
 
     this.layers.forEach((layer) => {
-      if (selectedLayerIds.has(layer.id)) {
+      if (!isDrillLayer(layer) && selectedLayerIds.has(layer.id)) {
         activeLayerIds.push(layer.layerId);
-        colorData.push(layer.color[0], layer.color[1], layer.color[2]);
+        colorData.push(layer.color[0], layer.color[1], layer.color[2], 1);
+        blendModes.push(0);
+      }
+    });
+
+    this.layers.forEach((layer) => {
+      if (isDrillLayer(layer) && layer.visible) {
+        activeLayerIds.push(layer.outlineLayerId);
+        colorData.push(outlineColor[0], outlineColor[1], outlineColor[2], drillAlpha);
+        blendModes.push(0);
+      }
+    });
+
+    this.layers.forEach((layer) => {
+      if (isDrillLayer(layer) && layer.visible) {
+        activeLayerIds.push(layer.fillLayerId);
+        colorData.push(
+          backgroundColor[0],
+          backgroundColor[1],
+          backgroundColor[2],
+          drillAlpha,
+        );
+        blendModes.push(1);
       }
     });
 
     return {
       activeLayerIds: new Uint32Array(activeLayerIds),
       colorData: new Float32Array(colorData),
+      blendModes: new Uint8Array(blendModes),
     };
   }
 
@@ -3393,7 +3562,7 @@ export class GerberViewer {
 
   updateLayerColor(layerId, hexColor) {
     const layer = this.layers.find((l) => l.id === layerId);
-    if (!layer) return;
+    if (!layer || isDrillLayer(layer)) return;
 
     const r = parseInt(hexColor.substr(1, 2), 16) / 255;
     const g = parseInt(hexColor.substr(3, 2), 16) / 255;
@@ -3418,7 +3587,7 @@ export class GerberViewer {
       try {
         // remove from WASM processor and handle errors
         if (this.wasmProcessor) {
-          this.wasmProcessor.remove_layer(layer.layerId);
+          this.removeWasmLayerRecord(layer);
         }
 
         // remove from JS array only if WASM removal succeeded
@@ -3435,6 +3604,20 @@ export class GerberViewer {
     this.renderLayerList();
     this.requestRender();
     this.updateUiState();
+  }
+
+  removeWasmLayerRecord(layer) {
+    if (!this.wasmProcessor || !layer) return;
+
+    const layerIds = isDrillLayer(layer)
+      ? [layer.outlineLayerId, layer.fillLayerId]
+      : [layer.layerId];
+
+    for (const layerId of layerIds) {
+      if (layerId !== undefined && layerId !== null) {
+        this.wasmProcessor.remove_layer(layerId);
+      }
+    }
   }
 
   clearAllLayers() {
@@ -3468,7 +3651,9 @@ export class GerberViewer {
 
   selectLayersByFilter(kind) {
     this.layers.forEach((layer) => {
-      layer.visible = this.layerFilterStore.matches(layer, kind);
+      if (!isDrillLayer(layer)) {
+        layer.visible = this.layerFilterStore.matches(layer, kind);
+      }
     });
     this.renderLayerList();
     this.requestRender();
@@ -3534,7 +3719,9 @@ export class GerberViewer {
 
     event.preventDefault();
     event.stopPropagation();
-    const fromIndex = this.layers.findIndex(
+    const gerberLayers = this.layers.filter((layer) => !isDrillLayer(layer));
+    const drillLayers = this.layers.filter(isDrillLayer);
+    const fromIndex = gerberLayers.findIndex(
       (layer) => layer.id === this.draggedLayerId,
     );
     if (fromIndex === -1) return;
@@ -3545,8 +3732,9 @@ export class GerberViewer {
     }
 
     if (fromIndex !== toIndex) {
-      const [layer] = this.layers.splice(fromIndex, 1);
-      this.layers.splice(toIndex, 0, layer);
+      const [layer] = gerberLayers.splice(fromIndex, 1);
+      gerberLayers.splice(toIndex, 0, layer);
+      this.layers = [...gerberLayers, ...drillLayers];
       this.renderLayerList();
       this.requestRender();
       this.updateUiState();
@@ -3559,7 +3747,7 @@ export class GerberViewer {
 
   getLayerDropPlacement(clientY) {
     const items = Array.from(
-      this.layerList.querySelectorAll(".layer-item[data-layer-id]"),
+      this.layerList.querySelectorAll('.layer-item[draggable="true"][data-layer-id]'),
     );
     if (items.length === 0) return null;
 
@@ -3613,6 +3801,10 @@ export class GerberViewer {
   }
 
   formatLayerBounds(layer) {
+    if (isDrillLayer(layer)) {
+      return this.formatDrillLayerMeta(layer);
+    }
+
     if (!layer.bounds) {
       return layer.visible ? "visible" : "hidden";
     }
@@ -3620,6 +3812,39 @@ export class GerberViewer {
     const width = layer.bounds.maxX - layer.bounds.minX;
     const height = layer.bounds.maxY - layer.bounds.minY;
     return formatDimensionPair(width, height, this.measurementUnit);
+  }
+
+  formatDrillLayerMeta(layer) {
+    const metadata = layer.drillMetadata ?? {};
+    const tools = Array.isArray(metadata.tools) ? metadata.tools : [];
+    const totalHits = Number(metadata.hitCount ?? 0);
+    const totalSlots = Number(metadata.slotCount ?? 0);
+    const parts = tools.slice(0, 3).map((tool) => {
+      const count = Number(tool.hitCount ?? 0) + Number(tool.slotCount ?? 0);
+      return `${this.formatDrillDiameter(tool.diameterMm)} x ${count}`;
+    });
+    if (tools.length > 3) {
+      parts.push(`+${tools.length - 3}`);
+    }
+
+    const countText =
+      totalSlots > 0
+        ? `${totalHits} hits, ${totalSlots} slots`
+        : `${totalHits} hits`;
+    return [countText, ...parts].join("\n");
+  }
+
+  formatDrillDiameter(diameterMm) {
+    const value = Number(diameterMm);
+    if (!Number.isFinite(value)) {
+      return "Ø ?";
+    }
+
+    if (this.measurementUnit === "inch") {
+      return `Ø ${(value / 25.4).toFixed(4)} in`;
+    }
+
+    return `Ø ${value.toFixed(3)} mm`;
   }
 
   triggerCanvasResize() {

--- a/js/main.js
+++ b/js/main.js
@@ -3068,8 +3068,10 @@ export class GerberViewer {
     const activeLayerIds = [];
     const colorData = [];
     const blendModes = [];
-    const backgroundColor = this.isCanvasLight ? [1, 1, 1] : [0, 0, 0];
-    const outlineColor = this.isCanvasLight ? [0, 0, 0] : [1, 1, 1];
+    const backgroundColor = this.isCanvasLight
+      ? [248 / 255, 250 / 255, 252 / 255]
+      : [2 / 255, 6 / 255, 23 / 255];
+    const outlineColor = backgroundColor.map((value) => 1 - value);
     const drillAlpha = this.globalAlpha > 0 ? 1 / this.globalAlpha : 0;
 
     this.layers.forEach((layer) => {

--- a/js/main.js
+++ b/js/main.js
@@ -1289,14 +1289,9 @@ export class GerberViewer {
   }
 
   async rebuildLayersForParserOptions() {
-    const layerSnapshot = this.layers.map((layer) => ({
-      id: layer.id,
-      name: layer.name,
-      visible: layer.visible,
-      color: layer.color ? [...layer.color] : null,
-      sourceContent: layer.sourceContent,
-      offset: { ...normalizeLayerOffset(layer.offset) },
-    }));
+    const layerSnapshot = this.layers.map((layer) =>
+      this.createLayerRecoverySnapshot(layer),
+    );
 
     if (
       layerSnapshot.some((layer) => typeof layer.sourceContent !== "string")

--- a/js/screenshot-exporter.js
+++ b/js/screenshot-exporter.js
@@ -18,6 +18,28 @@ function hasLayerOffset(offset) {
   return offset.x !== 0 || offset.y !== 0;
 }
 
+function isDrillLayer(layer) {
+  return layer?.kind === "drill";
+}
+
+function hexColorToRgb(color) {
+  const match = String(color ?? "").match(/^#([0-9a-f]{6})$/i);
+  if (!match) {
+    return [0, 0, 0];
+  }
+
+  const value = match[1];
+  return [
+    Number.parseInt(value.slice(0, 2), 16) / 255,
+    Number.parseInt(value.slice(2, 4), 16) / 255,
+    Number.parseInt(value.slice(4, 6), 16) / 255,
+  ];
+}
+
+function invertRgb(rgb) {
+  return [1 - rgb[0], 1 - rgb[1], 1 - rgb[2]];
+}
+
 export class ScreenshotExporter {
   constructor({
     canvas,
@@ -226,7 +248,7 @@ export class ScreenshotExporter {
     let screenshotRenderer = null;
 
     try {
-      screenshotRenderer = this.createRenderer();
+      screenshotRenderer = this.createRenderer(renderState);
       let blob = null;
 
       if (shouldStream) {
@@ -319,7 +341,7 @@ export class ScreenshotExporter {
     });
   }
 
-  createRenderer() {
+  createRenderer(renderState) {
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl2", { preserveDrawingBuffer: true });
     if (!gl) {
@@ -360,9 +382,42 @@ export class ScreenshotExporter {
 
     const activeLayerIds = [];
     const colorData = [];
+    const blendModes = [];
+    const drillLayers = [];
+    const drillFillColor = hexColorToRgb(renderState.backgroundColor);
+    const drillOutlineColor = invertRgb(drillFillColor);
+    const drillAlpha = renderState.globalAlpha > 0 ? 1 / renderState.globalAlpha : 0;
     for (const layer of this.getLayers()) {
       if (typeof layer.sourceContent !== "string") {
         throw new Error("Reload files before using high-resolution screenshot export.");
+      }
+
+      if (isDrillLayer(layer)) {
+        if (typeof processor.add_drill_layer !== "function") {
+          throw new Error("Drill screenshot export requires an updated WASM module.");
+        }
+        const offsetX = Number(layer.offset?.x) || 0;
+        const offsetY = Number(layer.offset?.y) || 0;
+        let result;
+        if (offsetX !== 0 || offsetY !== 0) {
+          if (typeof processor.add_drill_layer_with_offset !== "function") {
+            throw new Error("Drill screenshot offsets require an updated WASM module.");
+          }
+          result = processor.add_drill_layer_with_offset(
+            layer.sourceContent,
+            offsetX,
+            offsetY,
+          );
+        } else {
+          result = processor.add_drill_layer(layer.sourceContent);
+        }
+        if (layer.visible) {
+          drillLayers.push({
+            outlineLayerId: Number(result?.outlineLayerId),
+            fillLayerId: Number(result?.fillLayerId),
+          });
+        }
+        continue;
       }
 
       const offset = normalizeLayerOffset(layer.offset);
@@ -377,7 +432,29 @@ export class ScreenshotExporter {
         : processor.add_layer(layer.sourceContent);
       if (layer.visible) {
         activeLayerIds.push(layerId);
-        colorData.push(layer.color[0], layer.color[1], layer.color[2]);
+        colorData.push(layer.color[0], layer.color[1], layer.color[2], 1);
+        blendModes.push(0);
+      }
+    }
+
+    for (const layer of drillLayers) {
+      if (Number.isFinite(layer.outlineLayerId)) {
+        activeLayerIds.push(layer.outlineLayerId);
+        colorData.push(
+          drillOutlineColor[0],
+          drillOutlineColor[1],
+          drillOutlineColor[2],
+          drillAlpha,
+        );
+        blendModes.push(0);
+      }
+    }
+
+    for (const layer of drillLayers) {
+      if (Number.isFinite(layer.fillLayerId)) {
+        activeLayerIds.push(layer.fillLayerId);
+        colorData.push(drillFillColor[0], drillFillColor[1], drillFillColor[2], drillAlpha);
+        blendModes.push(1);
       }
     }
 
@@ -388,6 +465,7 @@ export class ScreenshotExporter {
       layerCount: this.getLayers().length,
       activeLayerIds: new Uint32Array(activeLayerIds),
       colorData: new Float32Array(colorData),
+      blendModes: new Uint8Array(blendModes),
     };
   }
 
@@ -773,21 +851,43 @@ export class ScreenshotExporter {
       screenshotRenderer.canvas.height = tileHeight;
       screenshotRenderer.processor.resize();
     }
-    screenshotRenderer.processor.render_tile(
-      screenshotRenderer.activeLayerIds,
-      screenshotRenderer.colorData,
-      exportWidth,
-      exportHeight,
-      tileX,
-      tileY,
-      tileWidth,
-      tileHeight,
-      renderState.viewScaleX,
-      renderState.viewScaleY,
-      renderState.offsetX,
-      renderState.offsetY,
-      renderState.globalAlpha,
-    );
+    if (screenshotRenderer.blendModes.some((mode) => mode !== 0)) {
+      if (typeof screenshotRenderer.processor.render_tile_with_blend_modes !== "function") {
+        throw new Error("Drill screenshot rendering requires an updated WASM module.");
+      }
+      screenshotRenderer.processor.render_tile_with_blend_modes(
+        screenshotRenderer.activeLayerIds,
+        screenshotRenderer.colorData,
+        screenshotRenderer.blendModes,
+        exportWidth,
+        exportHeight,
+        tileX,
+        tileY,
+        tileWidth,
+        tileHeight,
+        renderState.viewScaleX,
+        renderState.viewScaleY,
+        renderState.offsetX,
+        renderState.offsetY,
+        renderState.globalAlpha,
+      );
+    } else {
+      screenshotRenderer.processor.render_tile(
+        screenshotRenderer.activeLayerIds,
+        screenshotRenderer.colorData,
+        exportWidth,
+        exportHeight,
+        tileX,
+        tileY,
+        tileWidth,
+        tileHeight,
+        renderState.viewScaleX,
+        renderState.viewScaleY,
+        renderState.offsetX,
+        renderState.offsetY,
+        renderState.globalAlpha,
+      );
+    }
     screenshotRenderer.gl.finish();
   }
 

--- a/js/screenshot-exporter.js
+++ b/js/screenshot-exporter.js
@@ -384,6 +384,7 @@ export class ScreenshotExporter {
     const colorData = [];
     const blendModes = [];
     const drillLayers = [];
+    let wasmLayerCount = 0;
     const drillFillColor = hexColorToRgb(renderState.backgroundColor);
     const drillOutlineColor = invertRgb(drillFillColor);
     const drillAlpha = renderState.globalAlpha > 0 ? 1 / renderState.globalAlpha : 0;
@@ -411,6 +412,7 @@ export class ScreenshotExporter {
         } else {
           result = processor.add_drill_layer(layer.sourceContent);
         }
+        wasmLayerCount += 2;
         if (layer.visible) {
           drillLayers.push({
             outlineLayerId: Number(result?.outlineLayerId),
@@ -430,6 +432,7 @@ export class ScreenshotExporter {
       const layerId = hasLayerOffset(offset)
         ? processor.add_layer_with_offset(layer.sourceContent, offset.x, offset.y)
         : processor.add_layer(layer.sourceContent);
+      wasmLayerCount += 1;
       if (layer.visible) {
         activeLayerIds.push(layerId);
         colorData.push(layer.color[0], layer.color[1], layer.color[2], 1);
@@ -462,7 +465,7 @@ export class ScreenshotExporter {
       canvas,
       gl,
       processor,
-      layerCount: this.getLayers().length,
+      layerCount: wasmLayerCount,
       activeLayerIds: new Uint32Array(activeLayerIds),
       colorData: new Float32Array(colorData),
       blendModes: new Uint8Array(blendModes),

--- a/js/screenshot-exporter.js
+++ b/js/screenshot-exporter.js
@@ -248,7 +248,7 @@ export class ScreenshotExporter {
     let screenshotRenderer = null;
 
     try {
-      screenshotRenderer = this.createRenderer(renderState);
+      screenshotRenderer = this.createRenderer(renderState, includeBackground);
       let blob = null;
 
       if (shouldStream) {
@@ -341,7 +341,7 @@ export class ScreenshotExporter {
     });
   }
 
-  createRenderer(renderState) {
+  createRenderer(renderState, includeBackground) {
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl2", { preserveDrawingBuffer: true });
     if (!gl) {
@@ -454,7 +454,7 @@ export class ScreenshotExporter {
       if (Number.isFinite(layer.fillLayerId)) {
         activeLayerIds.push(layer.fillLayerId);
         colorData.push(drillFillColor[0], drillFillColor[1], drillFillColor[2], drillAlpha);
-        blendModes.push(1);
+        blendModes.push(includeBackground ? 1 : 2);
       }
     }
 

--- a/js/source-loader.js
+++ b/js/source-loader.js
@@ -1,7 +1,8 @@
 import {
   getBaseFileName,
+  getLayerSourceKind,
   isArchiveMetadataPath,
-  isSupportedGerberPath,
+  isSupportedLayerPath,
   isZipFile,
 } from "./file-utils.js";
 
@@ -84,6 +85,7 @@ export async function collectLayerSources(files, callbacks = {}) {
 
     layerSources.push({
       name: file.name,
+      kind: getLayerSourceKind(file.name),
       sizeBytes: file.size,
       readText: (onProgress) => readFileText(file, onProgress),
     });
@@ -103,6 +105,7 @@ export function repeatLayerSources(layerSources, repeat, { offset = {} } = {}) {
     const readText = createSharedTextReader(source.readText);
     return Array.from({ length: repeat }, (_, index) => ({
       name: `${source.name} #${index + 1}`,
+      kind: source.kind,
       sizeBytes: source.sizeBytes,
       readText,
       offset: addLayerOffsets(source.offset, {
@@ -209,7 +212,7 @@ async function collectZipLayerSources(
         (entry) =>
           !entry.dir &&
           !isArchiveMetadataPath(entry.name) &&
-          isSupportedGerberPath(entry.name),
+          isSupportedLayerPath(entry.name),
       )
       .sort((a, b) =>
         a.name.localeCompare(b.name, undefined, {
@@ -221,15 +224,16 @@ async function collectZipLayerSources(
     if (entries.length === 0) {
       onArchiveWarning(
         file.name,
-        "No supported Gerber files found in archive",
+        "No supported layer files found in archive",
       );
       return [];
     }
 
-    onArchiveInfo(file.name, `${entries.length} Gerber files found in archive`);
+    onArchiveInfo(file.name, `${entries.length} layer files found in archive`);
 
     return entries.map((entry) => ({
       name: getBaseFileName(entry.name),
+      kind: getLayerSourceKind(entry.name),
       sizeBytes: getZipEntrySizeBytes(entry),
       readText: (onProgress = () => {}) =>
         entry.async("string", (metadata) => {

--- a/js/source-loader.js
+++ b/js/source-loader.js
@@ -1,5 +1,6 @@
 import {
   getBaseFileName,
+  isAmbiguousDrdPath,
   getLayerSourceKind,
   isArchiveMetadataPath,
   isSupportedLayerPath,
@@ -85,7 +86,7 @@ export async function collectLayerSources(files, callbacks = {}) {
 
     layerSources.push({
       name: file.name,
-      kind: getLayerSourceKind(file.name),
+      kind: getLayerSourceKind(file.name, await readLayerKindPreview(file)),
       sizeBytes: file.size,
       readText: (onProgress) => readFileText(file, onProgress),
     });
@@ -231,19 +232,51 @@ async function collectZipLayerSources(
 
     onArchiveInfo(file.name, `${entries.length} layer files found in archive`);
 
-    return entries.map((entry) => ({
-      name: getBaseFileName(entry.name),
-      kind: getLayerSourceKind(entry.name),
-      sizeBytes: getZipEntrySizeBytes(entry),
-      readText: (onProgress = () => {}) =>
-        entry.async("string", (metadata) => {
-          onProgress(Math.min(metadata.percent / 100, 1));
-        }),
-    }));
+    const sources = [];
+    for (const entry of entries) {
+      const readText = createSharedTextReader((onProgress = () => {}) =>
+        readZipEntryText(entry, onProgress),
+      );
+      let preview = "";
+      if (isAmbiguousDrdPath(entry.name)) {
+        try {
+          preview = await readZipEntryText(entry);
+        } catch (_error) {
+          onArchiveWarning(
+            file.name,
+            `Could not inspect ${getBaseFileName(entry.name)}; loading as Gerber`,
+          );
+        }
+      }
+      sources.push({
+        name: getBaseFileName(entry.name),
+        kind: getLayerSourceKind(entry.name, preview),
+        sizeBytes: getZipEntrySizeBytes(entry),
+        readText,
+      });
+    }
+
+    return sources;
   } catch (error) {
     onArchiveError(file.name, error);
     return [];
   }
+}
+
+function readZipEntryText(entry, onProgress = () => {}) {
+  return entry.async("string", (metadata) => {
+    onProgress(Math.min(metadata.percent / 100, 1));
+  });
+}
+
+async function readLayerKindPreview(file) {
+  if (!isAmbiguousDrdPath(file.name)) {
+    return "";
+  }
+  if (typeof file.slice === "function") {
+    return file.slice(0, 8192).text();
+  }
+  return file.text();
 }
 
 function getZipEntrySizeBytes(entry) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -283,6 +283,7 @@ load. If every layer fails, the operation rejects with the first layer error.
 - `preserveArcRegions`: keeps exact region arcs. Defaults to `true`; set `false` to approximate region arcs.
 - `arcTessellationQuality`: arc approximation quality, `0` low, `1` normal, `2` high. Defaults to `1`.
 - `minimumFeaturePixels`: minimum rendered line/arc width in screen pixels. Defaults to `1`.
+- `renderDrills`: renders NC drill files (`.drl`, `.nc`, `.xnc`, `.xln`) as drill overlays. Defaults to `true`.
 - `globalAlpha`: opacity for layers without an explicit layer `alpha`. Defaults to `0.7`.
 - `layerErrorMode`: `"skip"` renders remaining valid layers; `"throw"` rejects on first failure. Defaults to `"skip"`.
 - `onLayerError`: callback for skipped layers in `"skip"` mode: `{ layer, name, error }`.
@@ -294,6 +295,7 @@ load. If every layer fails, the operation rejects with the first layer error.
 - `alpha`: per-layer opacity. When set, it overrides `globalAlpha` for that layer.
 - `offsetX`: X offset applied while loading geometry. Defaults to `0`.
 - `offsetY`: Y offset applied while loading geometry. Defaults to `0`.
+- `kind`: force `"gerber"` or `"drill"` when a source filename is unavailable or ambiguous.
 - `name`: layer display name for config objects such as `{ source, name }` or `{ path, name }`.
 
 `exportOptions` control PNG export:
@@ -347,7 +349,7 @@ gerber-renderer board-gerbers.tar.gz \
 
 CLI options:
 
-- `<input...>`: one or more Gerber files or `.tar.gz`/`.tgz` archives. Multiple files render as layers in argument order.
+- `<input...>`: one or more Gerber/drill files or `.tar.gz`/`.tgz` archives. Multiple files render as layers in argument order.
 - `-o, --output <path>`: PNG output path. Required for multiple inputs. Parent directories must already exist.
 - `--width <px>`: output width. Defaults to `1200`.
 - `--height <px>`: output height. Defaults to `800`.
@@ -360,6 +362,7 @@ CLI options:
 - `--arc-quality <0|1|2>`: approximate arc quality. Defaults to `1`.
 - `--flip-x`: mirrors the output horizontally.
 - `--flip-y`: mirrors the output vertically.
+- `--no-drill`: skips NC drill layers.
 - `--no-fit`: disables fit-to-view.
 - `--skill`: prints [package usage notes](SKILL.md) for AI agents.
 - `-h, --help`: prints CLI usage and exits.

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -71,6 +71,7 @@ Useful CLI options:
 - `--arc-quality <0|1|2>` controls approximate arc quality.
 - `--flip-x` mirrors the output horizontally.
 - `--flip-y` mirrors the output vertically.
+- `--no-drill` skips NC drill layers.
 - `--no-fit` disables automatic fit-to-view.
 - `--skill` prints package usage notes for AI agents.
 
@@ -275,6 +276,7 @@ Use `onLayerError` to report skipped layers. Use `layerErrorMode: "throw"` when 
 - `view`: manual `{ zoomX, zoomY, offsetX, offsetY }`.
 - `globalAlpha`: opacity multiplier for all layers.
 - `minimumFeaturePixels`: minimum visible line/arc width.
+- `renderDrills`: render NC drill files as drill overlays; set `false` to skip them.
 - `preserveArcRegions`: defaults to `true`; set `false` for approximate region arcs.
 - `arcTessellationQuality`: `0` low, `1` normal, `2` high.
 

--- a/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
+++ b/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
@@ -2,7 +2,7 @@
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { gunzipSync } from "node:zlib";
-import { fileLayer, renderGerberToPngFile } from "../node.js";
+import { createNodeGerberRenderer, fileLayer } from "../node.js";
 
 const USAGE = `Usage:
   gerber-renderer <input.gbr|input.tar.gz...> [options]
@@ -20,6 +20,7 @@ Options:
   --arc-quality <0|1|2>            Approx arc quality: low, normal, high (default: 1)
   --flip-x                         Mirror the output horizontally
   --flip-y                         Mirror the output vertically
+  --no-drill                       Skip NC drill layers
   --no-fit                         Use identity view instead of fit view (default: fit enabled)
   --skill                          Print AI usage notes
   -h, --help                       Show this help
@@ -58,9 +59,18 @@ async function main() {
     skippedLayers.push(name);
     process.stderr.write(`Skipped ${name}: ${errorMessage(error)}\n`);
   };
-  await renderGerberToPngFile(outputPath, layers, frameOptions);
+  const renderer = await createNodeGerberRenderer();
+  let renderResult = { renderedCount: 0, failures: [] };
+  try {
+    await renderer.withFrame(frameOptions, async () => {
+      renderResult = await renderer.renderLayers(layers, frameOptions);
+    });
+    await renderer.exportPngFile(outputPath, { background: frameOptions.background });
+  } finally {
+    renderer.dispose();
+  }
   process.stdout.write(
-    `Rendered ${layers.length - skippedLayers.length}/${layers.length} layer(s) to ${outputPath}\n`,
+    `Rendered ${renderResult.renderedCount}/${layers.length} layer(s) to ${outputPath}\n`,
   );
 }
 
@@ -102,6 +112,8 @@ function parseArgs(args) {
       frameOptions.flipX = true;
     } else if (arg === "--flip-y") {
       frameOptions.flipY = true;
+    } else if (arg === "--no-drill") {
+      frameOptions.renderDrills = false;
     } else if (arg === "--no-fit") {
       frameOptions.fit = false;
     } else if (arg.startsWith("-")) {

--- a/packages/wasm-gerber-renderer/index.d.ts
+++ b/packages/wasm-gerber-renderer/index.d.ts
@@ -14,10 +14,12 @@ export type GerberLayer =
       alpha?: number;
       offsetX?: number;
       offsetY?: number;
+      kind?: LayerKind;
     };
 
 export type RGBColor = [number, number, number];
 export type RGBAColor = [number, number, number, number];
+export type LayerKind = "gerber" | "drill";
 
 export type RendererOptions = {
   wasmModule?: unknown;
@@ -45,6 +47,7 @@ export type FrameOptions = {
   preserveArcRegions?: boolean;
   arcTessellationQuality?: 0 | 1 | 2;
   minimumFeaturePixels?: number;
+  renderDrills?: boolean;
   globalAlpha?: number;
   rendererOptions?: RendererOptions;
   onLayerError?: (failure: LayerFailure) => void;
@@ -64,6 +67,7 @@ export type LayerOptions = {
   alpha?: number;
   offsetX?: number;
   offsetY?: number;
+  kind?: LayerKind;
 };
 
 export type ExportOptions = {
@@ -107,7 +111,7 @@ export declare class GerberRenderer {
     callback: () => void | Promise<void>,
   ): Promise<void>;
 
-  renderLayer(layer: GerberLayer, layerOptions?: LayerOptions): Promise<number>;
+  renderLayer(layer: GerberLayer, layerOptions?: LayerOptions): Promise<number | null>;
 
   renderLayers(
     layers: GerberLayer | GerberLayer[] | FileList,

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -509,7 +509,7 @@ function createRenderEntries(layers, globalAlpha, background) {
         layerId: layer.fillLayerId,
         color: drillColors.fill,
         alpha: resolveLayerAlpha(layer.alpha, 1),
-        blendMode: background == null ? 2 : 1,
+        blendMode: drillColors.hasBackground ? 1 : 2,
       });
     }
   }

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -265,12 +265,18 @@ export class GerberRenderer {
     const { source, options } = normalizeLayer(layer, layerOptions);
     const offsetX = numberOrDefault(options.offsetX, 0);
     const offsetY = numberOrDefault(options.offsetY, 0);
-    const kind = normalizeLayerKind(options.kind, source, options.name);
+    const initialKind = normalizeLayerKind(options.kind, source, options.name);
+    if (isDrillLayerKind(initialKind) && !this.frame.options.renderDrills) {
+      return null;
+    }
+    const content = await sourceToText(source);
+    const kind = isDrillLayerKind(initialKind)
+      ? initialKind
+      : normalizeLayerKind(options.kind, source, options.name, content);
     if (isDrillLayerKind(kind)) {
       if (!this.frame.options.renderDrills) {
         return null;
       }
-      const content = await sourceToText(source);
       const result = addDrillLayerToProcessor(
         this.frame.processor,
         content,
@@ -298,7 +304,6 @@ export class GerberRenderer {
       };
     }
 
-    const content = await sourceToText(source);
     const layerId = addLayerToProcessor(
       this.frame.processor,
       content,

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -63,20 +63,26 @@ export async function renderGerberToPng(
   frameOptions = {},
   exportOptions = {},
 ) {
+  const renderFrameOptions = {
+    ...frameOptions,
+    ...("background" in exportOptions
+      ? { background: exportOptions.background }
+      : {}),
+  };
   const renderer = await createGerberRenderer(
     canvas,
     {
       releaseContext: false,
-      ...(frameOptions.rendererOptions || {}),
+      ...(renderFrameOptions.rendererOptions || {}),
     },
   );
 
   try {
-    await renderer.withFrame(frameOptions, async () => {
-      await renderer.renderLayers(layers, frameOptions);
+    await renderer.withFrame(renderFrameOptions, async () => {
+      await renderer.renderLayers(layers, renderFrameOptions);
     });
     return await renderer.exportPng({
-      background: frameOptions.background,
+      background: renderFrameOptions.background,
       ...exportOptions,
     });
   } finally {
@@ -91,20 +97,26 @@ export async function renderGerberToPngStream(
   frameOptions = {},
   exportOptions = {},
 ) {
+  const renderFrameOptions = {
+    ...frameOptions,
+    ...("background" in exportOptions
+      ? { background: exportOptions.background }
+      : {}),
+  };
   const renderer = await createGerberRenderer(
     canvas,
     {
       releaseContext: false,
-      ...(frameOptions.rendererOptions || {}),
+      ...(renderFrameOptions.rendererOptions || {}),
     },
   );
 
   try {
-    await renderer.withFrame(frameOptions, async () => {
-      await renderer.renderLayers(layers, frameOptions);
+    await renderer.withFrame(renderFrameOptions, async () => {
+      await renderer.renderLayers(layers, renderFrameOptions);
     });
     await renderer.exportPngStream(writable, {
-      background: frameOptions.background,
+      background: renderFrameOptions.background,
       ...exportOptions,
     });
   } finally {
@@ -497,7 +509,7 @@ function createRenderEntries(layers, globalAlpha, background) {
         layerId: layer.fillLayerId,
         color: drillColors.fill,
         alpha: resolveLayerAlpha(layer.alpha, 1),
-        blendMode: 1,
+        blendMode: background == null ? 2 : 1,
       });
     }
   }

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -2,6 +2,7 @@ import {
   DEFAULT_BACKGROUND,
   FrameState,
   PNG_SIGNATURE,
+  addDrillLayerToProcessor,
   addLayerToProcessor,
   applyProcessorOptions,
   boundaryToPlainObject,
@@ -12,12 +13,15 @@ import {
   getPngColorType,
   getPngRowStride,
   getSourceName,
+  isDrillLayerKind,
   loadWasmJsModule,
   normalizeColor,
+  normalizeLayerKind,
   normalizeLayer,
   normalizeLayerList,
   numberOrDefault,
   optionalAlpha,
+  resolveDrillRenderColors,
   parseColor,
   positiveIntegerOrDefault,
   renderLayersBestEffort,
@@ -164,6 +168,9 @@ export class GerberRenderer {
     }
 
     const layerRecord = await this.createLayerRecord(layer, layerOptions);
+    if (!layerRecord) {
+      return null;
+    }
     this.frame.addLayer(layerRecord);
     return layerRecord.layerId;
   }
@@ -244,9 +251,42 @@ export class GerberRenderer {
 
   async createLayerRecord(layer, layerOptions) {
     const { source, options } = normalizeLayer(layer, layerOptions);
-    const content = await sourceToText(source);
     const offsetX = numberOrDefault(options.offsetX, 0);
     const offsetY = numberOrDefault(options.offsetY, 0);
+    const kind = normalizeLayerKind(options.kind, source, options.name);
+    if (isDrillLayerKind(kind)) {
+      if (!this.frame.options.renderDrills) {
+        return null;
+      }
+      const content = await sourceToText(source);
+      const result = addDrillLayerToProcessor(
+        this.frame.processor,
+        content,
+        offsetX,
+        offsetY,
+      );
+      const outlineLayerId = Number(result?.outlineLayerId);
+      const fillLayerId = Number(result?.fillLayerId);
+      if (!Number.isInteger(outlineLayerId) || !Number.isInteger(fillLayerId)) {
+        throw new Error("Drill rendering did not return layer IDs.");
+      }
+      const bounds = boundaryToPlainObject(
+        this.frame.processor.get_layer_boundary(outlineLayerId),
+      );
+      const alpha = optionalAlpha(options.alpha);
+      return {
+        kind,
+        layerId: outlineLayerId,
+        outlineLayerId,
+        fillLayerId,
+        name: options.name || getSourceName(source) || `Layer ${outlineLayerId}`,
+        bounds,
+        color: null,
+        alpha,
+      };
+    }
+
+    const content = await sourceToText(source);
     const layerId = addLayerToProcessor(
       this.frame.processor,
       content,
@@ -263,6 +303,7 @@ export class GerberRenderer {
     const alpha = optionalAlpha(options.alpha);
 
     return {
+      kind,
       layerId,
       name: options.name || getSourceName(source) || `Layer ${layerId}`,
       bounds,
@@ -293,37 +334,63 @@ export class GerberRenderer {
       this.canvas.width,
       this.canvas.height,
     );
-    const activeLayerIds = new Uint32Array(frame.layers.map((layer) => layer.layerId));
     const globalAlpha = clamp01(numberOrDefault(frame.options.globalAlpha, 1));
+    const renderEntries = createRenderEntries(
+      frame.layers,
+      globalAlpha,
+      frame.options.background,
+    );
+    const activeLayerIds = new Uint32Array(renderEntries.map((entry) => entry.layerId));
+    const blendModes = new Uint8Array(renderEntries.map((entry) => entry.blendMode));
 
     if (typeof frame.processor.render_with_clear === "function") {
       const colorData = new Float32Array(
-        frame.layers.flatMap((layer) => [
-          layer.color[0],
-          layer.color[1],
-          layer.color[2],
-          resolveLayerAlpha(layer.alpha, globalAlpha),
+        renderEntries.flatMap((entry) => [
+          entry.color[0],
+          entry.color[1],
+          entry.color[2],
+          entry.alpha,
         ]),
       );
-      frame.processor.render_with_clear(
-        activeLayerIds,
-        colorData,
-        view.zoomX,
-        view.zoomY,
-        view.offsetX,
-        view.offsetY,
-        1,
-        clear,
-      );
+      if (blendModes.some((mode) => mode !== 0)) {
+        if (typeof frame.processor.render_with_clear_and_blend_modes !== "function") {
+          throw new Error("Drill rendering requires an updated WASM renderer.");
+        }
+        frame.processor.render_with_clear_and_blend_modes(
+          activeLayerIds,
+          colorData,
+          blendModes,
+          view.zoomX,
+          view.zoomY,
+          view.offsetX,
+          view.offsetY,
+          1,
+          clear,
+        );
+      } else {
+        frame.processor.render_with_clear(
+          activeLayerIds,
+          colorData,
+          view.zoomX,
+          view.zoomY,
+          view.offsetX,
+          view.offsetY,
+          1,
+          clear,
+        );
+      }
     } else {
       if (!clear) {
         throw new Error("clear:false requires an updated WASM renderer.");
       }
-      if (frame.layers.some((layer) => layer.alpha != null)) {
+      if (
+        frame.layers.some((layer) => layer.alpha != null) ||
+        frame.layers.some((layer) => isDrillLayerKind(layer.kind))
+      ) {
         throw new Error("Layer alpha requires an updated WASM renderer.");
       }
       const colorData = new Float32Array(
-        frame.layers.flatMap((layer) => layer.color),
+        renderEntries.flatMap((entry) => entry.color),
       );
       frame.processor.render(
         activeLayerIds,
@@ -396,6 +463,46 @@ export class GerberRenderer {
       throw new Error("GerberRenderer has been disposed.");
     }
   }
+}
+
+function createRenderEntries(layers, globalAlpha, background) {
+  const entries = [];
+  const drillColors = resolveDrillRenderColors(background);
+
+  for (const layer of layers) {
+    if (!isDrillLayerKind(layer.kind)) {
+      entries.push({
+        layerId: layer.layerId,
+        color: layer.color,
+        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
+        blendMode: 0,
+      });
+    }
+  }
+
+  for (const layer of layers) {
+    if (isDrillLayerKind(layer.kind)) {
+      entries.push({
+        layerId: layer.outlineLayerId,
+        color: drillColors.outline,
+        alpha: resolveLayerAlpha(layer.alpha, 1),
+        blendMode: 0,
+      });
+    }
+  }
+
+  for (const layer of layers) {
+    if (isDrillLayerKind(layer.kind)) {
+      entries.push({
+        layerId: layer.fillLayerId,
+        color: drillColors.fill,
+        alpha: resolveLayerAlpha(layer.alpha, 1),
+        blendMode: 1,
+      });
+    }
+  }
+
+  return entries;
 }
 
 async function loadWasmModule(rendererOptions) {

--- a/packages/wasm-gerber-renderer/node.d.ts
+++ b/packages/wasm-gerber-renderer/node.d.ts
@@ -17,6 +17,7 @@ export type GerberNodeLayer =
       alpha?: number;
       offsetX?: number;
       offsetY?: number;
+      kind?: LayerKind;
     }
   | {
       path: string;
@@ -25,6 +26,7 @@ export type GerberNodeLayer =
       alpha?: number;
       offsetX?: number;
       offsetY?: number;
+      kind?: LayerKind;
     };
 
 export type NodeLayerBounds = {
@@ -40,6 +42,7 @@ export type GerberNodePreparedLayer = {
   readonly [preparedLayerBrand]: true;
   readonly name: string;
   readonly sourceName: string;
+  readonly kind: LayerKind;
   readonly bounds: NodeLayerBounds;
   readonly offsetX: number;
   readonly offsetY: number;
@@ -47,6 +50,7 @@ export type GerberNodePreparedLayer = {
 
 export type RGBColor = [number, number, number];
 export type RGBAColor = [number, number, number, number];
+export type LayerKind = "gerber" | "drill";
 export type PngRenderStrategy = "auto" | "full-frame" | "stream";
 
 export type NodeRendererOptions = {
@@ -79,6 +83,7 @@ export type NodeFrameOptions = {
   preserveArcRegions?: boolean;
   arcTessellationQuality?: 0 | 1 | 2;
   minimumFeaturePixels?: number;
+  renderDrills?: boolean;
   globalAlpha?: number;
   maxBandBytes?: number;
   maxFullFrameBytes?: number;
@@ -103,6 +108,7 @@ export type NodeLayerOptions = {
   alpha?: number;
   offsetX?: number;
   offsetY?: number;
+  kind?: LayerKind;
 };
 
 export type NodeLayerLoadOptions = NodeLayerOptions & {
@@ -169,7 +175,7 @@ export declare class NodeGerberRenderer {
   renderLayer(
     layer: GerberNodeLayer,
     layerOptions?: NodeLayerOptions,
-  ): Promise<number>;
+  ): Promise<number | null>;
 
   renderLayers(
     layers: GerberNodeLayer | GerberNodeLayer[],

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -14,7 +14,6 @@ import {
   PNG_SIGNATURE,
   addLayerToProcessor,
   applyProcessorOptions,
-  boundaryToPlainObject,
   clamp01,
   createBaseFrameOptions,
   createPngHeader,
@@ -22,19 +21,23 @@ import {
   getPngColorType,
   getPngRowStride,
   getSourceName,
+  isDrillLayerKind,
   loadLayersBestEffort,
   loadWasmJsModule,
-  mergeBounds,
   normalizeColor,
   normalizeLayer,
+  normalizeLayerKind,
   normalizeLayerList,
   normalizeParseOptions,
   numberOrDefault,
   optionalAlpha,
+  parseDrillLayerPayload,
   parseColor,
+  payloadBounds,
   positiveIntegerOrDefault,
   positiveNumberOrDefault,
   renderLayersBestEffort,
+  resolveDrillRenderColors,
   resolveFrameView,
   resolveLayerAlpha,
   sourceToText,
@@ -170,6 +173,9 @@ export class NodeGerberRenderer {
     }
 
     const layerRecord = await this.createLayerRecord(layer, layerOptions);
+    if (!layerRecord) {
+      return null;
+    }
     this.frame.addLayer(layerRecord);
     return layerRecord.layerId;
   }
@@ -321,6 +327,12 @@ export class NodeGerberRenderer {
           ...this.frame.options,
           ...layerOptions,
         });
+    if (!prepared) {
+      return null;
+    }
+    if (isDrillLayerKind(prepared.kind) && !this.frame.options.renderDrills) {
+      return null;
+    }
     const layerId = this.frame.layers.length;
     const color =
       prepared.color == null
@@ -330,10 +342,12 @@ export class NodeGerberRenderer {
           });
 
     return {
+      kind: prepared.kind,
       layerId,
       name: prepared.name || `Layer ${layerId}`,
       content: prepared.content,
       parsedLayer: prepared.parsedLayer,
+      parsedDrillLayer: prepared.parsedDrillLayer,
       offsetX: prepared.offsetX,
       offsetY: prepared.offsetY,
       bounds: prepared.bounds,
@@ -350,30 +364,43 @@ export class NodeGerberRenderer {
     const { source, options } = normalizeLayer(layer, layerOptions, {
       allowPathConfig: true,
     });
+    const offsetX = numberOrDefault(options.offsetX, 0);
+    const offsetY = numberOrDefault(options.offsetY, 0);
+    const kind = normalizeLayerKind(options.kind, source, options.name);
+    if (isDrillLayerKind(kind) && options.renderDrills === false) {
+      return null;
+    }
     const content = await sourceToText(source, {
       fileUrlToPath: fileURLToPath,
       readPathText: (path) => readFile(path, "utf8"),
       sourceDescription:
         "a string, File, Blob, ArrayBuffer, Uint8Array, URL, or path config",
     });
-    const offsetX = numberOrDefault(options.offsetX, 0);
-    const offsetY = numberOrDefault(options.offsetY, 0);
     const parseOptions = normalizeParseOptions(options);
-    const parsed = parseLayerPayload(
-      this.wasmModule,
-      content,
-      offsetX,
-      offsetY,
-      parseOptions,
-    );
+    const parsed = isDrillLayerKind(kind)
+      ? parseDrillLayerPayload(this.wasmModule, content, offsetX, offsetY)
+      : parseLayerPayload(
+          this.wasmModule,
+          content,
+          offsetX,
+          offsetY,
+          parseOptions,
+        );
     const sourceName = getSourceName(source);
 
     return {
       [NODE_PREPARED_LAYER]: true,
+      kind,
       name: options.name || sourceName || "Layer",
       sourceName,
       content: supportsParsedLayerReuse(this.wasmModule) ? null : content,
-      parsedLayer: parsed.payload,
+      parsedLayer: isDrillLayerKind(kind) ? null : parsed.payload,
+      parsedDrillLayer: isDrillLayerKind(kind)
+        ? {
+            outlineLayer: parsed.outlineLayer,
+            fillLayer: parsed.fillLayer,
+          }
+        : null,
       bounds: parsed.bounds,
       offsetX,
       offsetY,
@@ -438,8 +465,10 @@ class NodeFrameState extends FrameState {
       framebufferMemorySafetyFactor: this.options.framebufferMemorySafetyFactor,
       strategy: this.options.strategy,
       layers: this.layers.map((layer) => ({
+        kind: layer.kind,
         content: layer.content,
         parsedLayer: layer.parsedLayer,
+        parsedDrillLayer: layer.parsedDrillLayer,
         offsetX: layer.offsetX,
         offsetY: layer.offsetY,
         color: layer.color,
@@ -589,11 +618,7 @@ function parseLayerPayload(wasmModule, content, offsetX, offsetY, frameOptions) 
     payload = parseDefault(content, offsetX, offsetY);
   }
 
-  const sublayers = Array.from(payload?.sublayers ?? []);
-  let bounds = null;
-  for (const sublayer of sublayers) {
-    bounds = mergeBounds(bounds, boundaryToPlainObject(sublayer.boundary));
-  }
+  const bounds = payloadBounds(payload);
   if (!bounds) {
     throw new Error("File does not contain valid Gerber data (no geometry found)");
   }
@@ -642,11 +667,19 @@ function isPreparedNodeLayer(value) {
 function mergePreparedLayerOptions(preparedLayer, layerOptions = {}) {
   const offsetX = numberOrDefault(preparedLayer.offsetX, 0);
   const offsetY = numberOrDefault(preparedLayer.offsetY, 0);
+  const kind = normalizeLayerKind(preparedLayer.kind, { name: preparedLayer.sourceName });
   if (
     ("offsetX" in layerOptions && numberOrDefault(layerOptions.offsetX, 0) !== offsetX) ||
     ("offsetY" in layerOptions && numberOrDefault(layerOptions.offsetY, 0) !== offsetY)
   ) {
     throw new Error("Prepared layer offsets are fixed. Load the layer again to change offsets.");
+  }
+  if (
+    "kind" in layerOptions &&
+      layerOptions.kind != null &&
+    normalizeLayerKind(layerOptions.kind, { name: preparedLayer.sourceName }) !== kind
+  ) {
+    throw new Error("Prepared layer kind is fixed. Load the layer again to change kind.");
   }
 
   return {
@@ -655,6 +688,7 @@ function mergePreparedLayerOptions(preparedLayer, layerOptions = {}) {
       "name" in layerOptions && layerOptions.name != null
         ? String(layerOptions.name)
         : preparedLayer.name,
+    kind,
     color:
       "color" in layerOptions
         ? layerOptions.color
@@ -710,7 +744,7 @@ async function renderPlanToPngSink(renderer, plan, exportOptions, sink) {
     exportOptions.framebufferMemorySafetyFactor,
     plan.framebufferMemorySafetyFactor || DEFAULT_FRAMEBUFFER_MEMORY_SAFETY_FACTOR,
   );
-  const layerCount = Math.max(1, plan.layers.length);
+  const layerCount = Math.max(1, getRenderLayerCount(plan.layers));
   const fullFrameEstimate = estimateFullFrameBytes(
     width,
     height,
@@ -956,21 +990,43 @@ function renderStreamBand(state, width, height, tileY, view, bandRowBytes) {
     const renderTileX =
       currentTileWidth === state.tileWidth ? tileX : Math.max(0, width - state.tileWidth);
     const readX = tileX - renderTileX;
-    state.renderContext.processor.render_tile(
-      state.renderContext.activeLayerIds,
-      state.renderContext.colorData,
-      width,
-      height,
-      renderTileX,
-      renderTileY,
-      state.tileWidth,
-      state.tileHeight,
-      view.zoomX,
-      view.zoomY,
-      view.offsetX,
-      view.offsetY,
-      1,
-    );
+    if (hasBlendModes(state.renderContext.blendModes)) {
+      if (typeof state.renderContext.processor.render_tile_with_blend_modes !== "function") {
+        throw new Error("Drill rendering requires an updated WASM renderer.");
+      }
+      state.renderContext.processor.render_tile_with_blend_modes(
+        state.renderContext.activeLayerIds,
+        state.renderContext.colorData,
+        state.renderContext.blendModes,
+        width,
+        height,
+        renderTileX,
+        renderTileY,
+        state.tileWidth,
+        state.tileHeight,
+        view.zoomX,
+        view.zoomY,
+        view.offsetX,
+        view.offsetY,
+        1,
+      );
+    } else {
+      state.renderContext.processor.render_tile(
+        state.renderContext.activeLayerIds,
+        state.renderContext.colorData,
+        width,
+        height,
+        renderTileX,
+        renderTileY,
+        state.tileWidth,
+        state.tileHeight,
+        view.zoomX,
+        view.zoomY,
+        view.offsetX,
+        view.offsetY,
+        1,
+      );
+    }
     state.renderGl.finish?.();
     state.renderGl.readPixels(
       readX,
@@ -1028,16 +1084,7 @@ async function renderPlanToFullFramePngSink(
   try {
     const pixels = plan.layers.length === 0 || !plan.view
       ? new Uint8Array(width * height * 4)
-      : renderContext.processor.render_pixels_with_clear(
-          renderContext.activeLayerIds,
-          renderContext.colorData,
-          plan.view.zoomX,
-          plan.view.zoomY,
-          plan.view.offsetX,
-          plan.view.offsetY,
-          1,
-          true,
-        );
+      : renderPlanPixels(renderContext, plan);
     await writePngDocument(sink, width, height, pngColorType, async (writeRow) => {
       await writeFullFramePixelRows(
         writeRow,
@@ -1064,22 +1111,62 @@ function createProcessorForPlan(renderer, plan, gl, width, height) {
     processor.init_with_size(gl, width, height);
     applyProcessorOptions(processor, plan);
 
-    const activeLayerIds = new Uint32Array(plan.layers.length);
-    const colorData = new Float32Array(plan.layers.length * 4);
-    for (const [index, layer] of plan.layers.entries()) {
-      activeLayerIds[index] = addPlanLayerToProcessor(processor, layer);
+    const renderEntries = createPlanRenderEntries(processor, plan);
+    const activeLayerIds = new Uint32Array(
+      renderEntries.map((entry) => entry.layerId),
+    );
+    const blendModes = new Uint8Array(renderEntries.map((entry) => entry.blendMode));
+    const colorData = new Float32Array(renderEntries.length * 4);
+    for (const [index, entry] of renderEntries.entries()) {
       const offset = index * 4;
-      colorData[offset] = layer.color[0];
-      colorData[offset + 1] = layer.color[1];
-      colorData[offset + 2] = layer.color[2];
-      colorData[offset + 3] = resolveLayerAlpha(layer.alpha, plan.globalAlpha);
+      colorData[offset] = entry.color[0];
+      colorData[offset + 1] = entry.color[1];
+      colorData[offset + 2] = entry.color[2];
+      colorData[offset + 3] = entry.alpha;
     }
 
-    return { processor, activeLayerIds, colorData };
+    return { processor, activeLayerIds, colorData, blendModes };
   } catch (error) {
     disposeProcessor(processor);
     throw error;
   }
+}
+
+function renderPlanPixels(renderContext, plan) {
+  if (hasBlendModes(renderContext.blendModes)) {
+    if (
+      typeof renderContext.processor.render_pixels_with_clear_and_blend_modes !==
+      "function"
+    ) {
+      throw new Error("Drill rendering requires an updated WASM renderer.");
+    }
+    return renderContext.processor.render_pixels_with_clear_and_blend_modes(
+      renderContext.activeLayerIds,
+      renderContext.colorData,
+      renderContext.blendModes,
+      plan.view.zoomX,
+      plan.view.zoomY,
+      plan.view.offsetX,
+      plan.view.offsetY,
+      1,
+      true,
+    );
+  }
+
+  return renderContext.processor.render_pixels_with_clear(
+    renderContext.activeLayerIds,
+    renderContext.colorData,
+    plan.view.zoomX,
+    plan.view.zoomY,
+    plan.view.offsetX,
+    plan.view.offsetY,
+    1,
+    true,
+  );
+}
+
+function hasBlendModes(blendModes) {
+  return Boolean(blendModes?.some((mode) => mode !== 0));
 }
 
 function addPlanLayerToProcessor(processor, layer) {
@@ -1095,6 +1182,85 @@ function addPlanLayerToProcessor(processor, layer) {
     throw new Error("Layer content is unavailable for rendering.");
   }
   return addLayerToProcessor(processor, layer.content, layer.offsetX, layer.offsetY);
+}
+
+function createPlanRenderEntries(processor, plan) {
+  const gerberEntries = [];
+  const drillOutlineEntries = [];
+  const drillFillEntries = [];
+  const drillColors = resolveDrillRenderColors(plan.background);
+
+  for (const layer of plan.layers) {
+    if (isDrillLayerKind(layer.kind)) {
+      const { outlineLayerId, fillLayerId } = addPlanDrillLayerToProcessor(processor, layer);
+      const alpha = resolveLayerAlpha(layer.alpha, 1);
+      drillOutlineEntries.push({
+        layerId: outlineLayerId,
+        color: drillColors.outline,
+        alpha,
+        blendMode: 0,
+      });
+      drillFillEntries.push({
+        layerId: fillLayerId,
+        color: drillColors.fill,
+        alpha,
+        blendMode: 1,
+      });
+      continue;
+    }
+
+    gerberEntries.push({
+      layerId: addPlanLayerToProcessor(processor, layer),
+      color: layer.color,
+      alpha: resolveLayerAlpha(layer.alpha, plan.globalAlpha),
+      blendMode: 0,
+    });
+  }
+
+  return [...gerberEntries, ...drillOutlineEntries, ...drillFillEntries];
+}
+
+function addPlanDrillLayerToProcessor(processor, layer) {
+  if (layer.parsedDrillLayer && typeof processor.add_parsed_layer === "function") {
+    return {
+      outlineLayerId: processor.add_parsed_layer(layer.parsedDrillLayer.outlineLayer),
+      fillLayerId: processor.add_parsed_layer(layer.parsedDrillLayer.fillLayer),
+    };
+  }
+  if (typeof layer.content !== "string") {
+    throw new Error("Drill layer content is unavailable for rendering.");
+  }
+  if (layer.offsetX !== 0 || layer.offsetY !== 0) {
+    if (typeof processor.add_drill_layer_with_offset !== "function") {
+      throw new Error("Drill layer offsets require an updated WASM renderer.");
+    }
+    const result = processor.add_drill_layer_with_offset(
+      layer.content,
+      layer.offsetX,
+      layer.offsetY,
+    );
+    return normalizeDrillLayerIds(result);
+  }
+  if (typeof processor.add_drill_layer !== "function") {
+    throw new Error("Drill rendering requires an updated WASM renderer.");
+  }
+  return normalizeDrillLayerIds(processor.add_drill_layer(layer.content));
+}
+
+function normalizeDrillLayerIds(result) {
+  const outlineLayerId = Number(result?.outlineLayerId);
+  const fillLayerId = Number(result?.fillLayerId);
+  if (!Number.isInteger(outlineLayerId) || !Number.isInteger(fillLayerId)) {
+    throw new Error("Drill rendering did not return layer IDs.");
+  }
+  return { outlineLayerId, fillLayerId };
+}
+
+function getRenderLayerCount(layers) {
+  return layers.reduce(
+    (count, layer) => count + (isDrillLayerKind(layer.kind) ? 2 : 1),
+    0,
+  );
 }
 
 function supportsParsedLayerReuse(wasmModule) {

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -333,9 +333,11 @@ export class NodeGerberRenderer {
     if (isDrillLayerKind(prepared.kind) && !this.frame.options.renderDrills) {
       return null;
     }
+    const isDrill = isDrillLayerKind(prepared.kind);
     const layerId = this.frame.layers.length;
-    const color =
-      prepared.color == null
+    const color = isDrill
+      ? null
+      : prepared.color == null
         ? this.frame.nextColor()
         : normalizeColor(prepared.color, this.frame.options.colors[0], {
             allowString: true,

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -1205,7 +1205,7 @@ function createPlanRenderEntries(processor, plan) {
         layerId: fillLayerId,
         color: drillColors.fill,
         alpha,
-        blendMode: plan.background == null ? 2 : 1,
+        blendMode: drillColors.hasBackground ? 1 : 2,
       });
       continue;
     }

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -722,6 +722,7 @@ async function renderPlanToPngSink(renderer, plan, exportOptions, sink) {
   const width = positiveIntegerOrDefault(plan.width, DEFAULT_WIDTH);
   const height = positiveIntegerOrDefault(plan.height, DEFAULT_HEIGHT);
   const strategy = normalizeExportStrategy(exportOptions.strategy || plan.strategy);
+  const renderPlan = { ...plan, background: exportOptions.background };
   const background =
     exportOptions.background == null
       ? null
@@ -744,7 +745,7 @@ async function renderPlanToPngSink(renderer, plan, exportOptions, sink) {
     exportOptions.framebufferMemorySafetyFactor,
     plan.framebufferMemorySafetyFactor || DEFAULT_FRAMEBUFFER_MEMORY_SAFETY_FACTOR,
   );
-  const layerCount = Math.max(1, getRenderLayerCount(plan.layers));
+  const layerCount = Math.max(1, getRenderLayerCount(renderPlan.layers));
   const fullFrameEstimate = estimateFullFrameBytes(
     width,
     height,
@@ -755,7 +756,7 @@ async function renderPlanToPngSink(renderer, plan, exportOptions, sink) {
     height,
     getFullFrameRenderTargetCount(layerCount),
   );
-  if (plan.layers.length === 0 || !plan.view) {
+  if (renderPlan.layers.length === 0 || !renderPlan.view) {
     const blankTileHeight = getBlankStreamTileHeight(
       width,
       height,
@@ -790,7 +791,7 @@ async function renderPlanToPngSink(renderer, plan, exportOptions, sink) {
     try {
       await renderPlanToFullFramePngSink(
         renderer,
-        plan,
+        renderPlan,
         sink,
         width,
         height,
@@ -825,7 +826,7 @@ async function renderPlanToPngSink(renderer, plan, exportOptions, sink) {
   await writePngDocument(sink, width, height, pngColorType, async (writeRow) => {
     let streamState = createStreamRenderStateWithFallback(
       renderer,
-      plan,
+      renderPlan,
       tileWidth,
       width,
       height,
@@ -1204,7 +1205,7 @@ function createPlanRenderEntries(processor, plan) {
         layerId: fillLayerId,
         color: drillColors.fill,
         alpha,
-        blendMode: 1,
+        blendMode: plan.background == null ? 2 : 1,
       });
       continue;
     }

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -368,8 +368,8 @@ export class NodeGerberRenderer {
     });
     const offsetX = numberOrDefault(options.offsetX, 0);
     const offsetY = numberOrDefault(options.offsetY, 0);
-    const kind = normalizeLayerKind(options.kind, source, options.name);
-    if (isDrillLayerKind(kind) && options.renderDrills === false) {
+    const initialKind = normalizeLayerKind(options.kind, source, options.name);
+    if (isDrillLayerKind(initialKind) && options.renderDrills === false) {
       return null;
     }
     const content = await sourceToText(source, {
@@ -378,6 +378,12 @@ export class NodeGerberRenderer {
       sourceDescription:
         "a string, File, Blob, ArrayBuffer, Uint8Array, URL, or path config",
     });
+    const kind = isDrillLayerKind(initialKind)
+      ? initialKind
+      : normalizeLayerKind(options.kind, source, options.name, content);
+    if (isDrillLayerKind(kind) && options.renderDrills === false) {
+      return null;
+    }
     const parseOptions = normalizeParseOptions(options);
     const parsed = isDrillLayerKind(kind)
       ? parseDrillLayerPayload(this.wasmModule, content, offsetX, offsetY)

--- a/packages/wasm-gerber-renderer/package.json
+++ b/packages/wasm-gerber-renderer/package.json
@@ -44,7 +44,7 @@
     "prepack": "npm run build:wasm && npm run stage:wasm",
     "postpack": "npm run clean:wasm",
     "prepublishOnly": "npm run check",
-    "check": "node --check index.js && node --check node.js && node --check shared.js && node --check bin/wasm-gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs",
+    "check": "node --check index.js && node --check node.js && node --check shared.js && node --check bin/wasm-gerber-renderer.js && node --check scripts/stage-wasm.mjs && node --check scripts/clean-wasm.mjs && node --test test/*.test.mjs",
     "verify:publish": "npm run check && npm pack --dry-run"
   },
   "license": "MIT",

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -20,6 +20,157 @@ export const LAYER_KIND_GERBER = "gerber";
 export const LAYER_KIND_DRILL = "drill";
 
 const DRILL_FILE_EXTENSIONS = new Set([".drd", ".drl", ".nc", ".xnc", ".xln"]);
+const CSS_NAMED_COLORS = new Map([
+  ["aliceblue", [240, 248, 255, 255]],
+  ["antiquewhite", [250, 235, 215, 255]],
+  ["aqua", [0, 255, 255, 255]],
+  ["aquamarine", [127, 255, 212, 255]],
+  ["azure", [240, 255, 255, 255]],
+  ["beige", [245, 245, 220, 255]],
+  ["bisque", [255, 228, 196, 255]],
+  ["black", [0, 0, 0, 255]],
+  ["blanchedalmond", [255, 235, 205, 255]],
+  ["blue", [0, 0, 255, 255]],
+  ["blueviolet", [138, 43, 226, 255]],
+  ["brown", [165, 42, 42, 255]],
+  ["burlywood", [222, 184, 135, 255]],
+  ["cadetblue", [95, 158, 160, 255]],
+  ["chartreuse", [127, 255, 0, 255]],
+  ["chocolate", [210, 105, 30, 255]],
+  ["coral", [255, 127, 80, 255]],
+  ["cornflowerblue", [100, 149, 237, 255]],
+  ["cornsilk", [255, 248, 220, 255]],
+  ["crimson", [220, 20, 60, 255]],
+  ["cyan", [0, 255, 255, 255]],
+  ["darkblue", [0, 0, 139, 255]],
+  ["darkcyan", [0, 139, 139, 255]],
+  ["darkgoldenrod", [184, 134, 11, 255]],
+  ["darkgray", [169, 169, 169, 255]],
+  ["darkgreen", [0, 100, 0, 255]],
+  ["darkgrey", [169, 169, 169, 255]],
+  ["darkkhaki", [189, 183, 107, 255]],
+  ["darkmagenta", [139, 0, 139, 255]],
+  ["darkolivegreen", [85, 107, 47, 255]],
+  ["darkorange", [255, 140, 0, 255]],
+  ["darkorchid", [153, 50, 204, 255]],
+  ["darkred", [139, 0, 0, 255]],
+  ["darksalmon", [233, 150, 122, 255]],
+  ["darkseagreen", [143, 188, 143, 255]],
+  ["darkslateblue", [72, 61, 139, 255]],
+  ["darkslategray", [47, 79, 79, 255]],
+  ["darkslategrey", [47, 79, 79, 255]],
+  ["darkturquoise", [0, 206, 209, 255]],
+  ["darkviolet", [148, 0, 211, 255]],
+  ["deeppink", [255, 20, 147, 255]],
+  ["deepskyblue", [0, 191, 255, 255]],
+  ["dimgray", [105, 105, 105, 255]],
+  ["dimgrey", [105, 105, 105, 255]],
+  ["dodgerblue", [30, 144, 255, 255]],
+  ["firebrick", [178, 34, 34, 255]],
+  ["floralwhite", [255, 250, 240, 255]],
+  ["forestgreen", [34, 139, 34, 255]],
+  ["fuchsia", [255, 0, 255, 255]],
+  ["gainsboro", [220, 220, 220, 255]],
+  ["ghostwhite", [248, 248, 255, 255]],
+  ["gold", [255, 215, 0, 255]],
+  ["goldenrod", [218, 165, 32, 255]],
+  ["gray", [128, 128, 128, 255]],
+  ["green", [0, 128, 0, 255]],
+  ["greenyellow", [173, 255, 47, 255]],
+  ["grey", [128, 128, 128, 255]],
+  ["honeydew", [240, 255, 240, 255]],
+  ["hotpink", [255, 105, 180, 255]],
+  ["indianred", [205, 92, 92, 255]],
+  ["indigo", [75, 0, 130, 255]],
+  ["ivory", [255, 255, 240, 255]],
+  ["khaki", [240, 230, 140, 255]],
+  ["lavender", [230, 230, 250, 255]],
+  ["lavenderblush", [255, 240, 245, 255]],
+  ["lawngreen", [124, 252, 0, 255]],
+  ["lemonchiffon", [255, 250, 205, 255]],
+  ["lightblue", [173, 216, 230, 255]],
+  ["lightcoral", [240, 128, 128, 255]],
+  ["lightcyan", [224, 255, 255, 255]],
+  ["lightgoldenrodyellow", [250, 250, 210, 255]],
+  ["lightgray", [211, 211, 211, 255]],
+  ["lightgreen", [144, 238, 144, 255]],
+  ["lightgrey", [211, 211, 211, 255]],
+  ["lightpink", [255, 182, 193, 255]],
+  ["lightsalmon", [255, 160, 122, 255]],
+  ["lightseagreen", [32, 178, 170, 255]],
+  ["lightskyblue", [135, 206, 250, 255]],
+  ["lightslategray", [119, 136, 153, 255]],
+  ["lightslategrey", [119, 136, 153, 255]],
+  ["lightsteelblue", [176, 196, 222, 255]],
+  ["lightyellow", [255, 255, 224, 255]],
+  ["lime", [0, 255, 0, 255]],
+  ["limegreen", [50, 205, 50, 255]],
+  ["linen", [250, 240, 230, 255]],
+  ["magenta", [255, 0, 255, 255]],
+  ["maroon", [128, 0, 0, 255]],
+  ["mediumaquamarine", [102, 205, 170, 255]],
+  ["mediumblue", [0, 0, 205, 255]],
+  ["mediumorchid", [186, 85, 211, 255]],
+  ["mediumpurple", [147, 112, 219, 255]],
+  ["mediumseagreen", [60, 179, 113, 255]],
+  ["mediumslateblue", [123, 104, 238, 255]],
+  ["mediumspringgreen", [0, 250, 154, 255]],
+  ["mediumturquoise", [72, 209, 204, 255]],
+  ["mediumvioletred", [199, 21, 133, 255]],
+  ["midnightblue", [25, 25, 112, 255]],
+  ["mintcream", [245, 255, 250, 255]],
+  ["mistyrose", [255, 228, 225, 255]],
+  ["moccasin", [255, 228, 181, 255]],
+  ["navajowhite", [255, 222, 173, 255]],
+  ["navy", [0, 0, 128, 255]],
+  ["oldlace", [253, 245, 230, 255]],
+  ["olive", [128, 128, 0, 255]],
+  ["olivedrab", [107, 142, 35, 255]],
+  ["orange", [255, 165, 0, 255]],
+  ["orangered", [255, 69, 0, 255]],
+  ["orchid", [218, 112, 214, 255]],
+  ["palegoldenrod", [238, 232, 170, 255]],
+  ["palegreen", [152, 251, 152, 255]],
+  ["paleturquoise", [175, 238, 238, 255]],
+  ["palevioletred", [219, 112, 147, 255]],
+  ["papayawhip", [255, 239, 213, 255]],
+  ["peachpuff", [255, 218, 185, 255]],
+  ["peru", [205, 133, 63, 255]],
+  ["pink", [255, 192, 203, 255]],
+  ["plum", [221, 160, 221, 255]],
+  ["powderblue", [176, 224, 230, 255]],
+  ["purple", [128, 0, 128, 255]],
+  ["rebeccapurple", [102, 51, 153, 255]],
+  ["red", [255, 0, 0, 255]],
+  ["rosybrown", [188, 143, 143, 255]],
+  ["royalblue", [65, 105, 225, 255]],
+  ["saddlebrown", [139, 69, 19, 255]],
+  ["salmon", [250, 128, 114, 255]],
+  ["sandybrown", [244, 164, 96, 255]],
+  ["seagreen", [46, 139, 87, 255]],
+  ["seashell", [255, 245, 238, 255]],
+  ["sienna", [160, 82, 45, 255]],
+  ["silver", [192, 192, 192, 255]],
+  ["skyblue", [135, 206, 235, 255]],
+  ["slateblue", [106, 90, 205, 255]],
+  ["slategray", [112, 128, 144, 255]],
+  ["slategrey", [112, 128, 144, 255]],
+  ["snow", [255, 250, 250, 255]],
+  ["springgreen", [0, 255, 127, 255]],
+  ["steelblue", [70, 130, 180, 255]],
+  ["tan", [210, 180, 140, 255]],
+  ["teal", [0, 128, 128, 255]],
+  ["thistle", [216, 191, 216, 255]],
+  ["tomato", [255, 99, 71, 255]],
+  ["transparent", [0, 0, 0, 0]],
+  ["turquoise", [64, 224, 208, 255]],
+  ["violet", [238, 130, 238, 255]],
+  ["wheat", [245, 222, 179, 255]],
+  ["white", [255, 255, 255, 255]],
+  ["whitesmoke", [245, 245, 245, 255]],
+  ["yellow", [255, 255, 0, 255]],
+  ["yellowgreen", [154, 205, 50, 255]],
+]);
 
 export class FrameState {
   constructor(options, extra = {}) {
@@ -324,10 +475,11 @@ export function isDrillPath(path) {
 }
 
 export function resolveDrillRenderColors(background) {
-  const fill = normalizeDrillFillColor(background);
+  const { fill, hasBackground } = normalizeDrillFillColor(background);
   return {
     fill,
     outline: [1 - fill[0], 1 - fill[1], 1 - fill[2]],
+    hasBackground,
   };
 }
 
@@ -513,6 +665,16 @@ export function parseColor(color, allowAlpha = false) {
 
   if (typeof color !== "string") {
     throw new TypeError("Color must be a CSS hex/rgb string or RGBA array.");
+  }
+
+  const namedColor = CSS_NAMED_COLORS.get(color.trim().toLowerCase());
+  if (namedColor) {
+    return [
+      namedColor[0],
+      namedColor[1],
+      namedColor[2],
+      allowAlpha ? namedColor[3] : 255,
+    ];
   }
 
   const hex = color.trim().match(/^#([0-9a-f]{3,8})$/i);
@@ -903,12 +1065,17 @@ function isLayerConfig(value) {
 
 function normalizeDrillFillColor(background) {
   if (background == null) {
-    return [0, 0, 0];
+    return { fill: [0, 0, 0], hasBackground: false };
   }
   try {
-    return parseColor(background, true).slice(0, 3).map((value) => value / 255);
+    const color = parseColor(background, true);
+    const fill = color.slice(0, 3).map((value) => value / 255);
+    if (color[3] !== 255) {
+      return { fill, hasBackground: false };
+    }
+    return { fill, hasBackground: true };
   } catch (_error) {
-    return [0, 0, 0];
+    return { fill: [0, 0, 0], hasBackground: false };
   }
 }
 

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -16,6 +16,10 @@ export const DEFAULT_BACKGROUND = null;
 export const DEFAULT_GLOBAL_ALPHA = 0.7;
 export const DEFAULT_MINIMUM_FEATURE_PIXELS = 1;
 export const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
+export const LAYER_KIND_GERBER = "gerber";
+export const LAYER_KIND_DRILL = "drill";
+
+const DRILL_FILE_EXTENSIONS = new Set([".drl", ".nc", ".xnc", ".xln"]);
 
 export class FrameState {
   constructor(options, extra = {}) {
@@ -52,7 +56,10 @@ export class FrameState {
         name: layer.name,
         bounds: layer.bounds,
         color: layer.color,
-        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
+        alpha: resolveLayerAlpha(
+          layer.alpha,
+          isDrillLayerKind(layer.kind) ? 1 : globalAlpha,
+        ),
       })),
     };
   }
@@ -76,6 +83,7 @@ export function createBaseFrameOptions(frameOptions = {}) {
       frameOptions.minimumFeaturePixels,
       DEFAULT_MINIMUM_FEATURE_PIXELS,
     ),
+    renderDrills: frameOptions.renderDrills !== false,
     globalAlpha: numberOrDefault(frameOptions.globalAlpha, DEFAULT_GLOBAL_ALPHA),
     colors: DEFAULT_COLORS.map((color) => [...color]),
   };
@@ -147,6 +155,19 @@ export function addLayerToProcessor(processor, content, offsetX, offsetY) {
   return processor.add_layer(content);
 }
 
+export function addDrillLayerToProcessor(processor, content, offsetX, offsetY) {
+  if (offsetX !== 0 || offsetY !== 0) {
+    if (typeof processor.add_drill_layer_with_offset !== "function") {
+      throw new Error("Drill layer offsets require an updated WASM renderer.");
+    }
+    return processor.add_drill_layer_with_offset(content, offsetX, offsetY);
+  }
+  if (typeof processor.add_drill_layer !== "function") {
+    throw new Error("Drill rendering requires an updated WASM renderer.");
+  }
+  return processor.add_drill_layer(content);
+}
+
 export function normalizeParseOptions(options = {}) {
   return {
     preserveArcRegions: options.preserveArcRegions !== false,
@@ -178,8 +199,10 @@ export async function renderLayersBestEffort(renderer, layers, options = {}) {
 
   for (const layer of layers) {
     try {
-      await renderer.renderLayer(layer);
-      renderedCount += 1;
+      const layerId = await renderer.renderLayer(layer);
+      if (layerId != null) {
+        renderedCount += 1;
+      }
     } catch (error) {
       const failure = {
         layer,
@@ -215,7 +238,10 @@ export async function loadLayersBestEffort(renderer, layers, options = {}) {
 
   for (const layer of layers) {
     try {
-      preparedLayers.push(await renderer.loadLayer(layer, layerOptions));
+      const preparedLayer = await renderer.loadLayer(layer, layerOptions);
+      if (preparedLayer) {
+        preparedLayers.push(preparedLayer);
+      }
     } catch (error) {
       const failure = {
         layer,
@@ -265,6 +291,68 @@ export function normalizeLayer(layer, layerOptions = {}, options = {}) {
   return {
     source: layer,
     options: { ...layerOptions },
+  };
+}
+
+export function normalizeLayerKind(kind, source, name = "") {
+  if (kind == null || kind === "") {
+    return isDrillSource(source, name) ? LAYER_KIND_DRILL : LAYER_KIND_GERBER;
+  }
+
+  const normalized = String(kind).toLowerCase();
+  if (normalized === LAYER_KIND_GERBER || normalized === LAYER_KIND_DRILL) {
+    return normalized;
+  }
+  throw new TypeError("Layer kind must be 'gerber' or 'drill'.");
+}
+
+export function isDrillLayerKind(kind) {
+  return kind === LAYER_KIND_DRILL;
+}
+
+export function isDrillSource(source, name = "") {
+  const sourceName = getSourceName(source);
+  return Boolean(
+    (name && isDrillPath(name)) || (sourceName && isDrillPath(sourceName)),
+  );
+}
+
+export function isDrillPath(path) {
+  const normalized = String(path).toLowerCase();
+  const dotIndex = normalized.lastIndexOf(".");
+  return dotIndex >= 0 && DRILL_FILE_EXTENSIONS.has(normalized.slice(dotIndex));
+}
+
+export function resolveDrillRenderColors(background) {
+  const fill = normalizeDrillFillColor(background);
+  return {
+    fill,
+    outline: [1 - fill[0], 1 - fill[1], 1 - fill[2]],
+  };
+}
+
+export function parseDrillLayerPayload(wasmModule, content, offsetX, offsetY) {
+  if (typeof wasmModule.parse_drill_layer !== "function") {
+    throw new Error("Drill parsing requires an updated WASM renderer.");
+  }
+  const payload = wasmModule.parse_drill_layer(content, offsetX, offsetY);
+  const outlineLayer = payload?.outlineLayer;
+  const fillLayer = payload?.fillLayer;
+  if (!outlineLayer || !fillLayer) {
+    throw new Error("Drill parsing did not return renderable layers.");
+  }
+  const bounds = mergeBounds(
+    payloadBounds(outlineLayer),
+    payloadBounds(fillLayer),
+  );
+  if (!bounds) {
+    throw new Error("File does not contain valid drill data (no holes found)");
+  }
+  return {
+    outlineLayer,
+    fillLayer,
+    metadata: payload.metadata ?? null,
+    bounds,
   };
 }
 
@@ -330,6 +418,15 @@ export function getLayerFailureName(layer) {
     }
   }
   return getSourceName(layer) || "Layer";
+}
+
+export function payloadBounds(payload) {
+  const sublayers = Array.from(payload?.sublayers ?? []);
+  let bounds = null;
+  for (const sublayer of sublayers) {
+    bounds = mergeBounds(bounds, boundaryToPlainObject(sublayer.boundary));
+  }
+  return bounds;
 }
 
 export function resolveFrameView(frameOptions, bounds, width, height) {
@@ -802,6 +899,17 @@ function isLayerConfig(value) {
     !isBlob(value) &&
     !isArrayBufferLike(value)
   );
+}
+
+function normalizeDrillFillColor(background) {
+  if (background == null) {
+    return [0, 0, 0];
+  }
+  try {
+    return parseColor(background, true).slice(0, 3).map((value) => value / 255);
+  } catch (_error) {
+    return [0, 0, 0];
+  }
 }
 
 function isBlob(value) {

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -19,7 +19,7 @@ export const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
 export const LAYER_KIND_GERBER = "gerber";
 export const LAYER_KIND_DRILL = "drill";
 
-const DRILL_FILE_EXTENSIONS = new Set([".drl", ".nc", ".xnc", ".xln"]);
+const DRILL_FILE_EXTENSIONS = new Set([".drd", ".drl", ".nc", ".xnc", ".xln"]);
 
 export class FrameState {
   constructor(options, extra = {}) {

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -19,7 +19,7 @@ export const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
 export const LAYER_KIND_GERBER = "gerber";
 export const LAYER_KIND_DRILL = "drill";
 
-const DRILL_FILE_EXTENSIONS = new Set([".drd", ".drl", ".nc", ".xnc", ".xln"]);
+const DRILL_FILE_EXTENSIONS = new Set([".drl", ".nc", ".xnc", ".xln"]);
 const CSS_NAMED_COLORS = new Map([
   ["aliceblue", [240, 248, 255, 255]],
   ["antiquewhite", [250, 235, 215, 255]],
@@ -445,9 +445,9 @@ export function normalizeLayer(layer, layerOptions = {}, options = {}) {
   };
 }
 
-export function normalizeLayerKind(kind, source, name = "") {
+export function normalizeLayerKind(kind, source, name = "", content = "") {
   if (kind == null || kind === "") {
-    return isDrillSource(source, name) ? LAYER_KIND_DRILL : LAYER_KIND_GERBER;
+    return isDrillSource(source, name, content) ? LAYER_KIND_DRILL : LAYER_KIND_GERBER;
   }
 
   const normalized = String(kind).toLowerCase();
@@ -461,10 +461,14 @@ export function isDrillLayerKind(kind) {
   return kind === LAYER_KIND_DRILL;
 }
 
-export function isDrillSource(source, name = "") {
+export function isDrillSource(source, name = "", content = "") {
   const sourceName = getSourceName(source);
+  const hasDrillPath = (name && isDrillPath(name)) || (sourceName && isDrillPath(sourceName));
+  const hasAmbiguousDrdPath =
+    (name && isAmbiguousDrdPath(name)) || (sourceName && isAmbiguousDrdPath(sourceName));
+  const hasSourcePath = Boolean(sourceName || (name && hasFileExtension(name)));
   return Boolean(
-    (name && isDrillPath(name)) || (sourceName && isDrillPath(sourceName)),
+    hasDrillPath || ((!hasSourcePath || hasAmbiguousDrdPath) && looksLikeDrillContent(content)),
   );
 }
 
@@ -472,6 +476,31 @@ export function isDrillPath(path) {
   const normalized = String(path).toLowerCase();
   const dotIndex = normalized.lastIndexOf(".");
   return dotIndex >= 0 && DRILL_FILE_EXTENSIONS.has(normalized.slice(dotIndex));
+}
+
+function isAmbiguousDrdPath(path) {
+  const normalized = String(path).toLowerCase();
+  return normalized.endsWith(".drd");
+}
+
+function hasFileExtension(path) {
+  const fileName = fileBasename(String(path));
+  const dotIndex = fileName.lastIndexOf(".");
+  return dotIndex > 0 && dotIndex < fileName.length - 1;
+}
+
+export function looksLikeDrillContent(content) {
+  const lines = String(content ?? "")
+    .split(/\r?\n/, 80)
+    .map((line) => line.trim().toUpperCase());
+  if (lines.some((line) => line === "M48")) {
+    return true;
+  }
+  const hasToolDeclaration = lines.some((line) => /^T\d+C[+\-.\d]+/.test(line));
+  const hasDrillCommand = lines.some((line) =>
+    /^(METRIC|INCH|M71|M72|G05|G90|G91|ICI,ON|ICI,OFF)\b/.test(line),
+  );
+  return hasToolDeclaration && hasDrillCommand;
 }
 
 export function resolveDrillRenderColors(background) {

--- a/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
+++ b/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getLayerSourceKind,
+} from "../../../js/file-utils.js";
+import {
+  collectLayerSources,
+} from "../../../js/source-loader.js";
+import { GerberRenderer } from "../index.js";
+import { fileLayer, NodeGerberRenderer } from "../node.js";
+import { normalizeLayerKind } from "../shared.js";
+
+const DRILL_CONTENT = `M48
+METRIC,LZ
+T01C0.6
+%
+T01
+X00090000Y00100000
+M30`;
+
+const GERBER_CONTENT = `%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1*%
+D10*
+X0Y0D03*
+M02*`;
+
+test("viewer layer kind keeps ambiguous .drd Gerbers as Gerber", () => {
+  assert.equal(getLayerSourceKind("board.drd", GERBER_CONTENT), "gerber");
+  assert.equal(getLayerSourceKind("holes.drd", DRILL_CONTENT), "drill");
+  assert.equal(getLayerSourceKind("holes.drl", GERBER_CONTENT), "drill");
+});
+
+test("viewer source loader inspects regular .drd file previews", async () => {
+  const sources = await collectLayerSources([
+    new File([DRILL_CONTENT], "holes.drd", { type: "text/plain" }),
+    new File([GERBER_CONTENT], "board.drd", { type: "text/plain" }),
+  ]);
+
+  assert.equal(sources.length, 2);
+  assert.equal(sources[0].kind, "drill");
+  assert.equal(sources[1].kind, "gerber");
+  assert.equal(await sources[0].readText(), DRILL_CONTENT);
+  assert.equal(await sources[1].readText(), GERBER_CONTENT);
+});
+
+test("viewer ZIP .drd preview failure does not poison readText", async () => {
+  let readCount = 0;
+  const entry = {
+    dir: false,
+    name: "board.drd",
+    _data: { uncompressedSize: GERBER_CONTENT.length },
+    async async(_type, onProgress) {
+      readCount += 1;
+      onProgress?.({ percent: 100 });
+      if (readCount === 1) {
+        throw new Error("preview failed");
+      }
+      return GERBER_CONTENT;
+    },
+  };
+  const warnings = [];
+  const sources = await collectLayerSources(
+    [new File(["zip"], "layers.zip", { type: "application/zip" })],
+    {
+      jsZip: {
+        async loadAsync() {
+          return { files: { "board.drd": entry } };
+        },
+      },
+      onArchiveWarning(_name, message) {
+        warnings.push(message);
+      },
+    },
+  );
+
+  assert.equal(sources.length, 1);
+  assert.equal(sources[0].kind, "gerber");
+  assert.match(warnings[0], /Could not inspect board\.drd/);
+  assert.equal(await sources[0].readText(), GERBER_CONTENT);
+  assert.equal(readCount, 2);
+});
+
+test("package layer kind uses source paths, names, and raw content deliberately", () => {
+  assert.equal(normalizeLayerKind(null, { path: "holes.drl" }), "drill");
+  assert.equal(normalizeLayerKind(null, { path: "holes.drd" }, "", DRILL_CONTENT), "drill");
+  assert.equal(normalizeLayerKind(null, { path: "board.drd" }, "", GERBER_CONTENT), "gerber");
+  assert.equal(normalizeLayerKind(null, GERBER_CONTENT, "holes.drl"), "drill");
+  assert.equal(normalizeLayerKind(null, DRILL_CONTENT, "", DRILL_CONTENT), "drill");
+  assert.equal(normalizeLayerKind(null, DRILL_CONTENT, "Drills", DRILL_CONTENT), "drill");
+  assert.equal(normalizeLayerKind(null, DRILL_CONTENT, "board.gbr", DRILL_CONTENT), "gerber");
+  assert.equal(normalizeLayerKind("drill", GERBER_CONTENT, "board.gbr"), "drill");
+});
+
+test("renderDrills false skips drill sources before reading", async () => {
+  const unreadableFile = {
+    name: "holes.drl",
+    async text() {
+      throw new Error("source should not be read");
+    },
+  };
+
+  const browserRecord = await GerberRenderer.prototype.createLayerRecord.call(
+    { frame: { options: { renderDrills: false } } },
+    { source: unreadableFile },
+    {},
+  );
+  assert.equal(browserRecord, null);
+
+  const nodeRecord = await NodeGerberRenderer.prototype.createPreparedLayer.call(
+    { wasmModule: {} },
+    fileLayer("/missing/holes.drl"),
+    { renderDrills: false },
+  );
+  assert.equal(nodeRecord, null);
+});

--- a/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
+++ b/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
@@ -34,8 +34,8 @@ test("viewer layer kind keeps ambiguous .drd Gerbers as Gerber", () => {
 
 test("viewer source loader inspects regular .drd file previews", async () => {
   const sources = await collectLayerSources([
-    new File([DRILL_CONTENT], "holes.drd", { type: "text/plain" }),
-    new File([GERBER_CONTENT], "board.drd", { type: "text/plain" }),
+    makeFile(DRILL_CONTENT, "holes.drd", "text/plain"),
+    makeFile(GERBER_CONTENT, "board.drd", "text/plain"),
   ]);
 
   assert.equal(sources.length, 2);
@@ -62,7 +62,7 @@ test("viewer ZIP .drd preview failure does not poison readText", async () => {
   };
   const warnings = [];
   const sources = await collectLayerSources(
-    [new File(["zip"], "layers.zip", { type: "application/zip" })],
+    [makeFile("zip", "layers.zip", "application/zip")],
     {
       jsZip: {
         async loadAsync() {
@@ -81,6 +81,17 @@ test("viewer ZIP .drd preview failure does not poison readText", async () => {
   assert.equal(await sources[0].readText(), GERBER_CONTENT);
   assert.equal(readCount, 2);
 });
+
+function makeFile(content, name, type = "") {
+  const blob = new Blob([content], { type });
+  return {
+    name,
+    type,
+    size: blob.size,
+    slice: (...args) => blob.slice(...args),
+    text: () => blob.text(),
+  };
+}
 
 test("package layer kind uses source paths, names, and raw content deliberately", () => {
   assert.equal(normalizeLayerKind(null, { path: "holes.drl" }), "drill");

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -1,0 +1,1098 @@
+use crate::shape::{
+    Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
+    Triangles,
+};
+use js_sys::{Array, Object, Reflect};
+use std::collections::BTreeMap;
+use wasm_bindgen::prelude::*;
+
+const INCH_TO_MM: f32 = 25.4;
+const TWO_PI: f32 = std::f32::consts::PI * 2.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Unit {
+    Metric,
+    Inch,
+}
+
+impl Unit {
+    fn multiplier(self) -> f32 {
+        match self {
+            Unit::Metric => 1.0,
+            Unit::Inch => INCH_TO_MM,
+        }
+    }
+
+    fn default_decimal_digits(self) -> u32 {
+        match self {
+            Unit::Metric => 3,
+            Unit::Inch => 4,
+        }
+    }
+
+    fn default_integer_digits(self) -> u32 {
+        match self {
+            Unit::Metric => 3,
+            Unit::Inch => 2,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ZeroSuppression {
+    Leading,
+    Trailing,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CoordinateFormat {
+    integer_digits: u32,
+    decimal_digits: u32,
+    zero_suppression: ZeroSuppression,
+}
+
+impl CoordinateFormat {
+    fn new(unit: Unit) -> Self {
+        Self {
+            integer_digits: unit.default_integer_digits(),
+            decimal_digits: unit.default_decimal_digits(),
+            zero_suppression: ZeroSuppression::Leading,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Mode {
+    Drill,
+    Rout,
+}
+
+#[derive(Clone, Debug)]
+struct Tool {
+    diameter_mm: f32,
+    hit_count: u32,
+    slot_count: u32,
+}
+
+#[derive(Debug)]
+pub struct DrillToolMetadata {
+    code: u32,
+    diameter_mm: f32,
+    hit_count: u32,
+    slot_count: u32,
+}
+
+impl DrillToolMetadata {
+    fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "code", JsValue::from_f64(self.code as f64))?;
+        set_property(
+            &object,
+            "diameterMm",
+            JsValue::from_f64(self.diameter_mm as f64),
+        )?;
+        set_property(
+            &object,
+            "hitCount",
+            JsValue::from_f64(self.hit_count as f64),
+        )?;
+        set_property(
+            &object,
+            "slotCount",
+            JsValue::from_f64(self.slot_count as f64),
+        )?;
+        Ok(object.into())
+    }
+}
+
+#[derive(Debug)]
+pub struct DrillMetadata {
+    tools: Vec<DrillToolMetadata>,
+    hit_count: u32,
+    slot_count: u32,
+}
+
+impl DrillMetadata {
+    pub fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        let tools = Array::new();
+        for tool in &self.tools {
+            tools.push(&tool.to_js()?);
+        }
+
+        set_property(&object, "tools", tools.into())?;
+        set_property(
+            &object,
+            "hitCount",
+            JsValue::from_f64(self.hit_count as f64),
+        )?;
+        set_property(
+            &object,
+            "slotCount",
+            JsValue::from_f64(self.slot_count as f64),
+        )?;
+        Ok(object.into())
+    }
+}
+
+pub struct DrillParseResult {
+    pub fill_layer: GerberData,
+    pub outline_layer: GerberData,
+    pub metadata: DrillMetadata,
+}
+
+#[derive(Default)]
+struct DrillGeometry {
+    circle_x: Vec<f32>,
+    circle_y: Vec<f32>,
+    circle_radius: Vec<f32>,
+    line_start_x: Vec<f32>,
+    line_start_y: Vec<f32>,
+    line_end_x: Vec<f32>,
+    line_end_y: Vec<f32>,
+    line_width: Vec<f32>,
+    arc_x: Vec<f32>,
+    arc_y: Vec<f32>,
+    arc_radius: Vec<f32>,
+    arc_start_angle: Vec<f32>,
+    arc_sweep_angle: Vec<f32>,
+    arc_thickness: Vec<f32>,
+    min_x: f32,
+    max_x: f32,
+    min_y: f32,
+    max_y: f32,
+    has_geometry: bool,
+}
+
+impl DrillGeometry {
+    fn new() -> Self {
+        Self {
+            min_x: f32::INFINITY,
+            max_x: f32::NEG_INFINITY,
+            min_y: f32::INFINITY,
+            max_y: f32::NEG_INFINITY,
+            ..Self::default()
+        }
+    }
+
+    fn push_circle(&mut self, x: f32, y: f32, radius: f32) {
+        self.circle_x.push(x);
+        self.circle_y.push(y);
+        self.circle_radius.push(radius);
+        self.include_circle_bounds(x, y, radius);
+    }
+
+    fn push_line(&mut self, start_x: f32, start_y: f32, end_x: f32, end_y: f32, width: f32) {
+        self.line_start_x.push(start_x);
+        self.line_start_y.push(start_y);
+        self.line_end_x.push(end_x);
+        self.line_end_y.push(end_y);
+        self.line_width.push(width);
+
+        let radius = width / 2.0;
+        self.include_circle_bounds(start_x, start_y, radius);
+        self.include_circle_bounds(end_x, end_y, radius);
+    }
+
+    fn push_arc(
+        &mut self,
+        center_x: f32,
+        center_y: f32,
+        radius: f32,
+        start_angle: f32,
+        sweep_angle: f32,
+        thickness: f32,
+    ) {
+        self.arc_x.push(center_x);
+        self.arc_y.push(center_y);
+        self.arc_radius.push(radius);
+        self.arc_start_angle.push(start_angle);
+        self.arc_sweep_angle.push(sweep_angle);
+        self.arc_thickness.push(thickness);
+        self.include_circle_bounds(center_x, center_y, radius + thickness / 2.0);
+    }
+
+    fn include_circle_bounds(&mut self, x: f32, y: f32, radius: f32) {
+        self.min_x = self.min_x.min(x - radius);
+        self.max_x = self.max_x.max(x + radius);
+        self.min_y = self.min_y.min(y - radius);
+        self.max_y = self.max_y.max(y + radius);
+        self.has_geometry = true;
+    }
+
+    fn boundary(&self) -> Boundary {
+        if !self.has_geometry {
+            return Boundary::new(0.0, 0.0, 0.0, 0.0);
+        }
+
+        Boundary::new(self.min_x, self.max_x, self.min_y, self.max_y)
+    }
+
+    fn into_layer(self) -> GerberData {
+        let boundary = self.boundary();
+        GerberData::new(
+            Triangles::new(Vec::new(), Vec::new(), Vec::new(), Vec::new()),
+            Vec::<TriangleTemplateInstances>::new(),
+            Lines::new(
+                self.line_start_x,
+                self.line_start_y,
+                self.line_end_x,
+                self.line_end_y,
+                self.line_width,
+            ),
+            Circles::new(
+                self.circle_x,
+                self.circle_y,
+                self.circle_radius,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+            Arcs::new(
+                self.arc_x,
+                self.arc_y,
+                self.arc_radius,
+                self.arc_start_angle,
+                self.arc_sweep_angle,
+                self.arc_thickness,
+            ),
+            Thermals::new(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+            PathRegions::empty(),
+            boundary,
+            false,
+        )
+    }
+}
+
+#[derive(Debug)]
+struct CoordinateWords {
+    x: Option<f32>,
+    y: Option<f32>,
+    i: Option<f32>,
+    j: Option<f32>,
+    a: Option<f32>,
+}
+
+struct DrillParser {
+    unit: Unit,
+    coordinate_format: CoordinateFormat,
+    mode: Mode,
+    is_absolute: bool,
+    routing_down: bool,
+    current_tool: Option<u32>,
+    current_x: f32,
+    current_y: f32,
+    tools: BTreeMap<u32, Tool>,
+    fill: DrillGeometry,
+    outline: DrillGeometry,
+    outline_width_mm: f32,
+    offset_x: f32,
+    offset_y: f32,
+}
+
+impl DrillParser {
+    fn new(outline_width_mm: f32, offset_x: f32, offset_y: f32) -> Result<Self, JsValue> {
+        if !offset_x.is_finite() || !offset_y.is_finite() {
+            return Err(JsValue::from_str("Drill layer offset must be finite"));
+        }
+
+        Ok(Self {
+            unit: Unit::Metric,
+            coordinate_format: CoordinateFormat::new(Unit::Metric),
+            mode: Mode::Drill,
+            is_absolute: true,
+            routing_down: false,
+            current_tool: None,
+            current_x: 0.0,
+            current_y: 0.0,
+            tools: BTreeMap::new(),
+            fill: DrillGeometry::new(),
+            outline: DrillGeometry::new(),
+            outline_width_mm: outline_width_mm.max(0.0),
+            offset_x,
+            offset_y,
+        })
+    }
+
+    fn parse(mut self, content: &str) -> Result<DrillParseResult, JsValue> {
+        for raw_line in content.lines() {
+            let line = sanitize_line(raw_line);
+            if line.is_empty() {
+                continue;
+            }
+            self.parse_line(&line)?;
+        }
+
+        if !self.fill.has_geometry {
+            return Err(JsValue::from_str(
+                "File does not contain valid drill data (no holes found)",
+            ));
+        }
+
+        let hit_count = self.tools.values().map(|tool| tool.hit_count).sum();
+        let slot_count = self.tools.values().map(|tool| tool.slot_count).sum();
+        let tools = self
+            .tools
+            .iter()
+            .filter_map(|(&code, tool)| {
+                (tool.hit_count > 0 || tool.slot_count > 0).then_some(DrillToolMetadata {
+                    code,
+                    diameter_mm: tool.diameter_mm,
+                    hit_count: tool.hit_count,
+                    slot_count: tool.slot_count,
+                })
+            })
+            .collect();
+
+        Ok(DrillParseResult {
+            fill_layer: self.fill.into_layer(),
+            outline_layer: self.outline.into_layer(),
+            metadata: DrillMetadata {
+                tools,
+                hit_count,
+                slot_count,
+            },
+        })
+    }
+
+    fn parse_line(&mut self, line: &str) -> Result<(), JsValue> {
+        if line == "M48" || line == "%" || line == "M30" || line.starts_with("FMAT") {
+            return Ok(());
+        }
+
+        if line == "G05" {
+            self.mode = Mode::Drill;
+            self.routing_down = false;
+            return Ok(());
+        }
+        if line == "M15" {
+            self.routing_down = true;
+            return Ok(());
+        }
+        if line == "M16" {
+            self.routing_down = false;
+            return Ok(());
+        }
+        if line == "G90" {
+            self.is_absolute = true;
+            return Ok(());
+        }
+        if line == "G91" {
+            self.is_absolute = false;
+            return Ok(());
+        }
+        if line.starts_with("METRIC") {
+            self.set_unit(Unit::Metric, line)?;
+            return Ok(());
+        }
+        if line == "M71" {
+            self.set_unit_code(Unit::Metric);
+            return Ok(());
+        }
+        if line.starts_with("INCH") {
+            self.set_unit(Unit::Inch, line)?;
+            return Ok(());
+        }
+        if line == "M72" {
+            self.set_unit_code(Unit::Inch);
+            return Ok(());
+        }
+
+        if let Some((code, diameter)) = parse_tool_declaration(line, self.unit)? {
+            self.tools.insert(
+                code,
+                Tool {
+                    diameter_mm: diameter,
+                    hit_count: 0,
+                    slot_count: 0,
+                },
+            );
+            return Ok(());
+        }
+
+        if let Some(code) = parse_tool_selection(line) {
+            if code == 0 {
+                self.current_tool = None;
+                return Ok(());
+            }
+            if !self.tools.contains_key(&code) {
+                return Err(JsValue::from_str(&format!(
+                    "Drill file selects undefined tool T{code}"
+                )));
+            }
+            self.current_tool = Some(code);
+            return Ok(());
+        }
+
+        if line.starts_with("G00") {
+            self.mode = Mode::Rout;
+            if let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)? {
+                let (x, y) = self.resolve_xy(words.x, words.y);
+                self.current_x = x;
+                self.current_y = y;
+            }
+            return Ok(());
+        }
+
+        if line.starts_with("G01") {
+            let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
+            else {
+                return Ok(());
+            };
+            let (end_x, end_y) = self.resolve_xy(words.x, words.y);
+            if self.mode == Mode::Rout && self.routing_down {
+                self.push_slot(end_x, end_y)?;
+            }
+            self.current_x = end_x;
+            self.current_y = end_y;
+            return Ok(());
+        }
+
+        if line.starts_with("G02") || line.starts_with("G03") {
+            let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
+            else {
+                return Ok(());
+            };
+            let (end_x, end_y) = self.resolve_xy(words.x, words.y);
+            if self.mode == Mode::Rout && self.routing_down {
+                self.push_arc(end_x, end_y, words, line.starts_with("G03"))?;
+            }
+            self.current_x = end_x;
+            self.current_y = end_y;
+            return Ok(());
+        }
+
+        if let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)? {
+            let (x, y) = self.resolve_xy(words.x, words.y);
+            if self.mode == Mode::Drill {
+                self.push_hit(x, y)?;
+            }
+            self.current_x = x;
+            self.current_y = y;
+        }
+
+        Ok(())
+    }
+
+    fn resolve_xy(&self, x: Option<f32>, y: Option<f32>) -> (f32, f32) {
+        let x = x.unwrap_or(self.current_x);
+        let y = y.unwrap_or(self.current_y);
+
+        if self.is_absolute {
+            (x, y)
+        } else {
+            (self.current_x + x, self.current_y + y)
+        }
+    }
+
+    fn set_unit(&mut self, unit: Unit, line: &str) -> Result<(), JsValue> {
+        self.unit = unit;
+        let mut format = CoordinateFormat::new(unit);
+        for token in line.split(',').skip(1) {
+            match token {
+                "LZ" => format.zero_suppression = ZeroSuppression::Leading,
+                "TZ" => format.zero_suppression = ZeroSuppression::Trailing,
+                _ => {
+                    if let Some((integer_digits, decimal_digits)) = parse_format_token(token)? {
+                        format.integer_digits = integer_digits;
+                        format.decimal_digits = decimal_digits;
+                    }
+                }
+            }
+        }
+        self.coordinate_format = format;
+        Ok(())
+    }
+
+    fn set_unit_code(&mut self, unit: Unit) {
+        if self.unit != unit {
+            self.coordinate_format.integer_digits = unit.default_integer_digits();
+            self.coordinate_format.decimal_digits = unit.default_decimal_digits();
+        }
+        self.unit = unit;
+    }
+
+    fn selected_tool(&self) -> Result<(u32, f32), JsValue> {
+        let code = self
+            .current_tool
+            .ok_or_else(|| JsValue::from_str("Drill hit appears before tool selection"))?;
+        let tool = self.tools.get(&code).ok_or_else(|| {
+            JsValue::from_str(&format!("Selected drill tool T{code} is undefined"))
+        })?;
+        Ok((code, tool.diameter_mm))
+    }
+
+    fn push_hit(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
+        let (code, diameter_mm) = self.selected_tool()?;
+        if diameter_mm <= 0.0 || !diameter_mm.is_finite() {
+            return Err(JsValue::from_str(&format!(
+                "Drill tool T{code} has invalid diameter"
+            )));
+        }
+
+        let x = x + self.offset_x;
+        let y = y + self.offset_y;
+        let radius = diameter_mm / 2.0;
+        self.outline
+            .push_circle(x, y, radius + self.outline_width_mm);
+        self.fill.push_circle(x, y, radius);
+        if let Some(tool) = self.tools.get_mut(&code) {
+            tool.hit_count = tool.hit_count.saturating_add(1);
+        }
+        Ok(())
+    }
+
+    fn push_slot(&mut self, end_x: f32, end_y: f32) -> Result<(), JsValue> {
+        let (code, diameter_mm) = self.selected_tool()?;
+        if diameter_mm <= 0.0 || !diameter_mm.is_finite() {
+            return Err(JsValue::from_str(&format!(
+                "Drill tool T{code} has invalid diameter"
+            )));
+        }
+
+        let start_x = self.current_x + self.offset_x;
+        let start_y = self.current_y + self.offset_y;
+        let end_x = end_x + self.offset_x;
+        let end_y = end_y + self.offset_y;
+        self.outline.push_line(
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            diameter_mm + self.outline_width_mm * 2.0,
+        );
+        self.fill
+            .push_line(start_x, start_y, end_x, end_y, diameter_mm);
+        if let Some(tool) = self.tools.get_mut(&code) {
+            tool.slot_count = tool.slot_count.saturating_add(1);
+        }
+        Ok(())
+    }
+
+    fn push_arc(
+        &mut self,
+        end_x: f32,
+        end_y: f32,
+        words: CoordinateWords,
+        ccw: bool,
+    ) -> Result<(), JsValue> {
+        let (code, diameter_mm) = self.selected_tool()?;
+        if diameter_mm <= 0.0 || !diameter_mm.is_finite() {
+            return Err(JsValue::from_str(&format!(
+                "Drill tool T{code} has invalid diameter"
+            )));
+        }
+
+        let arc = if let Some(radius) = words.a {
+            arc_from_radius(self.current_x, self.current_y, end_x, end_y, radius, ccw)?
+        } else if let (Some(i), Some(j)) = (words.i, words.j) {
+            arc_from_center_offset(self.current_x, self.current_y, end_x, end_y, i, j, ccw)?
+        } else {
+            return Err(JsValue::from_str(
+                "Circular drill rout requires A radius or I/J center offset",
+            ));
+        };
+
+        let center_x = arc.center_x + self.offset_x;
+        let center_y = arc.center_y + self.offset_y;
+        self.outline.push_arc(
+            center_x,
+            center_y,
+            arc.radius,
+            arc.start_angle,
+            arc.sweep_angle,
+            diameter_mm + self.outline_width_mm * 2.0,
+        );
+        self.fill.push_arc(
+            center_x,
+            center_y,
+            arc.radius,
+            arc.start_angle,
+            arc.sweep_angle,
+            diameter_mm,
+        );
+        if let Some(tool) = self.tools.get_mut(&code) {
+            tool.slot_count = tool.slot_count.saturating_add(1);
+        }
+        Ok(())
+    }
+}
+
+struct DrillArc {
+    center_x: f32,
+    center_y: f32,
+    radius: f32,
+    start_angle: f32,
+    sweep_angle: f32,
+}
+
+pub fn parse_drill_with_offset(
+    content: &str,
+    outline_width_mm: f32,
+    offset_x: f32,
+    offset_y: f32,
+) -> Result<DrillParseResult, JsValue> {
+    DrillParser::new(outline_width_mm, offset_x, offset_y)?.parse(content)
+}
+
+fn set_property(object: &Object, key: &str, value: JsValue) -> Result<(), JsValue> {
+    Reflect::set(object, &JsValue::from_str(key), &value)
+        .map(|_| ())
+        .map_err(|_| JsValue::from_str(&format!("Failed to set drill metadata field `{key}`")))
+}
+
+fn sanitize_line(raw_line: &str) -> String {
+    raw_line
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .replace(char::is_whitespace, "")
+        .to_ascii_uppercase()
+}
+
+fn parse_tool_declaration(line: &str, unit: Unit) -> Result<Option<(u32, f32)>, JsValue> {
+    if !line.starts_with('T') || !line.contains('C') {
+        return Ok(None);
+    }
+
+    let c_index = line
+        .find('C')
+        .ok_or_else(|| JsValue::from_str("Invalid drill tool declaration"))?;
+    let code = parse_tool_code(&line[1..c_index])
+        .ok_or_else(|| JsValue::from_str("Invalid drill tool number"))?;
+    let diameter_token = read_number(&line[c_index + 1..])
+        .ok_or_else(|| JsValue::from_str("Invalid drill tool diameter"))?;
+    let diameter = parse_decimal_number(diameter_token)? * unit.multiplier();
+    if diameter <= 0.0 || !diameter.is_finite() {
+        return Err(JsValue::from_str("Drill tool diameter must be positive"));
+    }
+
+    Ok(Some((code, diameter)))
+}
+
+fn parse_tool_selection(line: &str) -> Option<u32> {
+    if !line.starts_with('T') || line.len() < 2 {
+        return None;
+    }
+
+    line[1..]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+        .then(|| parse_tool_code(&line[1..]))
+        .flatten()
+}
+
+fn parse_tool_code(token: &str) -> Option<u32> {
+    let trimmed = token.trim_start_matches('0');
+    if trimmed.is_empty() {
+        Some(0)
+    } else {
+        trimmed.parse::<u32>().ok()
+    }
+}
+
+fn parse_coordinate_words(
+    line: &str,
+    unit: Unit,
+    format: CoordinateFormat,
+) -> Result<Option<CoordinateWords>, JsValue> {
+    let x = parse_word_value(line, 'X', unit, format)?;
+    let y = parse_word_value(line, 'Y', unit, format)?;
+    let i = parse_word_value(line, 'I', unit, format)?;
+    let j = parse_word_value(line, 'J', unit, format)?;
+    let a = parse_word_value(line, 'A', unit, format)?;
+    Ok(
+        (x.is_some() || y.is_some() || i.is_some() || j.is_some() || a.is_some())
+            .then_some(CoordinateWords { x, y, i, j, a }),
+    )
+}
+
+fn parse_word_value(
+    line: &str,
+    word: char,
+    unit: Unit,
+    format: CoordinateFormat,
+) -> Result<Option<f32>, JsValue> {
+    let Some(index) = line.find(word) else {
+        return Ok(None);
+    };
+    let value_start = index + word.len_utf8();
+    let token = read_number(&line[value_start..]).ok_or_else(|| {
+        JsValue::from_str(&format!("Invalid drill coordinate word {word} in `{line}`"))
+    })?;
+
+    Ok(Some(parse_coordinate_number(token, unit, format)?))
+}
+
+fn read_number(text: &str) -> Option<&str> {
+    let end = text
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_digit() || matches!(ch, '.' | '+' | '-'))
+        .map(|(index, ch)| index + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+
+    (end > 0).then_some(&text[..end])
+}
+
+fn parse_coordinate_number(
+    token: &str,
+    unit: Unit,
+    format: CoordinateFormat,
+) -> Result<f32, JsValue> {
+    let value = if token.contains('.') {
+        parse_decimal_number(token)?
+    } else {
+        parse_omitted_decimal_number(token, format)?
+    };
+
+    Ok(value * unit.multiplier())
+}
+
+fn parse_decimal_number(token: &str) -> Result<f32, JsValue> {
+    token
+        .parse::<f32>()
+        .map_err(|_| JsValue::from_str(&format!("Invalid drill number `{token}`")))
+}
+
+fn parse_omitted_decimal_number(token: &str, format: CoordinateFormat) -> Result<f32, JsValue> {
+    let sign = if token.starts_with('-') { -1.0 } else { 1.0 };
+    let digits = token.trim_start_matches(['+', '-']);
+    if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(JsValue::from_str(&format!(
+            "Invalid drill number `{token}`"
+        )));
+    }
+
+    let value_token = match format.zero_suppression {
+        ZeroSuppression::Leading => digits.to_string(),
+        ZeroSuppression::Trailing => {
+            let total_digits = (format.integer_digits + format.decimal_digits) as usize;
+            if digits.len() >= total_digits {
+                digits.to_string()
+            } else {
+                format!("{digits:0<total_digits$}")
+            }
+        }
+    };
+    let value = value_token
+        .parse::<i64>()
+        .map_err(|_| JsValue::from_str(&format!("Invalid drill number `{token}`")))?;
+    let divisor = 10_i64.pow(format.decimal_digits) as f32;
+    Ok(sign * value as f32 / divisor)
+}
+
+fn parse_format_token(token: &str) -> Result<Option<(u32, u32)>, JsValue> {
+    let Some(dot_index) = token.find('.') else {
+        return Ok(None);
+    };
+    let before = &token[..dot_index];
+    let after = &token[dot_index + 1..];
+    if before.is_empty() || after.is_empty() {
+        return Ok(None);
+    }
+
+    if before.chars().all(|ch| ch == '0') && after.chars().all(|ch| ch == '0') {
+        return Ok(Some((before.len() as u32, after.len() as u32)));
+    }
+
+    if before.chars().all(|ch| ch.is_ascii_digit()) && after.chars().all(|ch| ch.is_ascii_digit()) {
+        let integer_digits = before
+            .parse::<u32>()
+            .map_err(|_| JsValue::from_str("Invalid drill coordinate format"))?;
+        let decimal_digits = after
+            .parse::<u32>()
+            .map_err(|_| JsValue::from_str("Invalid drill coordinate format"))?;
+        if integer_digits > 0 && decimal_digits > 0 {
+            return Ok(Some((integer_digits, decimal_digits)));
+        }
+    }
+
+    Ok(None)
+}
+
+fn arc_from_center_offset(
+    start_x: f32,
+    start_y: f32,
+    end_x: f32,
+    end_y: f32,
+    center_offset_x: f32,
+    center_offset_y: f32,
+    ccw: bool,
+) -> Result<DrillArc, JsValue> {
+    let center_x = start_x + center_offset_x;
+    let center_y = start_y + center_offset_y;
+    let radius = ((start_x - center_x).powi(2) + (start_y - center_y).powi(2)).sqrt();
+    if radius <= 0.0 || !radius.is_finite() {
+        return Err(JsValue::from_str(
+            "Circular drill rout radius must be positive",
+        ));
+    }
+    Ok(arc_from_center(
+        start_x, start_y, end_x, end_y, center_x, center_y, radius, ccw,
+    ))
+}
+
+fn arc_from_radius(
+    start_x: f32,
+    start_y: f32,
+    end_x: f32,
+    end_y: f32,
+    radius: f32,
+    ccw: bool,
+) -> Result<DrillArc, JsValue> {
+    if radius <= 0.0 || !radius.is_finite() {
+        return Err(JsValue::from_str(
+            "Circular drill rout radius must be positive",
+        ));
+    }
+
+    let dx = end_x - start_x;
+    let dy = end_y - start_y;
+    let chord = (dx * dx + dy * dy).sqrt();
+    if chord <= f32::EPSILON {
+        return Err(JsValue::from_str(
+            "Circular drill rout with A radius requires different start and end points",
+        ));
+    }
+    if chord > radius * 2.0 + 0.0001 {
+        return Err(JsValue::from_str(
+            "Circular drill rout radius is too small for its end points",
+        ));
+    }
+
+    let midpoint_x = (start_x + end_x) * 0.5;
+    let midpoint_y = (start_y + end_y) * 0.5;
+    let height = (radius * radius - (chord * 0.5).powi(2)).max(0.0).sqrt();
+    let perp_x = -dy / chord;
+    let perp_y = dx / chord;
+    let candidates = [
+        (midpoint_x + perp_x * height, midpoint_y + perp_y * height),
+        (midpoint_x - perp_x * height, midpoint_y - perp_y * height),
+    ];
+
+    candidates
+        .into_iter()
+        .map(|(center_x, center_y)| {
+            arc_from_center(
+                start_x, start_y, end_x, end_y, center_x, center_y, radius, ccw,
+            )
+        })
+        .find(|arc| arc.sweep_angle.abs() <= std::f32::consts::PI + 0.0001)
+        .ok_or_else(|| JsValue::from_str("Circular drill rout arc exceeds 180 degrees"))
+}
+
+fn arc_from_center(
+    start_x: f32,
+    start_y: f32,
+    end_x: f32,
+    end_y: f32,
+    center_x: f32,
+    center_y: f32,
+    radius: f32,
+    ccw: bool,
+) -> DrillArc {
+    let start_angle = (start_y - center_y).atan2(start_x - center_x);
+    let end_angle = (end_y - center_y).atan2(end_x - center_x);
+    let ccw_sweep = positive_angle_delta(end_angle - start_angle);
+    let sweep_angle = if ccw {
+        if ccw_sweep == 0.0 {
+            TWO_PI
+        } else {
+            ccw_sweep
+        }
+    } else if ccw_sweep == 0.0 {
+        -TWO_PI
+    } else {
+        ccw_sweep - TWO_PI
+    };
+
+    DrillArc {
+        center_x,
+        center_y,
+        radius,
+        start_angle,
+        sweep_angle,
+    }
+}
+
+fn positive_angle_delta(angle: f32) -> f32 {
+    let mut normalized = angle % TWO_PI;
+    if normalized < 0.0 {
+        normalized += TWO_PI;
+    }
+    if normalized.abs() < 0.000001 {
+        0.0
+    } else {
+        normalized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_drill_with_offset;
+
+    fn assert_approx_eq(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 0.0001,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn parses_xnc_drill_hits_and_metadata() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.6
+T02C0.8
+%
+G05
+T01
+X9.01Y3.3375
+X9.01Y4.3125
+T02
+X8.01Y4.8
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("XNC drill file should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 3);
+        assert_eq!(parsed.metadata.hit_count, 3);
+        assert_eq!(parsed.metadata.tools.len(), 2);
+        assert_approx_eq(parsed.fill_layer.circles.radius[0], 0.3);
+        assert_approx_eq(parsed.outline_layer.circles.radius[0], 0.35);
+    }
+
+    #[test]
+    fn parses_xnc_linear_rout_as_slot() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+G00X8.01Y3.825
+M15
+G01X6.54Y3.825
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("XNC rout file should parse");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.lines.width[0], 0.8);
+        assert_approx_eq(parsed.outline_layer.lines.width[0], 0.9);
+    }
+
+    #[test]
+    fn treats_t00_as_tool_unload() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.6
+%
+T01
+X9.0Y3.0
+T00
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("T00 should unload the current drill tool");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 1);
+        assert_eq!(parsed.metadata.hit_count, 1);
+    }
+
+    #[test]
+    fn honors_trailing_zero_suppressed_metric_coordinates() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC,TZ
+T01C0.6
+%
+T01
+X009Y010
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("METRIC,TZ omitted-decimal coordinates should parse");
+
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+    }
+
+    #[test]
+    fn ignores_fmat_and_preserves_tz_after_m71() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+FMAT,2
+METRIC,TZ
+T01C0.6
+%
+M71
+T01
+X009Y010
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("LibrePCB-style drill header should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 1);
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+    }
+
+    #[test]
+    fn parses_xnc_circular_rout_as_arc() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+G00X5.05Y2.6
+M15
+G03X6.0Y1.6A1.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("XNC circular rout should parse as analytic arc");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 0);
+        assert_eq!(parsed.fill_layer.arcs.x.len(), 1);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.arcs.radius[0], 1.0);
+        assert_approx_eq(parsed.fill_layer.arcs.thickness[0], 0.8);
+    }
+}

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -367,6 +367,7 @@ impl CoordinateWords {
 struct DrillParser {
     unit: Unit,
     coordinate_format: CoordinateFormat,
+    coordinate_format_from_comment: bool,
     mode: Mode,
     routing_interpolation: RoutingInterpolation,
     modal_arc_words: CoordinateWords,
@@ -393,6 +394,7 @@ impl DrillParser {
         Ok(Self {
             unit: Unit::Metric,
             coordinate_format: CoordinateFormat::new(Unit::Metric),
+            coordinate_format_from_comment: false,
             mode: Mode::Drill,
             routing_interpolation: RoutingInterpolation::Linear,
             modal_arc_words: CoordinateWords::default(),
@@ -413,6 +415,12 @@ impl DrillParser {
 
     fn parse(mut self, content: &str) -> Result<DrillParseResult, JsValue> {
         for raw_line in content.lines() {
+            if let Some((integer_digits, decimal_digits)) = parse_file_format_comment(raw_line) {
+                self.coordinate_format.integer_digits = integer_digits;
+                self.coordinate_format.decimal_digits = decimal_digits;
+                self.coordinate_format_from_comment = true;
+                continue;
+            }
             let line = sanitize_line(raw_line);
             if line.is_empty() {
                 continue;
@@ -729,12 +737,17 @@ impl DrillParser {
     fn set_unit(&mut self, unit: Unit, line: &str) -> Result<(), JsValue> {
         self.unit = unit;
         let mut format = CoordinateFormat::new(unit);
+        if self.coordinate_format_from_comment {
+            format.integer_digits = self.coordinate_format.integer_digits;
+            format.decimal_digits = self.coordinate_format.decimal_digits;
+        }
         for token in line.split(',').skip(1) {
             if let Some(zero_suppression) = zero_suppression_from_excellon_token(token) {
                 format.zero_suppression = zero_suppression;
             } else if let Some((integer_digits, decimal_digits)) = parse_format_token(token)? {
                 format.integer_digits = integer_digits;
                 format.decimal_digits = decimal_digits;
+                self.coordinate_format_from_comment = false;
             }
         }
         self.coordinate_format = format;
@@ -742,7 +755,7 @@ impl DrillParser {
     }
 
     fn set_unit_code(&mut self, unit: Unit) {
-        if self.unit != unit {
+        if self.unit != unit && !self.coordinate_format_from_comment {
             self.coordinate_format.integer_digits = unit.default_integer_digits();
             self.coordinate_format.decimal_digits = unit.default_decimal_digits();
         }
@@ -924,6 +937,19 @@ fn sanitize_line(raw_line: &str) -> String {
         .trim()
         .replace(char::is_whitespace, "")
         .to_ascii_uppercase()
+}
+
+fn parse_file_format_comment(raw_line: &str) -> Option<(u32, u32)> {
+    let comment = raw_line.trim_start().strip_prefix(';')?;
+    let normalized = comment
+        .trim()
+        .replace(char::is_whitespace, "")
+        .to_ascii_uppercase();
+    let value = normalized.strip_prefix("FILE_FORMAT=")?;
+    let (integer, decimal) = value.split_once(':').or_else(|| value.split_once('.'))?;
+    let integer_digits = integer.parse::<u32>().ok()?;
+    let decimal_digits = decimal.parse::<u32>().ok()?;
+    (integer_digits > 0 && decimal_digits > 0).then_some((integer_digits, decimal_digits))
 }
 
 fn parse_tool_declaration(line: &str, unit: Unit) -> Result<Option<(u32, f32)>, JsValue> {
@@ -2051,6 +2077,28 @@ M30",
         assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
         assert_approx_eq(parsed.fill_layer.circles.x[1], 0.011);
         assert_approx_eq(parsed.fill_layer.circles.y[1], 0.012);
+    }
+
+    #[test]
+    fn honors_file_format_precision_comments() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+;FILE_FORMAT=4:4
+METRIC,LZ
+T01C0.6
+%
+T01
+X00090000Y00100000
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("FILE_FORMAT comment should set coordinate precision");
+
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
     }
 
     #[test]

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -209,7 +209,14 @@ impl DrillGeometry {
         self.arc_start_angle.push(start_angle);
         self.arc_sweep_angle.push(sweep_angle);
         self.arc_thickness.push(thickness);
-        self.include_circle_bounds(center_x, center_y, radius + thickness / 2.0);
+        self.include_arc_bounds(
+            center_x,
+            center_y,
+            radius,
+            start_angle,
+            sweep_angle,
+            thickness,
+        );
     }
 
     fn include_circle_bounds(&mut self, x: f32, y: f32, radius: f32) {
@@ -218,6 +225,57 @@ impl DrillGeometry {
         self.min_y = self.min_y.min(y - radius);
         self.max_y = self.max_y.max(y + radius);
         self.has_geometry = true;
+    }
+
+    fn include_arc_bounds(
+        &mut self,
+        center_x: f32,
+        center_y: f32,
+        radius: f32,
+        start_angle: f32,
+        sweep_angle: f32,
+        thickness: f32,
+    ) {
+        let cap_radius = thickness / 2.0;
+        if sweep_angle.abs() >= TWO_PI - 0.000001 {
+            self.include_circle_bounds(center_x, center_y, radius + cap_radius);
+            return;
+        }
+
+        self.include_arc_point_bounds(center_x, center_y, radius, start_angle, cap_radius);
+        self.include_arc_point_bounds(
+            center_x,
+            center_y,
+            radius,
+            start_angle + sweep_angle,
+            cap_radius,
+        );
+
+        for angle in [
+            0.0,
+            std::f32::consts::FRAC_PI_2,
+            std::f32::consts::PI,
+            std::f32::consts::PI * 1.5,
+        ] {
+            if angle_is_on_sweep(angle, start_angle, sweep_angle) {
+                self.include_arc_point_bounds(center_x, center_y, radius, angle, cap_radius);
+            }
+        }
+    }
+
+    fn include_arc_point_bounds(
+        &mut self,
+        center_x: f32,
+        center_y: f32,
+        radius: f32,
+        angle: f32,
+        cap_radius: f32,
+    ) {
+        self.include_circle_bounds(
+            center_x + angle.cos() * radius,
+            center_y + angle.sin() * radius,
+            cap_radius,
+        );
     }
 
     fn boundary(&self) -> Boundary {
@@ -375,6 +433,7 @@ impl DrillParser {
             return Ok(());
         }
         if line == "M15" {
+            self.mode = Mode::Rout;
             self.routing_down = true;
             return Ok(());
         }
@@ -449,7 +508,8 @@ impl DrillParser {
                 return Ok(());
             };
             let (end_x, end_y) = self.resolve_xy(words.x, words.y);
-            if self.mode == Mode::Rout && self.routing_down {
+            if self.routing_down {
+                self.mode = Mode::Rout;
                 self.push_slot(end_x, end_y)?;
             }
             self.current_x = end_x;
@@ -503,6 +563,8 @@ impl DrillParser {
             let (x, y) = self.resolve_xy(words.x, words.y);
             if self.mode == Mode::Drill {
                 self.push_hit(x, y)?;
+            } else if self.mode == Mode::Rout && self.routing_down {
+                self.push_slot(x, y)?;
             }
             self.current_x = x;
             self.current_y = y;
@@ -512,13 +574,13 @@ impl DrillParser {
     }
 
     fn resolve_xy(&self, x: Option<f32>, y: Option<f32>) -> (f32, f32) {
-        let x = x.unwrap_or(self.current_x);
-        let y = y.unwrap_or(self.current_y);
-
         if self.is_absolute {
-            (x, y)
+            (x.unwrap_or(self.current_x), y.unwrap_or(self.current_y))
         } else {
-            (self.current_x + x, self.current_y + y)
+            (
+                self.current_x + x.unwrap_or(0.0),
+                self.current_y + y.unwrap_or(0.0),
+            )
         }
     }
 
@@ -601,6 +663,8 @@ impl DrillParser {
         let start_y = start_y + self.offset_y;
         let end_x = end_x + self.offset_x;
         let end_y = end_y + self.offset_y;
+        let outline_radius = diameter_mm / 2.0 + self.outline_width_mm;
+        let fill_radius = diameter_mm / 2.0;
         self.outline.push_line(
             start_x,
             start_y,
@@ -608,8 +672,12 @@ impl DrillParser {
             end_y,
             diameter_mm + self.outline_width_mm * 2.0,
         );
+        self.outline.push_circle(start_x, start_y, outline_radius);
+        self.outline.push_circle(end_x, end_y, outline_radius);
         self.fill
             .push_line(start_x, start_y, end_x, end_y, diameter_mm);
+        self.fill.push_circle(start_x, start_y, fill_radius);
+        self.fill.push_circle(end_x, end_y, fill_radius);
         if let Some(tool) = self.tools.get_mut(&code) {
             tool.slot_count = tool.slot_count.saturating_add(1);
         }
@@ -719,6 +787,7 @@ fn parse_tool_declaration(line: &str, unit: Unit) -> Result<Option<(u32, f32)>, 
 }
 
 fn parse_tool_selection(line: &str) -> Option<u32> {
+    let line = line.strip_prefix("G54").unwrap_or(line);
     if !line.starts_with('T') || line.len() < 2 {
         return None;
     }
@@ -1047,6 +1116,20 @@ fn positive_angle_delta(angle: f32) -> f32 {
     }
 }
 
+fn angle_is_on_sweep(angle: f32, start_angle: f32, sweep_angle: f32) -> bool {
+    let epsilon = 0.000001;
+    if sweep_angle.abs() >= TWO_PI - epsilon {
+        return true;
+    }
+
+    let delta = if sweep_angle >= 0.0 {
+        positive_angle_delta(angle - start_angle)
+    } else {
+        positive_angle_delta(start_angle - angle)
+    };
+    delta <= sweep_angle.abs() + epsilon
+}
+
 #[cfg(test)]
 mod tests {
     use super::parse_drill_with_offset;
@@ -1107,6 +1190,8 @@ M30",
         )
         .expect("XNC rout file should parse");
 
+        assert_eq!(parsed.fill_layer.circles.x.len(), 2);
+        assert_eq!(parsed.outline_layer.circles.x.len(), 2);
         assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
         assert_eq!(parsed.metadata.slot_count, 1);
         assert_approx_eq(parsed.fill_layer.lines.width[0], 0.8);
@@ -1131,7 +1216,7 @@ M30",
         )
         .expect("G85 slot command should parse");
 
-        assert_eq!(parsed.fill_layer.circles.x.len(), 1);
+        assert_eq!(parsed.fill_layer.circles.x.len(), 3);
         assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
         assert_eq!(parsed.metadata.hit_count, 1);
         assert_eq!(parsed.metadata.slot_count, 1);
@@ -1159,7 +1244,7 @@ M30",
         )
         .expect("Inline G85 slot endpoints should parse");
 
-        assert_eq!(parsed.fill_layer.circles.x.len(), 0);
+        assert_eq!(parsed.fill_layer.circles.x.len(), 2);
         assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
         assert_eq!(parsed.metadata.hit_count, 0);
         assert_eq!(parsed.metadata.slot_count, 1);
@@ -1189,12 +1274,121 @@ M30",
         )
         .expect("Short Excellon rout commands should parse");
 
-        assert_eq!(parsed.fill_layer.circles.x.len(), 0);
+        assert_eq!(parsed.fill_layer.circles.x.len(), 2);
         assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
         assert_eq!(parsed.metadata.hit_count, 0);
         assert_eq!(parsed.metadata.slot_count, 1);
         assert_approx_eq(parsed.fill_layer.lines.start_x[0], 8.01);
         assert_approx_eq(parsed.fill_layer.lines.end_x[0], 6.54);
+    }
+
+    #[test]
+    fn accepts_g54_prefixed_tool_selection() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.6
+%
+G54T01
+X9.0Y3.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("G54-prefixed tool selection should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 1);
+        assert_eq!(parsed.metadata.hit_count, 1);
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
+    }
+
+    #[test]
+    fn preserves_modal_rout_coordinate_moves() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+G00X1.0Y1.0
+M15
+G01X2.0Y1.0
+X3.0Y1.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Modal coordinate-only rout move should parse as a slot");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 4);
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 2);
+        assert_eq!(parsed.metadata.hit_count, 0);
+        assert_eq!(parsed.metadata.slot_count, 2);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[0], 1.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[0], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[1], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[1], 3.0);
+    }
+
+    #[test]
+    fn routes_g01_after_m15_without_prior_g00() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+M15
+G01X2.0Y1.0
+X3.0Y1.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("G01 after M15 should start a routed slot");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 4);
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 2);
+        assert_eq!(parsed.metadata.hit_count, 0);
+        assert_eq!(parsed.metadata.slot_count, 2);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[0], 0.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[0], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[1], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[1], 3.0);
+    }
+
+    #[test]
+    fn incremental_coordinates_keep_omitted_axis_current() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.6
+%
+T01
+X10.0Y10.0
+G91
+X1.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Incremental omitted axes should preserve current coordinate");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 2);
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[1], 11.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[1], 10.0);
     }
 
     #[test]
@@ -1289,5 +1483,32 @@ M30",
         assert_eq!(parsed.metadata.slot_count, 1);
         assert_approx_eq(parsed.fill_layer.arcs.radius[0], 1.0);
         assert_approx_eq(parsed.fill_layer.arcs.thickness[0], 0.8);
+    }
+
+    #[test]
+    fn routed_arc_bounds_follow_sweep() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C1.0
+%
+T01
+G00X10.0Y0.0
+M15
+G03X0.0Y10.0I-10.0J0.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Routed arc should parse");
+
+        assert_eq!(parsed.fill_layer.arcs.x.len(), 1);
+        assert_approx_eq(parsed.fill_layer.boundary.min_x, -0.5);
+        assert_approx_eq(parsed.fill_layer.boundary.max_x, 10.5);
+        assert_approx_eq(parsed.fill_layer.boundary.min_y, -0.5);
+        assert_approx_eq(parsed.fill_layer.boundary.max_y, 10.5);
     }
 }

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -455,6 +455,18 @@ impl DrillParser {
             return Ok(());
         }
 
+        if line.starts_with("G85") {
+            let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
+            else {
+                return Ok(());
+            };
+            let (end_x, end_y) = self.resolve_xy(words.x, words.y);
+            self.push_slot(end_x, end_y)?;
+            self.current_x = end_x;
+            self.current_y = end_y;
+            return Ok(());
+        }
+
         if line.starts_with("G02") || line.starts_with("G03") {
             let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
             else {
@@ -1000,6 +1012,35 @@ M30",
         assert_eq!(parsed.metadata.slot_count, 1);
         assert_approx_eq(parsed.fill_layer.lines.width[0], 0.8);
         assert_approx_eq(parsed.outline_layer.lines.width[0], 0.9);
+    }
+
+    #[test]
+    fn parses_g85_as_slot_from_current_position() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+X1.0Y2.0
+G85X4.0Y2.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("G85 slot command should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 1);
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
+        assert_eq!(parsed.metadata.hit_count, 1);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[0], 1.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_y[0], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[0], 4.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_y[0], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.width[0], 0.8);
     }
 
     #[test]

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -67,6 +67,22 @@ enum Mode {
     Rout,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum RoutingInterpolation {
+    Linear,
+    ClockwiseArc,
+    CounterClockwiseArc,
+}
+
+impl RoutingInterpolation {
+    fn is_arc(self) -> bool {
+        matches!(
+            self,
+            RoutingInterpolation::ClockwiseArc | RoutingInterpolation::CounterClockwiseArc
+        )
+    }
+}
+
 #[derive(Clone, Debug)]
 struct Tool {
     diameter_mm: f32,
@@ -329,7 +345,7 @@ impl DrillGeometry {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Clone, Copy, Default, Debug)]
 struct CoordinateWords {
     x: Option<f32>,
     y: Option<f32>,
@@ -338,10 +354,22 @@ struct CoordinateWords {
     a: Option<f32>,
 }
 
+impl CoordinateWords {
+    fn has_xy(self) -> bool {
+        self.x.is_some() || self.y.is_some()
+    }
+
+    fn has_arc_definition(self) -> bool {
+        self.a.is_some() || self.i.is_some() || self.j.is_some()
+    }
+}
+
 struct DrillParser {
     unit: Unit,
     coordinate_format: CoordinateFormat,
     mode: Mode,
+    routing_interpolation: RoutingInterpolation,
+    modal_arc_words: CoordinateWords,
     is_absolute: bool,
     routing_down: bool,
     current_tool: Option<u32>,
@@ -365,6 +393,8 @@ impl DrillParser {
             unit: Unit::Metric,
             coordinate_format: CoordinateFormat::new(Unit::Metric),
             mode: Mode::Drill,
+            routing_interpolation: RoutingInterpolation::Linear,
+            modal_arc_words: CoordinateWords::default(),
             is_absolute: true,
             routing_down: false,
             current_tool: None,
@@ -449,6 +479,22 @@ impl DrillParser {
             self.is_absolute = false;
             return Ok(());
         }
+        if line == "ICI,ON" {
+            self.is_absolute = false;
+            return Ok(());
+        }
+        if line == "ICI,OFF" {
+            self.is_absolute = true;
+            return Ok(());
+        }
+        if line == "LZ" {
+            self.coordinate_format.zero_suppression = ZeroSuppression::Leading;
+            return Ok(());
+        }
+        if line == "TZ" {
+            self.coordinate_format.zero_suppression = ZeroSuppression::Trailing;
+            return Ok(());
+        }
         if line.starts_with("METRIC") {
             self.set_unit(Unit::Metric, line)?;
             return Ok(());
@@ -478,7 +524,9 @@ impl DrillParser {
             return Ok(());
         }
 
-        if let Some(code) = parse_tool_selection(line) {
+        if let Some(code) =
+            parse_tool_selection(line).map_err(|message| JsValue::from_str(&message))?
+        {
             if code == 0 {
                 self.current_tool = None;
                 return Ok(());
@@ -494,6 +542,7 @@ impl DrillParser {
 
         if g_code == Some(0) {
             self.mode = Mode::Rout;
+            self.routing_interpolation = RoutingInterpolation::Linear;
             if let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)? {
                 let (x, y) = self.resolve_xy(words.x, words.y);
                 self.current_x = x;
@@ -503,6 +552,7 @@ impl DrillParser {
         }
 
         if g_code == Some(1) {
+            self.routing_interpolation = RoutingInterpolation::Linear;
             let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
             else {
                 return Ok(());
@@ -517,17 +567,15 @@ impl DrillParser {
             return Ok(());
         }
 
-        if g_code == Some(85) {
-            let word_sets = parse_coordinate_word_sets(line, self.unit, self.coordinate_format)?;
-            if word_sets.is_empty() {
+        if g_code == Some(85) || line_has_g_code(line, 85) {
+            let Some((start_words, end_words)) =
+                parse_g85_words(line, self.unit, self.coordinate_format)?
+            else {
                 return Ok(());
-            }
-            let (start_x, start_y, end_words) = if word_sets.len() >= 2 {
-                let (start_x, start_y) = self.resolve_xy(word_sets[0].x, word_sets[0].y);
-                (start_x, start_y, &word_sets[1])
-            } else {
-                (self.current_x, self.current_y, &word_sets[0])
             };
+            let (start_x, start_y) = start_words
+                .map(|words| self.resolve_xy(words.x, words.y))
+                .unwrap_or((self.current_x, self.current_y));
             let (end_x, end_y) = if self.is_absolute {
                 (
                     end_words.x.unwrap_or(start_x),
@@ -546,13 +594,27 @@ impl DrillParser {
         }
 
         if matches!(g_code, Some(2) | Some(3)) {
+            self.routing_interpolation = if g_code == Some(3) {
+                RoutingInterpolation::CounterClockwiseArc
+            } else {
+                RoutingInterpolation::ClockwiseArc
+            };
             let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
             else {
                 return Ok(());
             };
+            self.update_modal_arc_words(words);
+            if !words.has_xy() {
+                return Ok(());
+            }
             let (end_x, end_y) = self.resolve_xy(words.x, words.y);
             if self.mode == Mode::Rout && self.routing_down {
-                self.push_arc(end_x, end_y, words, g_code == Some(3))?;
+                self.push_arc(
+                    end_x,
+                    end_y,
+                    self.words_with_modal_arc(words),
+                    self.routing_interpolation == RoutingInterpolation::CounterClockwiseArc,
+                )?;
             }
             self.current_x = end_x;
             self.current_y = end_y;
@@ -560,17 +622,83 @@ impl DrillParser {
         }
 
         if let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)? {
+            if !words.has_xy() && words.has_arc_definition() {
+                self.update_modal_arc_words(words);
+                return Ok(());
+            }
             let (x, y) = self.resolve_xy(words.x, words.y);
             if self.mode == Mode::Drill {
                 self.push_hit(x, y)?;
             } else if self.mode == Mode::Rout && self.routing_down {
-                self.push_slot(x, y)?;
+                if self.routing_interpolation.is_arc() && !words.has_xy() {
+                    self.update_modal_arc_words(words);
+                    return Ok(());
+                }
+                self.push_modal_rout(x, y, words)?;
             }
             self.current_x = x;
             self.current_y = y;
         }
 
         Ok(())
+    }
+
+    fn push_modal_rout(
+        &mut self,
+        end_x: f32,
+        end_y: f32,
+        words: CoordinateWords,
+    ) -> Result<(), JsValue> {
+        match self.routing_interpolation {
+            RoutingInterpolation::Linear => self.push_slot(end_x, end_y),
+            RoutingInterpolation::ClockwiseArc => {
+                self.update_modal_arc_words(words);
+                self.push_arc(end_x, end_y, self.words_with_modal_arc(words), false)
+            }
+            RoutingInterpolation::CounterClockwiseArc => {
+                self.update_modal_arc_words(words);
+                self.push_arc(end_x, end_y, self.words_with_modal_arc(words), true)
+            }
+        }
+    }
+
+    fn update_modal_arc_words(&mut self, words: CoordinateWords) {
+        if words.a.is_some() {
+            self.modal_arc_words.a = words.a;
+            self.modal_arc_words.i = None;
+            self.modal_arc_words.j = None;
+            return;
+        }
+        if words.i.is_some() || words.j.is_some() {
+            if words.i.is_some() {
+                self.modal_arc_words.i = words.i;
+            }
+            if words.j.is_some() {
+                self.modal_arc_words.j = words.j;
+            }
+            self.modal_arc_words.a = None;
+        }
+    }
+
+    fn words_with_modal_arc(&self, mut words: CoordinateWords) -> CoordinateWords {
+        if words.a.is_some() {
+            return words;
+        }
+        if words.i.is_some() || words.j.is_some() {
+            if words.i.is_none() {
+                words.i = self.modal_arc_words.i;
+            }
+            if words.j.is_none() {
+                words.j = self.modal_arc_words.j;
+            }
+            return words;
+        }
+        if !words.has_arc_definition() {
+            words.a = self.modal_arc_words.a;
+            words.i = self.modal_arc_words.i;
+            words.j = self.modal_arc_words.j;
+        }
+        words
     }
 
     fn resolve_xy(&self, x: Option<f32>, y: Option<f32>) -> (f32, f32) {
@@ -786,17 +914,48 @@ fn parse_tool_declaration(line: &str, unit: Unit) -> Result<Option<(u32, f32)>, 
     Ok(Some((code, diameter)))
 }
 
-fn parse_tool_selection(line: &str) -> Option<u32> {
+fn parse_tool_selection(line: &str) -> Result<Option<u32>, String> {
     let line = line.strip_prefix("G54").unwrap_or(line);
-    if !line.starts_with('T') || line.len() < 2 {
-        return None;
+    let Some(rest) = line.strip_prefix('T') else {
+        return Ok(None);
+    };
+    let digits_end = rest
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_digit())
+        .map(|(index, ch)| index + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+    if digits_end == 0 {
+        return Err("Invalid drill tool selection".to_string());
     }
 
-    line[1..]
-        .chars()
-        .all(|ch| ch.is_ascii_digit())
-        .then(|| parse_tool_code(&line[1..]))
-        .flatten()
+    let code = parse_tool_code(&rest[..digits_end])
+        .ok_or_else(|| "Invalid drill tool selection".to_string())?;
+    parse_tool_selection_suffix(&rest[digits_end..])?;
+    Ok(Some(code))
+}
+
+fn parse_tool_selection_suffix(mut suffix: &str) -> Result<(), String> {
+    while !suffix.is_empty() {
+        let Some(word) = suffix.chars().next() else {
+            return Ok(());
+        };
+        if !matches!(word, 'F' | 'S') {
+            return Err(format!("Invalid drill tool selection suffix `{suffix}`"));
+        }
+        let value_start = word.len_utf8();
+        let Some(token) = read_number(&suffix[value_start..]) else {
+            return Err(format!("Invalid drill tool selection suffix `{suffix}`"));
+        };
+        let value = token
+            .parse::<f32>()
+            .map_err(|_| format!("Invalid drill tool selection suffix `{suffix}`"))?;
+        if !value.is_finite() || value < 0.0 {
+            return Err(format!("Invalid drill tool selection suffix `{suffix}`"));
+        }
+        suffix = &suffix[value_start + token.len()..];
+    }
+    Ok(())
 }
 
 fn parse_tool_code(token: &str) -> Option<u32> {
@@ -821,6 +980,38 @@ fn parse_g_code(line: &str) -> Option<u32> {
     }
 
     rest[..digits_end].parse::<u32>().ok()
+}
+
+fn line_has_g_code(line: &str, code: u32) -> bool {
+    line.char_indices()
+        .filter(|(_, ch)| *ch == 'G')
+        .any(|(index, _)| parse_g_code(&line[index..]) == Some(code))
+}
+
+fn parse_g85_words(
+    line: &str,
+    unit: Unit,
+    format: CoordinateFormat,
+) -> Result<Option<(Option<CoordinateWords>, CoordinateWords)>, JsValue> {
+    let Some(g85_index) = find_g_code_index(line, 85) else {
+        return Ok(None);
+    };
+    let start_words = parse_coordinate_words(&line[..g85_index], unit, format)?;
+    let suffix = &line[g85_index..];
+    let suffix_sets = parse_coordinate_word_sets(suffix, unit, format)?;
+    if suffix_sets.len() >= 2 && start_words.is_none() {
+        return Ok(Some((Some(suffix_sets[0]), suffix_sets[1])));
+    }
+    if let Some(end_words) = suffix_sets.into_iter().next() {
+        return Ok(Some((start_words, end_words)));
+    }
+    Ok(None)
+}
+
+fn find_g_code_index(line: &str, code: u32) -> Option<usize> {
+    line.char_indices()
+        .filter(|(_, ch)| *ch == 'G')
+        .find_map(|(index, _)| (parse_g_code(&line[index..]) == Some(code)).then_some(index))
 }
 
 fn parse_coordinate_words(
@@ -1255,6 +1446,63 @@ M30",
     }
 
     #[test]
+    fn parses_embedded_g85_start_and_end_coordinates() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+X1.0Y2.0G85X4.0Y2.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Embedded G85 slot endpoints should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 2);
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
+        assert_eq!(parsed.metadata.hit_count, 0);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[0], 1.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_y[0], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[0], 4.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_y[0], 2.0);
+    }
+
+    #[test]
+    fn parses_embedded_g85_with_omitted_axes() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+Y2.0G85X4.0Y3.0
+Y5.0G85X6.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Embedded G85 omitted axes should parse from the G85 split point");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 2);
+        assert_eq!(parsed.metadata.slot_count, 2);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[0], 0.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_y[0], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[0], 4.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_y[0], 3.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[1], 4.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_y[1], 5.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[1], 6.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_y[1], 5.0);
+    }
+
+    #[test]
     fn parses_short_g_rout_commands_as_slot() {
         let parsed = parse_drill_with_offset(
             "\
@@ -1305,6 +1553,39 @@ M30",
     }
 
     #[test]
+    fn accepts_tool_selection_with_feed_and_speed_words() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.6
+T02C1.2
+%
+T02F200S61
+X9.0Y3.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Tool selection with feed and speed words should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 1);
+        assert_eq!(parsed.metadata.hit_count, 1);
+        assert_approx_eq(parsed.fill_layer.circles.radius[0], 0.6);
+    }
+
+    #[test]
+    fn rejects_malformed_tool_selection_suffixes() {
+        for selection in ["T02F", "T02Q1", "G54T02F", "T02F+", "T02S."] {
+            assert!(
+                super::parse_tool_selection(selection).is_err(),
+                "malformed tool selection `{selection}` should fail"
+            );
+        }
+    }
+
+    #[test]
     fn preserves_modal_rout_coordinate_moves() {
         let parsed = parse_drill_with_offset(
             "\
@@ -1333,6 +1614,151 @@ M30",
         assert_approx_eq(parsed.fill_layer.lines.end_x[0], 2.0);
         assert_approx_eq(parsed.fill_layer.lines.start_x[1], 2.0);
         assert_approx_eq(parsed.fill_layer.lines.end_x[1], 3.0);
+    }
+
+    #[test]
+    fn preserves_modal_arc_rout_coordinate_moves() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C1.0
+%
+T01
+G00X10.0Y0.0
+M15
+G03X0.0Y10.0I-10.0J0.0
+X-10.0Y0.0I0.0J-10.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Modal coordinate-only arc rout move should parse as an arc");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 0);
+        assert_eq!(parsed.fill_layer.arcs.x.len(), 2);
+        assert_eq!(parsed.metadata.hit_count, 0);
+        assert_eq!(parsed.metadata.slot_count, 2);
+        assert_approx_eq(parsed.fill_layer.arcs.x[1], 0.0);
+        assert_approx_eq(parsed.fill_layer.arcs.y[1], 0.0);
+    }
+
+    #[test]
+    fn preserves_modal_arc_definition_for_coordinate_only_rout() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C1.0
+%
+T01
+G00X10.0Y0.0
+M15
+G03I-10.0J0.0
+X0.0Y10.0
+X-10.0Y0.0I0.0J-10.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Modal arc definition should apply to coordinate-only rout moves");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 0);
+        assert_eq!(parsed.fill_layer.arcs.x.len(), 2);
+        assert_eq!(parsed.metadata.hit_count, 0);
+        assert_eq!(parsed.metadata.slot_count, 2);
+        assert_approx_eq(parsed.fill_layer.arcs.x[0], 0.0);
+        assert_approx_eq(parsed.fill_layer.arcs.y[0], 0.0);
+        assert_approx_eq(parsed.fill_layer.arcs.x[1], 0.0);
+        assert_approx_eq(parsed.fill_layer.arcs.y[1], 0.0);
+    }
+
+    #[test]
+    fn updates_modal_arc_definition_without_endpoint() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C1.0
+%
+T01
+G00X10.0Y0.0
+M15
+G03I-10.0J0.0
+I-10.0J0.0
+X0.0Y10.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Arc definition-only rout records should update modal state");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 0);
+        assert_eq!(parsed.fill_layer.arcs.x.len(), 1);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.arcs.x[0], 0.0);
+        assert_approx_eq(parsed.fill_layer.arcs.y[0], 0.0);
+    }
+
+    #[test]
+    fn stores_arc_definition_before_arc_interpolation() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C1.0
+%
+T01
+G00X0.0Y0.0
+M15
+A1.0
+G03X1.0Y1.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Arc definition-only records should be modal before G03");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 0);
+        assert_eq!(parsed.fill_layer.arcs.x.len(), 1);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.arcs.radius[0], 1.0);
+    }
+
+    #[test]
+    fn merges_partial_modal_arc_center_offsets() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C1.0
+%
+T01
+G00X0.0Y10.0
+M15
+G03I0.0J-10.0
+X-10.0Y0.0I0.0
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Partial modal I/J updates should retain the omitted companion word");
+
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 0);
+        assert_eq!(parsed.fill_layer.arcs.x.len(), 1);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.arcs.x[0], 0.0);
+        assert_approx_eq(parsed.fill_layer.arcs.y[0], 0.0);
     }
 
     #[test]
@@ -1392,6 +1818,36 @@ M30",
     }
 
     #[test]
+    fn honors_ici_incremental_coordinate_mode() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+ICI,ON
+T01C0.6
+%
+T01
+X10.0Y10.0
+X1.0Y0.0
+ICI,OFF
+X1.0Y0.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("ICI incremental coordinate mode should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 3);
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[1], 11.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[1], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[2], 1.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[2], 0.0);
+    }
+
+    #[test]
     fn treats_t00_as_tool_unload() {
         let parsed = parse_drill_with_offset(
             "\
@@ -1432,6 +1888,33 @@ M30",
 
         assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
         assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+    }
+
+    #[test]
+    fn honors_standalone_zero_suppression_commands() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+TZ
+T01C0.6
+%
+T01
+X009Y010
+LZ
+X011Y012
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Standalone zero-suppression commands should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 2);
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[1], 0.011);
+        assert_approx_eq(parsed.fill_layer.circles.y[1], 0.012);
     }
 
     #[test]

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -375,6 +375,7 @@ struct DrillParser {
     current_tool: Option<u32>,
     current_x: f32,
     current_y: f32,
+    last_hit: Option<(f32, f32)>,
     tools: BTreeMap<u32, Tool>,
     fill: DrillGeometry,
     outline: DrillGeometry,
@@ -400,6 +401,7 @@ impl DrillParser {
             current_tool: None,
             current_x: 0.0,
             current_y: 0.0,
+            last_hit: None,
             tools: BTreeMap::new(),
             fill: DrillGeometry::new(),
             outline: DrillGeometry::new(),
@@ -488,11 +490,13 @@ impl DrillParser {
             return Ok(());
         }
         if line == "LZ" {
-            self.coordinate_format.zero_suppression = ZeroSuppression::Leading;
+            self.coordinate_format.zero_suppression = zero_suppression_from_excellon_token(line)
+                .unwrap_or(self.coordinate_format.zero_suppression);
             return Ok(());
         }
         if line == "TZ" {
-            self.coordinate_format.zero_suppression = ZeroSuppression::Trailing;
+            self.coordinate_format.zero_suppression = zero_suppression_from_excellon_token(line)
+                .unwrap_or(self.coordinate_format.zero_suppression);
             return Ok(());
         }
         if line.starts_with("METRIC") {
@@ -621,6 +625,16 @@ impl DrillParser {
             return Ok(());
         }
 
+        if self.mode == Mode::Drill {
+            if let Some((count, spacing)) =
+                parse_repeat_hole(line, self.unit, self.coordinate_format)
+                    .map_err(|message| JsValue::from_str(&message))?
+            {
+                self.push_repeated_hits(count, spacing)?;
+                return Ok(());
+            }
+        }
+
         if let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)? {
             if !words.has_xy() && words.has_arc_definition() {
                 self.update_modal_arc_words(words);
@@ -716,15 +730,11 @@ impl DrillParser {
         self.unit = unit;
         let mut format = CoordinateFormat::new(unit);
         for token in line.split(',').skip(1) {
-            match token {
-                "LZ" => format.zero_suppression = ZeroSuppression::Leading,
-                "TZ" => format.zero_suppression = ZeroSuppression::Trailing,
-                _ => {
-                    if let Some((integer_digits, decimal_digits)) = parse_format_token(token)? {
-                        format.integer_digits = integer_digits;
-                        format.decimal_digits = decimal_digits;
-                    }
-                }
+            if let Some(zero_suppression) = zero_suppression_from_excellon_token(token) {
+                format.zero_suppression = zero_suppression;
+            } else if let Some((integer_digits, decimal_digits)) = parse_format_token(token)? {
+                format.integer_digits = integer_digits;
+                format.decimal_digits = decimal_digits;
             }
         }
         self.coordinate_format = format;
@@ -749,6 +759,27 @@ impl DrillParser {
         Ok((code, tool.diameter_mm))
     }
 
+    fn push_repeated_hits(&mut self, count: u32, spacing: CoordinateWords) -> Result<(), JsValue> {
+        let dx = spacing.x.unwrap_or(0.0);
+        let dy = spacing.y.unwrap_or(0.0);
+        let Some((mut x, mut y)) = self.last_hit else {
+            return Err(JsValue::from_str(
+                "Repeat drill record appears before an initial drill hit",
+            ));
+        };
+
+        for _ in 0..count {
+            x += dx;
+            y += dy;
+            self.push_hit(x, y)?;
+        }
+
+        self.current_x = x;
+        self.current_y = y;
+        self.last_hit = Some((x, y));
+        Ok(())
+    }
+
     fn push_hit(&mut self, x: f32, y: f32) -> Result<(), JsValue> {
         let (code, diameter_mm) = self.selected_tool()?;
         if diameter_mm <= 0.0 || !diameter_mm.is_finite() {
@@ -766,6 +797,7 @@ impl DrillParser {
         if let Some(tool) = self.tools.get_mut(&code) {
             tool.hit_count = tool.hit_count.saturating_add(1);
         }
+        self.last_hit = Some((x - self.offset_x, y - self.offset_y));
         Ok(())
     }
 
@@ -1012,6 +1044,89 @@ fn find_g_code_index(line: &str, code: u32) -> Option<usize> {
     line.char_indices()
         .filter(|(_, ch)| *ch == 'G')
         .find_map(|(index, _)| (parse_g_code(&line[index..]) == Some(code)).then_some(index))
+}
+
+fn zero_suppression_from_excellon_token(token: &str) -> Option<ZeroSuppression> {
+    match token {
+        "LZ" => Some(ZeroSuppression::Trailing),
+        "TZ" => Some(ZeroSuppression::Leading),
+        _ => None,
+    }
+}
+
+fn parse_repeat_hole(
+    line: &str,
+    unit: Unit,
+    format: CoordinateFormat,
+) -> Result<Option<(u32, CoordinateWords)>, String> {
+    let Some(rest) = line.strip_prefix('R') else {
+        return Ok(None);
+    };
+    let digits_end = rest
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_digit())
+        .map(|(index, ch)| index + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+    if digits_end == 0 {
+        return Ok(None);
+    }
+    if digits_end > 4 {
+        return Err(format!(
+            "Repeat drill count must be 1 to 4 digits in `{line}`"
+        ));
+    }
+
+    let count = rest[..digits_end]
+        .parse::<u32>()
+        .map_err(|_| format!("Invalid repeat drill count in `{line}`"))?;
+    if count == 0 {
+        return Err(format!("Repeat drill count must be positive in `{line}`"));
+    }
+    let words = parse_repeat_hole_spacing(&rest[digits_end..], unit, format, line)?;
+
+    Ok(Some((count, words)))
+}
+
+fn parse_repeat_hole_spacing(
+    suffix: &str,
+    unit: Unit,
+    format: CoordinateFormat,
+    line: &str,
+) -> Result<CoordinateWords, String> {
+    if suffix.is_empty() || !matches!(suffix.chars().next(), Some('X' | 'Y')) {
+        return Err(format!(
+            "Repeat drill record requires X or Y spacing in `{line}`"
+        ));
+    }
+
+    let mut words = CoordinateWords::default();
+    let mut index = 0;
+    while index < suffix.len() {
+        let word = suffix[index..].chars().next().unwrap_or_default();
+        if !matches!(word, 'X' | 'Y') {
+            return Err(format!(
+                "Repeat drill record only supports X/Y spacing in `{line}`"
+            ));
+        }
+        let value_start = index + word.len_utf8();
+        let token = read_number(&suffix[value_start..])
+            .ok_or_else(|| format!("Invalid repeat drill spacing in `{line}`"))?;
+        let value = parse_coordinate_number(token, unit, format)
+            .map_err(|_| format!("Invalid repeat drill spacing in `{line}`"))?;
+        match word {
+            'X' if words.x.is_none() => words.x = Some(value),
+            'Y' if words.y.is_none() => words.y = Some(value),
+            _ => {
+                return Err(format!(
+                    "Repeat drill record has duplicate spacing word in `{line}`"
+                ));
+            }
+        }
+        index = value_start + token.len();
+    }
+
+    Ok(words)
 }
 
 fn parse_coordinate_words(
@@ -1323,7 +1438,7 @@ fn angle_is_on_sweep(angle: f32, start_angle: f32, sweep_angle: f32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_drill_with_offset;
+    use super::{parse_drill_with_offset, parse_repeat_hole, CoordinateFormat, Unit};
 
     fn assert_approx_eq(actual: f32, expected: f32) {
         assert!(
@@ -1870,7 +1985,28 @@ M30",
     }
 
     #[test]
-    fn honors_trailing_zero_suppressed_metric_coordinates() {
+    fn honors_included_leading_zero_metric_coordinates() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC,LZ
+T01C0.6
+%
+T01
+X009Y010
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("METRIC,LZ omitted-decimal coordinates should parse");
+
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+    }
+
+    #[test]
+    fn honors_included_trailing_zero_metric_coordinates() {
         let parsed = parse_drill_with_offset(
             "\
 M48
@@ -1886,8 +2022,8 @@ M30",
         )
         .expect("METRIC,TZ omitted-decimal coordinates should parse");
 
-        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
-        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 0.009);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 0.010);
     }
 
     #[test]
@@ -1896,12 +2032,12 @@ M30",
             "\
 M48
 METRIC
-TZ
+LZ
 T01C0.6
 %
 T01
 X009Y010
-LZ
+TZ
 X011Y012
 M30",
             0.05,
@@ -1918,12 +2054,66 @@ M30",
     }
 
     #[test]
-    fn ignores_fmat_and_preserves_tz_after_m71() {
+    fn parses_repeat_hole_records() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC,LZ
+T01C0.6
+%
+T01
+X009Y010
+R3X001Y000
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Repeat-hole records should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 4);
+        assert_eq!(parsed.metadata.hit_count, 4);
+        assert_approx_eq(parsed.fill_layer.circles.x[0], 9.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[0], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[1], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[1], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[2], 11.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[2], 10.0);
+        assert_approx_eq(parsed.fill_layer.circles.x[3], 12.0);
+        assert_approx_eq(parsed.fill_layer.circles.y[3], 10.0);
+    }
+
+    #[test]
+    fn rejects_unsupported_repeat_pattern_records() {
+        let error = parse_repeat_hole(
+            "R2M02X001Y001",
+            Unit::Metric,
+            CoordinateFormat::new(Unit::Metric),
+        )
+        .expect_err("Repeat-pattern records should not be treated as repeat holes");
+
+        assert!(error.contains("requires X or Y spacing"));
+    }
+
+    #[test]
+    fn rejects_repeat_hole_counts_over_four_digits() {
+        let error = parse_repeat_hole(
+            "R10000X001Y000",
+            Unit::Metric,
+            CoordinateFormat::new(Unit::Metric),
+        )
+        .expect_err("Repeat-hole counts should be limited");
+
+        assert!(error.contains("1 to 4 digits"));
+    }
+
+    #[test]
+    fn ignores_fmat_and_preserves_zero_format_after_m71() {
         let parsed = parse_drill_with_offset(
             "\
 M48
 FMAT,2
-METRIC,TZ
+METRIC,LZ
 T01C0.6
 %
 M71

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -271,7 +271,7 @@ impl DrillGeometry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 struct CoordinateWords {
     x: Option<f32>,
     y: Option<f32>,
@@ -367,7 +367,9 @@ impl DrillParser {
             return Ok(());
         }
 
-        if line == "G05" {
+        let g_code = parse_g_code(line);
+
+        if g_code == Some(5) {
             self.mode = Mode::Drill;
             self.routing_down = false;
             return Ok(());
@@ -431,7 +433,7 @@ impl DrillParser {
             return Ok(());
         }
 
-        if line.starts_with("G00") {
+        if g_code == Some(0) {
             self.mode = Mode::Rout;
             if let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)? {
                 let (x, y) = self.resolve_xy(words.x, words.y);
@@ -441,7 +443,7 @@ impl DrillParser {
             return Ok(());
         }
 
-        if line.starts_with("G01") {
+        if g_code == Some(1) {
             let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
             else {
                 return Ok(());
@@ -455,26 +457,42 @@ impl DrillParser {
             return Ok(());
         }
 
-        if line.starts_with("G85") {
-            let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
-            else {
+        if g_code == Some(85) {
+            let word_sets = parse_coordinate_word_sets(line, self.unit, self.coordinate_format)?;
+            if word_sets.is_empty() {
                 return Ok(());
+            }
+            let (start_x, start_y, end_words) = if word_sets.len() >= 2 {
+                let (start_x, start_y) = self.resolve_xy(word_sets[0].x, word_sets[0].y);
+                (start_x, start_y, &word_sets[1])
+            } else {
+                (self.current_x, self.current_y, &word_sets[0])
             };
-            let (end_x, end_y) = self.resolve_xy(words.x, words.y);
-            self.push_slot(end_x, end_y)?;
+            let (end_x, end_y) = if self.is_absolute {
+                (
+                    end_words.x.unwrap_or(start_x),
+                    end_words.y.unwrap_or(start_y),
+                )
+            } else {
+                (
+                    start_x + end_words.x.unwrap_or(0.0),
+                    start_y + end_words.y.unwrap_or(0.0),
+                )
+            };
+            self.push_slot_between(start_x, start_y, end_x, end_y)?;
             self.current_x = end_x;
             self.current_y = end_y;
             return Ok(());
         }
 
-        if line.starts_with("G02") || line.starts_with("G03") {
+        if matches!(g_code, Some(2) | Some(3)) {
             let Some(words) = parse_coordinate_words(line, self.unit, self.coordinate_format)?
             else {
                 return Ok(());
             };
             let (end_x, end_y) = self.resolve_xy(words.x, words.y);
             if self.mode == Mode::Rout && self.routing_down {
-                self.push_arc(end_x, end_y, words, line.starts_with("G03"))?;
+                self.push_arc(end_x, end_y, words, g_code == Some(3))?;
             }
             self.current_x = end_x;
             self.current_y = end_y;
@@ -562,6 +580,16 @@ impl DrillParser {
     }
 
     fn push_slot(&mut self, end_x: f32, end_y: f32) -> Result<(), JsValue> {
+        self.push_slot_between(self.current_x, self.current_y, end_x, end_y)
+    }
+
+    fn push_slot_between(
+        &mut self,
+        start_x: f32,
+        start_y: f32,
+        end_x: f32,
+        end_y: f32,
+    ) -> Result<(), JsValue> {
         let (code, diameter_mm) = self.selected_tool()?;
         if diameter_mm <= 0.0 || !diameter_mm.is_finite() {
             return Err(JsValue::from_str(&format!(
@@ -569,8 +597,8 @@ impl DrillParser {
             )));
         }
 
-        let start_x = self.current_x + self.offset_x;
-        let start_y = self.current_y + self.offset_y;
+        let start_x = start_x + self.offset_x;
+        let start_y = start_y + self.offset_y;
         let end_x = end_x + self.offset_x;
         let end_y = end_y + self.offset_y;
         self.outline.push_line(
@@ -711,6 +739,21 @@ fn parse_tool_code(token: &str) -> Option<u32> {
     }
 }
 
+fn parse_g_code(line: &str) -> Option<u32> {
+    let rest = line.strip_prefix('G')?;
+    let digits_end = rest
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_digit())
+        .map(|(index, ch)| index + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+    if digits_end == 0 {
+        return None;
+    }
+
+    rest[..digits_end].parse::<u32>().ok()
+}
+
 fn parse_coordinate_words(
     line: &str,
     unit: Unit,
@@ -725,6 +768,62 @@ fn parse_coordinate_words(
         (x.is_some() || y.is_some() || i.is_some() || j.is_some() || a.is_some())
             .then_some(CoordinateWords { x, y, i, j, a }),
     )
+}
+
+fn parse_coordinate_word_sets(
+    line: &str,
+    unit: Unit,
+    format: CoordinateFormat,
+) -> Result<Vec<CoordinateWords>, JsValue> {
+    let mut words = Vec::new();
+    let mut current = CoordinateWords::default();
+    let mut has_current = false;
+    let mut index = 0;
+
+    while index < line.len() {
+        let Some((relative_index, word)) = line[index..]
+            .char_indices()
+            .find(|(_, ch)| matches!(ch, 'X' | 'Y' | 'I' | 'J' | 'A'))
+        else {
+            break;
+        };
+        index += relative_index;
+
+        let starts_new_set = matches!(
+            (word, current.x, current.y, current.i, current.j, current.a),
+            ('X', Some(_), _, _, _, _)
+                | ('Y', _, Some(_), _, _, _)
+                | ('I', _, _, Some(_), _, _)
+                | ('J', _, _, _, Some(_), _)
+                | ('A', _, _, _, _, Some(_))
+        );
+        if starts_new_set && has_current {
+            words.push(current);
+            current = CoordinateWords::default();
+        }
+
+        let value_start = index + word.len_utf8();
+        let token = read_number(&line[value_start..]).ok_or_else(|| {
+            JsValue::from_str(&format!("Invalid drill coordinate word {word} in `{line}`"))
+        })?;
+        let value = parse_coordinate_number(token, unit, format)?;
+        match word {
+            'X' => current.x = Some(value),
+            'Y' => current.y = Some(value),
+            'I' => current.i = Some(value),
+            'J' => current.j = Some(value),
+            'A' => current.a = Some(value),
+            _ => {}
+        }
+        has_current = true;
+        index = value_start + token.len();
+    }
+
+    if has_current {
+        words.push(current);
+    }
+
+    Ok(words)
 }
 
 fn parse_word_value(
@@ -1041,6 +1140,61 @@ M30",
         assert_approx_eq(parsed.fill_layer.lines.end_x[0], 4.0);
         assert_approx_eq(parsed.fill_layer.lines.end_y[0], 2.0);
         assert_approx_eq(parsed.fill_layer.lines.width[0], 0.8);
+    }
+
+    #[test]
+    fn parses_inline_g85_start_and_end_coordinates() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+G85X1.0Y2.0X4.0Y2.0
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Inline G85 slot endpoints should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 0);
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
+        assert_eq!(parsed.metadata.hit_count, 0);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[0], 1.0);
+        assert_approx_eq(parsed.fill_layer.lines.start_y[0], 2.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[0], 4.0);
+        assert_approx_eq(parsed.fill_layer.lines.end_y[0], 2.0);
+    }
+
+    #[test]
+    fn parses_short_g_rout_commands_as_slot() {
+        let parsed = parse_drill_with_offset(
+            "\
+M48
+METRIC
+T01C0.8
+%
+T01
+G0X8.01Y3.825
+M15
+G1X6.54Y3.825
+M16
+M30",
+            0.05,
+            0.0,
+            0.0,
+        )
+        .expect("Short Excellon rout commands should parse");
+
+        assert_eq!(parsed.fill_layer.circles.x.len(), 0);
+        assert_eq!(parsed.fill_layer.lines.start_x.len(), 1);
+        assert_eq!(parsed.metadata.hit_count, 0);
+        assert_eq!(parsed.metadata.slot_count, 1);
+        assert_approx_eq(parsed.fill_layer.lines.start_x[0], 8.01);
+        assert_approx_eq(parsed.fill_layer.lines.end_x[0], 6.54);
     }
 
     #[test]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,14 +1,19 @@
+mod drill;
 mod parser;
 mod renderer;
 mod shape;
 mod util;
 
+use crate::drill::{parse_drill_with_offset, DrillParseResult};
 use crate::parser::parse_gerber_with_options;
 use crate::renderer::Renderer;
 use crate::shape::{gerber_data_layers_from_js, gerber_data_layers_to_js, Boundary, GerberData};
 use crate::util::format_bytes;
+use js_sys::{Object, Reflect};
 use wasm_bindgen::prelude::*;
 use web_sys::WebGl2RenderingContext;
+
+const DRILL_OUTLINE_WIDTH_MM: f32 = 0.05;
 
 /// Initialize panic hook for better error messages in browser console
 #[wasm_bindgen]
@@ -92,6 +97,36 @@ pub fn parse_gerber_layer_with_options(
     gerber_data_layers_to_js(&gerber_data_layers)
 }
 
+fn drill_parse_result_to_js(drill: DrillParseResult) -> Result<JsValue, JsValue> {
+    let object = Object::new();
+    Reflect::set(
+        &object,
+        &JsValue::from_str("outlineLayer"),
+        &gerber_data_layers_to_js(&[drill.outline_layer])?,
+    )?;
+    Reflect::set(
+        &object,
+        &JsValue::from_str("fillLayer"),
+        &gerber_data_layers_to_js(&[drill.fill_layer])?,
+    )?;
+    Reflect::set(
+        &object,
+        &JsValue::from_str("metadata"),
+        &drill.metadata.to_js()?,
+    )?;
+    Ok(object.into())
+}
+
+#[wasm_bindgen]
+pub fn parse_drill_layer(
+    content: String,
+    offset_x: f32,
+    offset_y: f32,
+) -> Result<JsValue, JsValue> {
+    let drill = parse_drill_with_offset(&content, DRILL_OUTLINE_WIDTH_MM, offset_x, offset_y)?;
+    drill_parse_result_to_js(drill)
+}
+
 /// Main Gerber processor with stateful WebGL renderer
 #[wasm_bindgen]
 pub struct GerberProcessor {
@@ -138,6 +173,48 @@ impl GerberProcessor {
                 "Renderer not initialized. Call init() first.",
             ))
         }
+    }
+
+    fn add_drill_parse_result(&mut self, drill: DrillParseResult) -> Result<JsValue, JsValue> {
+        if !drill.fill_layer.has_geometry() {
+            return Err(JsValue::from_str(
+                "File does not contain valid drill data (no holes found)",
+            ));
+        }
+
+        let Some(renderer) = &mut self.renderer else {
+            return Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ));
+        };
+
+        let outline_layer_id = renderer.add_layer(vec![drill.outline_layer])?;
+        let fill_layer_id = match renderer.add_layer(vec![drill.fill_layer]) {
+            Ok(layer_id) => layer_id,
+            Err(error) => {
+                let _ = renderer.remove_layer(outline_layer_id);
+                return Err(error);
+            }
+        };
+
+        let object = Object::new();
+        Reflect::set(
+            &object,
+            &JsValue::from_str("outlineLayerId"),
+            &JsValue::from_f64(outline_layer_id as f64),
+        )?;
+        Reflect::set(
+            &object,
+            &JsValue::from_str("fillLayerId"),
+            &JsValue::from_f64(fill_layer_id as f64),
+        )?;
+        Reflect::set(
+            &object,
+            &JsValue::from_str("metadata"),
+            &drill.metadata.to_js()?,
+        )?;
+
+        Ok(object.into())
     }
 }
 
@@ -289,6 +366,22 @@ impl GerberProcessor {
         self.add_parsed_layers(gerber_data_layers)
     }
 
+    /// Add an Excellon / NC Drill file as a drill overlay.
+    pub fn add_drill_layer(&mut self, content: String) -> Result<JsValue, JsValue> {
+        let drill = parse_drill_with_offset(&content, DRILL_OUTLINE_WIDTH_MM, 0.0, 0.0)?;
+        self.add_drill_parse_result(drill)
+    }
+
+    pub fn add_drill_layer_with_offset(
+        &mut self,
+        content: String,
+        offset_x: f32,
+        offset_y: f32,
+    ) -> Result<JsValue, JsValue> {
+        let drill = parse_drill_with_offset(&content, DRILL_OUTLINE_WIDTH_MM, offset_x, offset_y)?;
+        self.add_drill_parse_result(drill)
+    }
+
     /// Add a layer from geometry parsed in a worker or another WASM instance.
     pub fn add_parsed_layer(&mut self, parsed_layer: JsValue) -> Result<u32, JsValue> {
         let gerber_data_layers = gerber_data_layers_from_js(&parsed_layer)?;
@@ -427,6 +520,39 @@ impl GerberProcessor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_with_clear_and_blend_modes(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        blend_modes: &[u8],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<String, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.render_with_clear_and_blend_modes(
+                active_layer_ids,
+                color_data,
+                blend_modes,
+                zoom_x,
+                zoom_y,
+                offset_x,
+                offset_y,
+                alpha,
+                clear_canvas,
+            )?;
+            Ok("render_done".to_string())
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
     /// Render into an offscreen framebuffer and return bottom-up RGBA pixels.
     #[allow(clippy::too_many_arguments)]
     pub fn render_pixels_with_clear(
@@ -444,6 +570,38 @@ impl GerberProcessor {
             renderer.render_pixels_with_clear(
                 active_layer_ids,
                 color_data,
+                zoom_x,
+                zoom_y,
+                offset_x,
+                offset_y,
+                alpha,
+                clear_canvas,
+            )
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_pixels_with_clear_and_blend_modes(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        blend_modes: &[u8],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<Vec<u8>, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.render_pixels_with_clear_and_blend_modes(
+                active_layer_ids,
+                color_data,
+                blend_modes,
                 zoom_x,
                 zoom_y,
                 offset_x,
@@ -484,6 +642,49 @@ impl GerberProcessor {
             renderer.render_tile(
                 active_layer_ids,
                 color_data,
+                export_width,
+                export_height,
+                tile_x,
+                tile_y,
+                tile_width,
+                tile_height,
+                zoom_x,
+                zoom_y,
+                offset_x,
+                offset_y,
+                alpha,
+            )?;
+            Ok("render_tile_done".to_string())
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_tile_with_blend_modes(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        blend_modes: &[u8],
+        export_width: u32,
+        export_height: u32,
+        tile_x: u32,
+        tile_y: u32,
+        tile_width: u32,
+        tile_height: u32,
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+    ) -> Result<String, JsValue> {
+        if let Some(renderer) = &mut self.renderer {
+            renderer.render_tile_with_blend_modes(
+                active_layer_ids,
+                color_data,
+                blend_modes,
                 export_width,
                 export_height,
                 tile_x,

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -2249,6 +2249,27 @@ impl Renderer {
         Ok(())
     }
 
+    fn validate_blend_modes(active_layer_ids: &[u32], blend_modes: &[u8]) -> Result<(), JsValue> {
+        if blend_modes.len() != active_layer_ids.len() {
+            return Err(JsValue::from_str(&format!(
+                "Blend mode data length mismatch: expected {}, got {}",
+                active_layer_ids.len(),
+                blend_modes.len()
+            )));
+        }
+        if blend_modes.iter().any(|&mode| mode > 1) {
+            return Err(JsValue::from_str("Blend mode must be 0 or 1"));
+        }
+        Ok(())
+    }
+
+    fn blend_mode_at(blend_modes: Option<&[u8]>, index: usize) -> u8 {
+        blend_modes
+            .and_then(|modes| modes.get(index))
+            .copied()
+            .unwrap_or(0)
+    }
+
     fn color_data_stride(active_layer_ids: &[u32], color_data: &[f32]) -> usize {
         let rgba_len = active_layer_ids.len().saturating_mul(4);
         if color_data.len() >= rgba_len {
@@ -3551,7 +3572,7 @@ impl Renderer {
         // Get transform matrix
         let transform = self.camera.get_transform_matrix(width, height);
 
-        self.render_with_transform(active_layer_ids, color_data, alpha, transform, true)
+        self.render_with_transform(active_layer_ids, color_data, alpha, transform, true, None)
     }
 
     /// Render geometry and optionally preserve the existing canvas contents.
@@ -3585,7 +3606,56 @@ impl Renderer {
 
         let transform = self.camera.get_transform_matrix(width, height);
 
-        self.render_with_transform(active_layer_ids, color_data, alpha, transform, clear_canvas)
+        self.render_with_transform(
+            active_layer_ids,
+            color_data,
+            alpha,
+            transform,
+            clear_canvas,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_with_clear_and_blend_modes(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        blend_modes: &[u8],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<(), JsValue> {
+        Self::validate_render_inputs(
+            active_layer_ids,
+            color_data,
+            zoom_x,
+            zoom_y,
+            offset_x,
+            offset_y,
+            alpha,
+        )?;
+        Self::validate_blend_modes(active_layer_ids, blend_modes)?;
+
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
+        let (width, height) = self.get_canvas_size()?;
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
+        }
+
+        let transform = self.camera.get_transform_matrix(width, height);
+
+        self.render_with_transform(
+            active_layer_ids,
+            color_data,
+            alpha,
+            transform,
+            clear_canvas,
+            Some(blend_modes),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3635,7 +3705,66 @@ impl Renderer {
             tile_height,
         );
 
-        self.render_with_transform(active_layer_ids, color_data, alpha, transform, true)
+        self.render_with_transform(active_layer_ids, color_data, alpha, transform, true, None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_tile_with_blend_modes(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        blend_modes: &[u8],
+        export_width: u32,
+        export_height: u32,
+        tile_x: u32,
+        tile_y: u32,
+        tile_width: u32,
+        tile_height: u32,
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+    ) -> Result<(), JsValue> {
+        Self::validate_render_inputs(
+            active_layer_ids,
+            color_data,
+            zoom_x,
+            zoom_y,
+            offset_x,
+            offset_y,
+            alpha,
+        )?;
+        Self::validate_blend_modes(active_layer_ids, blend_modes)?;
+        Self::validate_tile_inputs(
+            export_width,
+            export_height,
+            tile_x,
+            tile_y,
+            tile_width,
+            tile_height,
+        )?;
+
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
+        let transform = Self::tile_transform_matrix(
+            self.camera
+                .get_transform_matrix(export_width, export_height),
+            export_width,
+            export_height,
+            tile_x,
+            tile_y,
+            tile_width,
+            tile_height,
+        );
+
+        self.render_with_transform(
+            active_layer_ids,
+            color_data,
+            alpha,
+            transform,
+            true,
+            Some(blend_modes),
+        )
     }
 
     /// Render to an offscreen framebuffer and return bottom-up RGBA pixels.
@@ -3685,6 +3814,83 @@ impl Renderer {
                 color_data,
                 alpha,
                 clear_canvas,
+                None,
+                Some(&output_fbo.framebuffer),
+            )?;
+            self.gl
+                .read_pixels_with_opt_u8_array(
+                    0,
+                    0,
+                    width_i32,
+                    height_i32,
+                    WebGl2RenderingContext::RGBA,
+                    WebGl2RenderingContext::UNSIGNED_BYTE,
+                    Some(&mut pixels),
+                )
+                .map_err(|error| {
+                    if error.is_string() {
+                        error
+                    } else {
+                        JsValue::from_str("Failed to read rendered pixels")
+                    }
+                })?;
+            Ok(pixels)
+        })();
+
+        Self::delete_fbo(&self.gl, output_fbo);
+        result
+    }
+
+    /// Render to an offscreen framebuffer with per-layer composite modes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_pixels_with_clear_and_blend_modes(
+        &mut self,
+        active_layer_ids: &[u32],
+        color_data: &[f32],
+        blend_modes: &[u8],
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+        alpha: f32,
+        clear_canvas: bool,
+    ) -> Result<Vec<u8>, JsValue> {
+        Self::validate_render_inputs(
+            active_layer_ids,
+            color_data,
+            zoom_x,
+            zoom_y,
+            offset_x,
+            offset_y,
+            alpha,
+        )?;
+        Self::validate_blend_modes(active_layer_ids, blend_modes)?;
+
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
+        let (width, height) = self.get_canvas_size()?;
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str("Cannot render to a zero-sized canvas"));
+        }
+
+        let transform = self.camera.get_transform_matrix(width, height);
+        let width_i32 = Self::checked_u32_to_i32("canvas width", width)?;
+        let height_i32 = Self::checked_u32_to_i32("canvas height", height)?;
+        let pixel_count = Self::checked_u32_to_usize("render output width", width)?
+            .checked_mul(Self::checked_u32_to_usize("render output height", height)?)
+            .and_then(|value| value.checked_mul(4))
+            .ok_or_else(|| JsValue::from_str("Render output size exceeds platform limits"))?;
+        let mut pixels = Self::reserved_vec("render output pixels", pixel_count)?;
+        pixels.resize(pixel_count, 0);
+
+        let output_fbo = Self::create_fbo(&self.gl, width, height, false)?;
+        let result = (|| {
+            self.render_layer_fbos(active_layer_ids, transform, width, height)?;
+            self.composite_layers_to_target(
+                active_layer_ids,
+                color_data,
+                alpha,
+                clear_canvas,
+                Some(blend_modes),
                 Some(&output_fbo.framebuffer),
             )?;
             self.gl
@@ -3718,6 +3924,7 @@ impl Renderer {
         alpha: f32,
         transform: [f32; 9],
         clear_canvas: bool,
+        blend_modes: Option<&[u8]>,
     ) -> Result<(), JsValue> {
         let (width, height) = self.get_canvas_size()?;
         if width == 0 || height == 0 {
@@ -3728,7 +3935,13 @@ impl Renderer {
         self.render_layer_fbos(active_layer_ids, transform, width, height)?;
 
         // STEP 2: Composite FBOs to canvas
-        self.composite_layers(active_layer_ids, color_data, alpha, clear_canvas)?;
+        self.composite_layers(
+            active_layer_ids,
+            color_data,
+            alpha,
+            clear_canvas,
+            blend_modes,
+        )?;
 
         Ok(())
     }
@@ -3839,8 +4052,16 @@ impl Renderer {
         color_data: &[f32],
         alpha: f32,
         clear_canvas: bool,
+        blend_modes: Option<&[u8]>,
     ) -> Result<(), JsValue> {
-        self.composite_layers_to_target(active_layer_ids, color_data, alpha, clear_canvas, None)
+        self.composite_layers_to_target(
+            active_layer_ids,
+            color_data,
+            alpha,
+            clear_canvas,
+            blend_modes,
+            None,
+        )
     }
 
     fn composite_layers_to_target(
@@ -3849,6 +4070,7 @@ impl Renderer {
         color_data: &[f32],
         alpha: f32,
         clear_canvas: bool,
+        blend_modes: Option<&[u8]>,
         target_framebuffer: Option<&WebGlFramebuffer>,
     ) -> Result<(), JsValue> {
         // Get canvas dimensions
@@ -3866,9 +4088,7 @@ impl Renderer {
             self.gl.clear(COLOR_BUFFER_BIT);
         }
 
-        // Setup additive blending for layer compositing (lighter blend mode)
         self.gl.enable(BLEND);
-        self.gl.blend_func(ONE, ONE);
         self.gl.blend_equation(FUNC_ADD);
 
         // Render each active layer's FBO to canvas with its color/alpha
@@ -3890,6 +4110,16 @@ impl Renderer {
                         color_data[color_offset + 2],
                         layer_alpha,
                     ];
+                    if Self::blend_mode_at(blend_modes, color_index) == 1 {
+                        self.gl.blend_func_separate(
+                            ONE,
+                            ONE_MINUS_SRC_ALPHA,
+                            ONE,
+                            ONE_MINUS_SRC_ALPHA,
+                        );
+                    } else {
+                        self.gl.blend_func(ONE, ONE);
+                    }
                     self.draw_fbo_texture(&layer.fbo.texture, &color)?;
                 }
             }

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -2257,8 +2257,8 @@ impl Renderer {
                 blend_modes.len()
             )));
         }
-        if blend_modes.iter().any(|&mode| mode > 1) {
-            return Err(JsValue::from_str("Blend mode must be 0 or 1"));
+        if blend_modes.iter().any(|&mode| mode > 2) {
+            return Err(JsValue::from_str("Blend mode must be 0, 1, or 2"));
         }
         Ok(())
     }
@@ -4110,15 +4110,24 @@ impl Renderer {
                         color_data[color_offset + 2],
                         layer_alpha,
                     ];
-                    if Self::blend_mode_at(blend_modes, color_index) == 1 {
-                        self.gl.blend_func_separate(
-                            ONE,
-                            ONE_MINUS_SRC_ALPHA,
-                            ONE,
-                            ONE_MINUS_SRC_ALPHA,
-                        );
-                    } else {
-                        self.gl.blend_func(ONE, ONE);
+                    match Self::blend_mode_at(blend_modes, color_index) {
+                        1 => {
+                            self.gl.blend_func_separate(
+                                ONE,
+                                ONE_MINUS_SRC_ALPHA,
+                                ONE,
+                                ONE_MINUS_SRC_ALPHA,
+                            );
+                        }
+                        2 => {
+                            self.gl.blend_func_separate(
+                                ZERO,
+                                ONE_MINUS_SRC_ALPHA,
+                                ZERO,
+                                ONE_MINUS_SRC_ALPHA,
+                            );
+                        }
+                        _ => self.gl.blend_func(ONE, ONE),
                     }
                     self.draw_fbo_texture(&layer.fbo.texture, &color)?;
                 }


### PR DESCRIPTION
## Summary

- add Excellon/XNC drill parsing for hits, linear routes, and routed arcs
- render drills as grouped overlay layers with background-colored fills and drill metadata in the layer list
- expose drill rendering through the browser package, Node package, CLI, screenshots, and archive/file loading

## Notes

This also handles LibrePCB-style drill headers such as `FMAT,2`, `METRIC,TZ`, `M71`, and `T0/T00` tool unloads. Routed drill arcs are sent through the existing arc primitive path instead of being flattened into straight slots.

## Validation

- `cargo test --manifest-path wasm/Cargo.toml --lib`
- `node --check js/main.js && npm run check --prefix packages/wasm-gerber-renderer`
- `./scripts/vercel-build.sh`
