### PR TITLE
Share coordinate parsing between Gerber and drill

### DIFF
--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -1,7 +1,7 @@
 use crate::parse_common::{
     find_g_code_index, line_has_g_code, parse_coordinate_number as parse_common_coordinate_number,
     parse_decimal_number as parse_common_decimal_number, parse_g_code, read_number,
-    CoordinateFormat as CommonCoordinateFormat, ZeroSuppression,
+    CoordinateFormat, ZeroSuppression,
 };
 use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
@@ -43,28 +43,11 @@ impl Unit {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-struct CoordinateFormat {
-    integer_digits: u32,
-    decimal_digits: u32,
-    zero_suppression: ZeroSuppression,
-}
-
-impl CoordinateFormat {
-    fn new(unit: Unit) -> Self {
-        Self {
-            integer_digits: unit.default_integer_digits(),
-            decimal_digits: unit.default_decimal_digits(),
-            zero_suppression: ZeroSuppression::Leading,
-        }
-    }
-
-    fn to_common(self) -> CommonCoordinateFormat {
-        CommonCoordinateFormat {
-            integer_digits: self.integer_digits,
-            decimal_digits: self.decimal_digits,
-            zero_suppression: self.zero_suppression,
-        }
+fn default_coordinate_format(unit: Unit) -> CoordinateFormat {
+    CoordinateFormat {
+        integer_digits: unit.default_integer_digits(),
+        decimal_digits: unit.default_decimal_digits(),
+        zero_suppression: ZeroSuppression::Leading,
     }
 }
 
@@ -400,7 +383,7 @@ impl DrillParser {
 
         Ok(Self {
             unit: Unit::Metric,
-            coordinate_format: CoordinateFormat::new(Unit::Metric),
+            coordinate_format: default_coordinate_format(Unit::Metric),
             coordinate_format_from_comment: false,
             mode: Mode::Drill,
             routing_interpolation: RoutingInterpolation::Linear,
@@ -743,7 +726,7 @@ impl DrillParser {
 
     fn set_unit(&mut self, unit: Unit, line: &str) -> Result<(), JsValue> {
         self.unit = unit;
-        let mut format = CoordinateFormat::new(unit);
+        let mut format = default_coordinate_format(unit);
         if self.coordinate_format_from_comment {
             format.integer_digits = self.coordinate_format.integer_digits;
             format.decimal_digits = self.coordinate_format.decimal_digits;
@@ -1229,7 +1212,7 @@ fn parse_coordinate_number(
     unit: Unit,
     format: CoordinateFormat,
 ) -> Result<f32, JsValue> {
-    parse_common_coordinate_number(token, format.to_common(), unit.multiplier(), "drill")
+    parse_common_coordinate_number(token, format, unit.multiplier(), "drill")
         .map_err(|message| JsValue::from_str(&message))
 }
 
@@ -1399,7 +1382,7 @@ fn angle_is_on_sweep(angle: f32, start_angle: f32, sweep_angle: f32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_drill_with_offset, parse_repeat_hole, CoordinateFormat, Unit};
+    use super::{default_coordinate_format, parse_drill_with_offset, parse_repeat_hole, Unit};
 
     fn assert_approx_eq(actual: f32, expected: f32) {
         assert!(
@@ -2074,7 +2057,7 @@ M30",
         let error = parse_repeat_hole(
             "R2M02X001Y001",
             Unit::Metric,
-            CoordinateFormat::new(Unit::Metric),
+            default_coordinate_format(Unit::Metric),
         )
         .expect_err("Repeat-pattern records should not be treated as repeat holes");
 
@@ -2086,7 +2069,7 @@ M30",
         let error = parse_repeat_hole(
             "R10000X001Y000",
             Unit::Metric,
-            CoordinateFormat::new(Unit::Metric),
+            default_coordinate_format(Unit::Metric),
         )
         .expect_err("Repeat-hole counts should be limited");
 

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -5,7 +5,7 @@ mod state;
 
 // Export only what's needed externally
 pub use aperture::Aperture;
-pub use state::{FormatSpec, ParserState, Polarity, ZeroOmission};
+pub use state::{FormatSpec, ParserState, Polarity};
 
 // Internal use only
 use aperture::parse_aperture;

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1,8 +1,5 @@
-use crate::parse_common::{
-    parse_g_code, parse_omitted_decimal_number, read_word_value,
-    CoordinateFormat as CommonCoordinateFormat, ZeroSuppression,
-};
-use crate::parser::{Aperture, FormatSpec, ParserState, Polarity, PolarityLayer, ZeroOmission};
+use crate::parse_common::{parse_coordinate_number, parse_g_code, read_word_value};
+use crate::parser::{Aperture, FormatSpec, ParserState, Polarity, PolarityLayer};
 use crate::shape::PathRegions;
 use crate::util::{format_bytes, format_count};
 use i_overlay::core::fill_rule::FillRule;
@@ -949,6 +946,10 @@ pub fn extract_value(line: &str, key: char) -> Option<String> {
     read_word_value(line, key, false).map(ToString::to_string)
 }
 
+fn extract_coordinate_value(line: &str, key: char) -> Option<String> {
+    read_word_value(line, key, true).map(ToString::to_string)
+}
+
 /// Coordinate value conversion - decimal point processing according to format spec
 pub fn convert_coordinate(
     coord_str: &str,
@@ -956,25 +957,12 @@ pub fn convert_coordinate(
     format_spec: &FormatSpec,
     unit_multiplier: f32,
 ) -> f32 {
-    let (integer_digits, decimal_digits) = match axis {
-        'x' => (format_spec.x_integer_digits, format_spec.x_decimal_digits),
-        'y' => (format_spec.y_integer_digits, format_spec.y_decimal_digits),
-        _ => (0, 4),
-    };
-    let zero_suppression = match format_spec.zero_omission {
-        ZeroOmission::Leading => ZeroSuppression::Leading,
-        ZeroOmission::Trailing => ZeroSuppression::Trailing,
-    };
-    let result = parse_omitted_decimal_number(
+    let result = parse_coordinate_number(
         coord_str,
-        CommonCoordinateFormat {
-            integer_digits,
-            decimal_digits,
-            zero_suppression,
-        },
+        format_spec.coordinate_format(axis),
+        unit_multiplier,
         "Gerber coordinate",
     )
-    .map(|value| value * unit_multiplier)
     .unwrap_or(0.0);
 
     result.is_finite().then_some(result).unwrap_or(0.0)
@@ -2246,10 +2234,10 @@ pub fn parse_graphic_command(
     }
 
     // Extract coordinates and D-code using regex
-    let x_match = extract_value(clean_line, 'X');
-    let y_match = extract_value(clean_line, 'Y');
-    let i_match = extract_value(clean_line, 'I');
-    let j_match = extract_value(clean_line, 'J');
+    let x_match = extract_coordinate_value(clean_line, 'X');
+    let y_match = extract_coordinate_value(clean_line, 'Y');
+    let i_match = extract_coordinate_value(clean_line, 'I');
+    let j_match = extract_coordinate_value(clean_line, 'J');
     let d_match = extract_value(clean_line, 'D');
 
     let mut x = state.x;

--- a/wasm/src/parser/state.rs
+++ b/wasm/src/parser/state.rs
@@ -1,5 +1,8 @@
 use super::geometry::Primitive;
 use super::PolarityLayer;
+use crate::parse_common::{
+    CoordinateFormat as CommonCoordinateFormat, ZeroSuppression as CommonZeroSuppression,
+};
 use crate::shape::PathRegions;
 use std::mem::take;
 
@@ -43,6 +46,25 @@ impl Default for FormatSpec {
             y_divisor: 10000.0, // 10^4
             x_total_digits: 6,  // 2 + 4
             y_total_digits: 6,  // 2 + 4
+        }
+    }
+}
+
+impl FormatSpec {
+    pub fn coordinate_format(&self, axis: char) -> CommonCoordinateFormat {
+        let (integer_digits, decimal_digits) = match axis {
+            'x' | 'X' => (self.x_integer_digits, self.x_decimal_digits),
+            'y' | 'Y' => (self.y_integer_digits, self.y_decimal_digits),
+            _ => (0, 4),
+        };
+
+        CommonCoordinateFormat {
+            integer_digits,
+            decimal_digits,
+            zero_suppression: match self.zero_omission {
+                ZeroOmission::Leading => CommonZeroSuppression::Leading,
+                ZeroOmission::Trailing => CommonZeroSuppression::Trailing,
+            },
         }
     }
 }

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -98,6 +98,40 @@ M02*",
 }
 
 #[test]
+fn explicit_decimal_coordinates_use_common_number_parser() {
+    let layers = parse_gerber(
+        "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+X1.25Y-2.5D03*
+M02*",
+    )
+    .expect("explicit decimal coordinates should parse");
+
+    assert_eq!(layers.len(), 1);
+    assert!(has_circle_at(&layers[0].circles, 1.25, -2.5, 0.5));
+}
+
+#[test]
+fn x_and_y_coordinate_formats_can_differ() {
+    let layers = parse_gerber(
+        "\
+%FSLAX24Y36*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+X010000Y1000000D03*
+M02*",
+    )
+    .expect("mixed X/Y coordinate formats should parse");
+
+    assert_eq!(layers.len(), 1);
+    assert!(has_circle_at(&layers[0].circles, 1.0, 1.0, 0.5));
+}
+
+#[test]
 fn x2_attributes_are_ignored_for_image_rendering() {
     let layers = parse_gerber(
         "\


### PR DESCRIPTION
## Summary
- use the shared coordinate format/parser for drill coordinate parsing instead of a drill-local duplicate type
- route Gerber coordinate conversion through the shared coordinate parser while keeping Gerber and Excellon state machines separate
- add Gerber regression tests for explicit decimal coordinates and different X/Y coordinate formats

## Checks
- cargo fmt --manifest-path wasm/Cargo.toml -- --check
- cargo test --manifest-path wasm/Cargo.toml --lib
- npm run check --prefix packages/wasm-gerber-renderer
- wasm-pack build wasm --target web --out-dir pkg