### PR TITLE
[codex] Avoid bundling repo-only WASM fallback

### DIFF
--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -1,6 +1,8 @@
+const DEV_WASM_MODULE_PATH = "../../wasm/pkg/wasm_gerber_processor.js";
+
 export const DEFAULT_WASM_MODULE_URLS = [
   new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
-  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
+  new URL(getDevWasmModulePath(), import.meta.url),
 ];
 
 export const DEFAULT_COLORS = [
@@ -175,6 +177,10 @@ const CSS_NAMED_COLORS = new Map([
   ["yellow", [255, 255, 0, 255]],
   ["yellowgreen", [154, 205, 50, 255]],
 ]);
+
+function getDevWasmModulePath() {
+  return DEV_WASM_MODULE_PATH;
+}
 
 export class FrameState {
   constructor(options, extra = {}) {

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -1,14 +1,6 @@
 export const DEFAULT_WASM_MODULE_URLS = [
-  // Bundle-size analyzers using webpack/Rspack reject auxiliary JS assets
-  // emitted from these package-relative WASM loader URLs.
-  new URL(
-    /* webpackIgnore: true */ "./wasm/wasm_gerber_processor.js",
-    import.meta.url,
-  ),
-  new URL(
-    /* webpackIgnore: true */ "../../wasm/pkg/wasm_gerber_processor.js",
-    import.meta.url,
-  ),
+  new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
+  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
 ];
 
 export const DEFAULT_COLORS = [

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -1,6 +1,14 @@
 export const DEFAULT_WASM_MODULE_URLS = [
-  new URL("./wasm/wasm_gerber_processor.js", import.meta.url),
-  new URL("../../wasm/pkg/wasm_gerber_processor.js", import.meta.url),
+  // Bundle-size analyzers using webpack/Rspack reject auxiliary JS assets
+  // emitted from these package-relative WASM loader URLs.
+  new URL(
+    /* webpackIgnore: true */ "./wasm/wasm_gerber_processor.js",
+    import.meta.url,
+  ),
+  new URL(
+    /* webpackIgnore: true */ "../../wasm/pkg/wasm_gerber_processor.js",
+    import.meta.url,
+  ),
 ];
 
 export const DEFAULT_COLORS = [


### PR DESCRIPTION
## Summary
- Keep the published package WASM loader URL as a static `new URL("./wasm/wasm_gerber_processor.js", import.meta.url)` so webpack/Rspack consumers can still emit and rewrite the bundled asset.
- Hide only the repo-local development fallback path from bundler static analysis, because `../../wasm/pkg/wasm_gerber_processor.js` is not present in the published package.
- Pair this package-side cleanup with the upstream `package-build-stats` config fix in https://github.com/pastelsky/package-build-stats/pull/74.

## Root Cause
The Bundlephobia failure has two parts. In this package, the default fallback list contained a repo-only development path that published-package bundlers could try to resolve. Separately, `package-build-stats` leaves Rspack asset modules on the default hashed filename pattern, while its asset parser expects emitted non-runtime assets to contain `.bundle.`.

The package fix here avoids bundling the missing dev fallback without reintroducing `webpackIgnore` on the real published WASM loader asset. The visible Bundlephobia suffix error is addressed in the upstream PR by setting Rspack asset module output to a hash-preserving `.bundle` filename.

## Validation
- `npm --prefix packages/wasm-gerber-renderer run check`
- `git diff --check`
- Packed-package Rspack smoke through public `createGerberRenderer` import:
  - default Rspack output includes `caaf4c9c800939e7.js`
  - with upstream-style `assetModuleFilename: "[name].[contenthash:8].bundle[ext]"`, output includes `wasm_gerber_processor.11529b57.bundle.js`
- Project-required subagent review completed with no blockers after the final diff.
