### PR TITLE
[codex] Share parser number helpers

### DIFF
--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -1,3 +1,8 @@
+use crate::parse_common::{
+    find_g_code_index, line_has_g_code, parse_coordinate_number as parse_common_coordinate_number,
+    parse_decimal_number as parse_common_decimal_number, parse_g_code, read_number,
+    CoordinateFormat as CommonCoordinateFormat, ZeroSuppression,
+};
 use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
     Triangles,
@@ -38,12 +43,6 @@ impl Unit {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum ZeroSuppression {
-    Leading,
-    Trailing,
-}
-
 #[derive(Clone, Copy, Debug)]
 struct CoordinateFormat {
     integer_digits: u32,
@@ -57,6 +56,14 @@ impl CoordinateFormat {
             integer_digits: unit.default_integer_digits(),
             decimal_digits: unit.default_decimal_digits(),
             zero_suppression: ZeroSuppression::Leading,
+        }
+    }
+
+    fn to_common(self) -> CommonCoordinateFormat {
+        CommonCoordinateFormat {
+            integer_digits: self.integer_digits,
+            decimal_digits: self.decimal_digits,
+            zero_suppression: self.zero_suppression,
         }
     }
 }
@@ -962,7 +969,7 @@ fn parse_tool_declaration(line: &str, unit: Unit) -> Result<Option<(u32, f32)>, 
         .ok_or_else(|| JsValue::from_str("Invalid drill tool declaration"))?;
     let code = parse_tool_code(&line[1..c_index])
         .ok_or_else(|| JsValue::from_str("Invalid drill tool number"))?;
-    let diameter_token = read_number(&line[c_index + 1..])
+    let diameter_token = read_number(&line[c_index + 1..], true)
         .ok_or_else(|| JsValue::from_str("Invalid drill tool diameter"))?;
     let diameter = parse_decimal_number(diameter_token)? * unit.multiplier();
     if diameter <= 0.0 || !diameter.is_finite() {
@@ -1002,7 +1009,7 @@ fn parse_tool_selection_suffix(mut suffix: &str) -> Result<(), String> {
             return Err(format!("Invalid drill tool selection suffix `{suffix}`"));
         }
         let value_start = word.len_utf8();
-        let Some(token) = read_number(&suffix[value_start..]) else {
+        let Some(token) = read_number(&suffix[value_start..], true) else {
             return Err(format!("Invalid drill tool selection suffix `{suffix}`"));
         };
         let value = token
@@ -1025,27 +1032,6 @@ fn parse_tool_code(token: &str) -> Option<u32> {
     }
 }
 
-fn parse_g_code(line: &str) -> Option<u32> {
-    let rest = line.strip_prefix('G')?;
-    let digits_end = rest
-        .char_indices()
-        .take_while(|(_, ch)| ch.is_ascii_digit())
-        .map(|(index, ch)| index + ch.len_utf8())
-        .last()
-        .unwrap_or(0);
-    if digits_end == 0 {
-        return None;
-    }
-
-    rest[..digits_end].parse::<u32>().ok()
-}
-
-fn line_has_g_code(line: &str, code: u32) -> bool {
-    line.char_indices()
-        .filter(|(_, ch)| *ch == 'G')
-        .any(|(index, _)| parse_g_code(&line[index..]) == Some(code))
-}
-
 fn parse_g85_words(
     line: &str,
     unit: Unit,
@@ -1064,12 +1050,6 @@ fn parse_g85_words(
         return Ok(Some((start_words, end_words)));
     }
     Ok(None)
-}
-
-fn find_g_code_index(line: &str, code: u32) -> Option<usize> {
-    line.char_indices()
-        .filter(|(_, ch)| *ch == 'G')
-        .find_map(|(index, _)| (parse_g_code(&line[index..]) == Some(code)).then_some(index))
 }
 
 fn zero_suppression_from_excellon_token(token: &str) -> Option<ZeroSuppression> {
@@ -1136,7 +1116,7 @@ fn parse_repeat_hole_spacing(
             ));
         }
         let value_start = index + word.len_utf8();
-        let token = read_number(&suffix[value_start..])
+        let token = read_number(&suffix[value_start..], true)
             .ok_or_else(|| format!("Invalid repeat drill spacing in `{line}`"))?;
         let value = parse_coordinate_number(token, unit, format)
             .map_err(|_| format!("Invalid repeat drill spacing in `{line}`"))?;
@@ -1204,7 +1184,7 @@ fn parse_coordinate_word_sets(
         }
 
         let value_start = index + word.len_utf8();
-        let token = read_number(&line[value_start..]).ok_or_else(|| {
+        let token = read_number(&line[value_start..], true).ok_or_else(|| {
             JsValue::from_str(&format!("Invalid drill coordinate word {word} in `{line}`"))
         })?;
         let value = parse_coordinate_number(token, unit, format)?;
@@ -1237,22 +1217,11 @@ fn parse_word_value(
         return Ok(None);
     };
     let value_start = index + word.len_utf8();
-    let token = read_number(&line[value_start..]).ok_or_else(|| {
+    let token = read_number(&line[value_start..], true).ok_or_else(|| {
         JsValue::from_str(&format!("Invalid drill coordinate word {word} in `{line}`"))
     })?;
 
     Ok(Some(parse_coordinate_number(token, unit, format)?))
-}
-
-fn read_number(text: &str) -> Option<&str> {
-    let end = text
-        .char_indices()
-        .take_while(|(_, ch)| ch.is_ascii_digit() || matches!(ch, '.' | '+' | '-'))
-        .map(|(index, ch)| index + ch.len_utf8())
-        .last()
-        .unwrap_or(0);
-
-    (end > 0).then_some(&text[..end])
 }
 
 fn parse_coordinate_number(
@@ -1260,46 +1229,12 @@ fn parse_coordinate_number(
     unit: Unit,
     format: CoordinateFormat,
 ) -> Result<f32, JsValue> {
-    let value = if token.contains('.') {
-        parse_decimal_number(token)?
-    } else {
-        parse_omitted_decimal_number(token, format)?
-    };
-
-    Ok(value * unit.multiplier())
+    parse_common_coordinate_number(token, format.to_common(), unit.multiplier(), "drill")
+        .map_err(|message| JsValue::from_str(&message))
 }
 
 fn parse_decimal_number(token: &str) -> Result<f32, JsValue> {
-    token
-        .parse::<f32>()
-        .map_err(|_| JsValue::from_str(&format!("Invalid drill number `{token}`")))
-}
-
-fn parse_omitted_decimal_number(token: &str, format: CoordinateFormat) -> Result<f32, JsValue> {
-    let sign = if token.starts_with('-') { -1.0 } else { 1.0 };
-    let digits = token.trim_start_matches(['+', '-']);
-    if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
-        return Err(JsValue::from_str(&format!(
-            "Invalid drill number `{token}`"
-        )));
-    }
-
-    let value_token = match format.zero_suppression {
-        ZeroSuppression::Leading => digits.to_string(),
-        ZeroSuppression::Trailing => {
-            let total_digits = (format.integer_digits + format.decimal_digits) as usize;
-            if digits.len() >= total_digits {
-                digits.to_string()
-            } else {
-                format!("{digits:0<total_digits$}")
-            }
-        }
-    };
-    let value = value_token
-        .parse::<i64>()
-        .map_err(|_| JsValue::from_str(&format!("Invalid drill number `{token}`")))?;
-    let divisor = 10_i64.pow(format.decimal_digits) as f32;
-    Ok(sign * value as f32 / divisor)
+    parse_common_decimal_number(token, "drill").map_err(|message| JsValue::from_str(&message))
 }
 
 fn parse_format_token(token: &str) -> Result<Option<(u32, u32)>, JsValue> {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,5 @@
 mod drill;
+mod parse_common;
 mod parser;
 mod renderer;
 mod shape;

--- a/wasm/src/parse_common.rs
+++ b/wasm/src/parse_common.rs
@@ -1,0 +1,159 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ZeroSuppression {
+    Leading,
+    Trailing,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CoordinateFormat {
+    pub integer_digits: u32,
+    pub decimal_digits: u32,
+    pub zero_suppression: ZeroSuppression,
+}
+
+pub fn read_number(text: &str, allow_decimal: bool) -> Option<&str> {
+    let end = text
+        .char_indices()
+        .take_while(|(_, ch)| {
+            ch.is_ascii_digit() || matches!(ch, '+' | '-') || (allow_decimal && *ch == '.')
+        })
+        .map(|(index, ch)| index + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+
+    (end > 0).then_some(&text[..end])
+}
+
+pub fn read_word_value(line: &str, word: char, allow_decimal: bool) -> Option<&str> {
+    let index = line.find(word)?;
+    read_number(&line[index + word.len_utf8()..], allow_decimal)
+}
+
+pub fn parse_g_code(line: &str) -> Option<u32> {
+    let rest = line.strip_prefix('G')?;
+    let digits_end = rest
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_digit())
+        .map(|(index, ch)| index + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+    if digits_end == 0 {
+        return None;
+    }
+
+    rest[..digits_end].parse::<u32>().ok()
+}
+
+pub fn line_has_g_code(line: &str, code: u32) -> bool {
+    line.char_indices()
+        .filter(|(_, ch)| *ch == 'G')
+        .any(|(index, _)| parse_g_code(&line[index..]) == Some(code))
+}
+
+pub fn find_g_code_index(line: &str, code: u32) -> Option<usize> {
+    line.char_indices()
+        .filter(|(_, ch)| *ch == 'G')
+        .find_map(|(index, _)| (parse_g_code(&line[index..]) == Some(code)).then_some(index))
+}
+
+pub fn parse_decimal_number(token: &str, context: &str) -> Result<f32, String> {
+    token
+        .parse::<f32>()
+        .map_err(|_| format!("Invalid {context} number `{token}`"))
+}
+
+pub fn parse_omitted_decimal_number(
+    token: &str,
+    format: CoordinateFormat,
+    context: &str,
+) -> Result<f32, String> {
+    let sign = if token.starts_with('-') { -1.0 } else { 1.0 };
+    let digits = token.trim_start_matches(['+', '-']);
+    if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(format!("Invalid {context} number `{token}`"));
+    }
+
+    let value_token = match format.zero_suppression {
+        ZeroSuppression::Leading => digits.to_string(),
+        ZeroSuppression::Trailing => {
+            let total_digits = (format.integer_digits + format.decimal_digits) as usize;
+            if digits.len() >= total_digits {
+                digits.to_string()
+            } else {
+                format!("{digits:0<total_digits$}")
+            }
+        }
+    };
+    let value = value_token
+        .parse::<i64>()
+        .map_err(|_| format!("Invalid {context} number `{token}`"))?;
+    let divisor = 10_i64.pow(format.decimal_digits) as f32;
+    Ok(sign * value as f32 / divisor)
+}
+
+pub fn parse_coordinate_number(
+    token: &str,
+    format: CoordinateFormat,
+    unit_multiplier: f32,
+    context: &str,
+) -> Result<f32, String> {
+    let value = if token.contains('.') {
+        parse_decimal_number(token, context)?
+    } else {
+        parse_omitted_decimal_number(token, format, context)?
+    };
+
+    Ok(value * unit_multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        find_g_code_index, line_has_g_code, parse_coordinate_number, parse_g_code, read_number,
+        read_word_value, CoordinateFormat, ZeroSuppression,
+    };
+
+    #[test]
+    fn parses_g_code_words() {
+        assert_eq!(parse_g_code("G03X1Y2"), Some(3));
+        assert_eq!(parse_g_code("G85X1Y2"), Some(85));
+        assert_eq!(parse_g_code("X1Y2"), None);
+        assert_eq!(find_g_code_index("X1G85Y2", 85), Some(2));
+        assert!(line_has_g_code("G00X1G85Y2", 85));
+    }
+
+    #[test]
+    fn reads_coordinate_number_tokens() {
+        assert_eq!(read_number("-12.340Y1", true), Some("-12.340"));
+        assert_eq!(read_number("-12340Y1", false), Some("-12340"));
+        assert_eq!(read_word_value("X-10.5Y2", 'X', true), Some("-10.5"));
+        assert_eq!(read_word_value("X-10.5Y2", 'Y', true), Some("2"));
+    }
+
+    #[test]
+    fn parses_zero_suppressed_coordinates() {
+        let leading = CoordinateFormat {
+            integer_digits: 3,
+            decimal_digits: 3,
+            zero_suppression: ZeroSuppression::Leading,
+        };
+        let trailing = CoordinateFormat {
+            integer_digits: 3,
+            decimal_digits: 3,
+            zero_suppression: ZeroSuppression::Trailing,
+        };
+
+        assert_eq!(
+            parse_coordinate_number("009", leading, 1.0, "test").unwrap(),
+            0.009
+        );
+        assert_eq!(
+            parse_coordinate_number("009", trailing, 1.0, "test").unwrap(),
+            9.0
+        );
+        assert_eq!(
+            parse_coordinate_number("1.5", leading, 25.4, "test").unwrap(),
+            38.1
+        );
+    }
+}

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1,3 +1,7 @@
+use crate::parse_common::{
+    parse_g_code, parse_omitted_decimal_number, read_word_value,
+    CoordinateFormat as CommonCoordinateFormat, ZeroSuppression,
+};
 use crate::parser::{Aperture, FormatSpec, ParserState, Polarity, PolarityLayer, ZeroOmission};
 use crate::shape::PathRegions;
 use crate::util::{format_bytes, format_count};
@@ -942,33 +946,7 @@ pub fn offset_primitive_by(primitive: &Primitive, dx: f32, dy: f32) -> Primitive
 
 /// Extracts the numeric value after a specific character in a string (e.g., "X1000" → "1000")
 pub fn extract_value(line: &str, key: char) -> Option<String> {
-    let key_str = key.to_string();
-    if let Some(pos) = line.find(&key_str) {
-        let rest = &line[pos + 1..];
-        let mut value = String::new();
-        let mut has_minus = false;
-
-        for ch in rest.chars() {
-            if ch == '-' || ch == '+' {
-                has_minus = ch == '-';
-            } else if ch.is_ascii_digit() {
-                if has_minus && value.is_empty() {
-                    value.push('-');
-                }
-                value.push(ch);
-            } else {
-                break;
-            }
-        }
-
-        if value.is_empty() {
-            None
-        } else {
-            Some(value)
-        }
-    } else {
-        None
-    }
+    read_word_value(line, key, false).map(ToString::to_string)
 }
 
 /// Coordinate value conversion - decimal point processing according to format spec
@@ -978,53 +956,28 @@ pub fn convert_coordinate(
     format_spec: &FormatSpec,
     unit_multiplier: f32,
 ) -> f32 {
-    let normalized_coord;
-    let coord_str = if format_spec.zero_omission == ZeroOmission::Trailing {
-        let (sign, digits) = match coord_str.as_bytes().first().copied() {
-            Some(b'-') | Some(b'+') => coord_str.split_at(1),
-            _ => ("", coord_str),
-        };
-        let total_digits = match axis {
-            'x' => format_spec.x_total_digits,
-            'y' => format_spec.y_total_digits,
-            _ => 0,
-        }
-        .max(0) as usize;
-
-        if digits.len() < total_digits {
-            normalized_coord = format!("{sign}{digits:0<total_digits$}");
-            normalized_coord.as_str()
-        } else {
-            coord_str
-        }
-    } else {
-        coord_str
+    let (integer_digits, decimal_digits) = match axis {
+        'x' => (format_spec.x_integer_digits, format_spec.x_decimal_digits),
+        'y' => (format_spec.y_integer_digits, format_spec.y_decimal_digits),
+        _ => (0, 4),
     };
+    let zero_suppression = match format_spec.zero_omission {
+        ZeroOmission::Leading => ZeroSuppression::Leading,
+        ZeroOmission::Trailing => ZeroSuppression::Trailing,
+    };
+    let result = parse_omitted_decimal_number(
+        coord_str,
+        CommonCoordinateFormat {
+            integer_digits,
+            decimal_digits,
+            zero_suppression,
+        },
+        "Gerber coordinate",
+    )
+    .map(|value| value * unit_multiplier)
+    .unwrap_or(0.0);
 
-    if let Ok(val) = coord_str.parse::<i64>() {
-        let divisor = match axis {
-            'x' => format_spec.x_divisor,
-            'y' => format_spec.y_divisor,
-            _ => 10000.0,
-        };
-
-        // Check for division by zero
-        if divisor == 0.0 || !divisor.is_finite() {
-            return 0.0;
-        }
-
-        // Divide by decimal point position (no padding) and then convert units (1.0 for mm, 25.4 for inch)
-        let result = (val as f64 / divisor) as f32 * unit_multiplier;
-
-        // Check for numeric overflow
-        if !result.is_finite() {
-            return 0.0;
-        }
-
-        result
-    } else {
-        0.0
-    }
+    result.is_finite().then_some(result).unwrap_or(0.0)
 }
 
 /// Flash aperture at given position without Step and Repeat
@@ -2160,8 +2113,8 @@ pub fn parse_graphic_command(
     let clean_line = line.trim_end_matches('*');
 
     // Process G-code
-    if let Some(g_match) = extract_value(clean_line, 'G') {
-        if let Ok(g_code) = g_match.parse::<u32>() {
+    if let Some(g_index) = clean_line.find('G') {
+        if let Some(g_code) = parse_g_code(&clean_line[g_index..]) {
             match g_code {
                 1 => {
                     // G01: Linear interpolation (1x scale)


### PR DESCRIPTION
## Summary
- Add a shared Rust parse_common module for low-level number, G-code, and zero-suppressed coordinate helpers
- Reuse the shared helpers from both Gerber geometry parsing and Excellon drill parsing
- Keep Gerber and drill state machines separate while adding focused helper tests

- ## Checks
- cargo test --manifest-path wasm/Cargo.toml --lib
- npm run check --prefix packages/wasm-gerber-renderer
- cargo fmt --manifest-path wasm/Cargo.toml -- --check
- git diff --check

- Subagent pre-push review: no blockers found.