### PR TITLE
[codex] Fix collapsed drawer control layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -522,6 +522,8 @@ button {
 
 .side-panel.collapsed .panel-section[data-panel="layers"] {
   display: flex;
+  flex-direction: column;
+  gap: 12px;
   padding: 10px;
 }
 
@@ -1528,6 +1530,7 @@ button {
   }
 
   .side-panel.collapsed .panel-section[data-panel="layers"] {
+    gap: 8px;
     padding: 8px 10px;
   }
 


### PR DESCRIPTION
## Summary
- Ensure the collapsed layers panel defines its own column layout even when Layers was not the active tab before collapsing.
- Keep mobile collapsed drawer spacing consistent so All/Top/Bottom flex across the bottom drawer.

## Validation
- npm --prefix packages/wasm-gerber-renderer run check
- git diff --check origin/main..HEAD
- final diff reviewed by one gpt-5.5 xhigh subagent reviewer; no blockers found