### PR TITLE
[codex] Add WebGL feature picking interactions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,7 @@
   --panel-bottom-collapse-threshold: 200px;
   --toolbar-height: 58px;
   --status-height: 34px;
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --radius: 8px;
 }
 
@@ -62,6 +63,7 @@ button {
 .app-shell {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   display: grid;
   grid-template-rows: var(--toolbar-height) minmax(0, 1fr);
   background: var(--bg);
@@ -469,8 +471,18 @@ button {
   right: var(--panel-overlay-width);
 }
 
+.workspace.panel-open .empty-state,
+.workspace.panel-open .canvas-status {
+  right: var(--panel-overlay-width);
+}
+
 .workspace:has(.side-panel.collapsed) .empty-state,
 .workspace:has(.side-panel.collapsed) .canvas-status {
+  right: var(--panel-collapsed-width);
+}
+
+.workspace.panel-collapsed .empty-state,
+.workspace.panel-collapsed .canvas-status {
   right: var(--panel-collapsed-width);
 }
 
@@ -1464,8 +1476,20 @@ button {
     bottom: var(--panel-overlay-height);
   }
 
+  .workspace.panel-open .empty-state,
+  .workspace.panel-open .canvas-status {
+    right: 0;
+    bottom: var(--panel-overlay-height);
+  }
+
   .workspace:has(.side-panel.collapsed) .empty-state,
   .workspace:has(.side-panel.collapsed) .canvas-status {
+    right: 0;
+    bottom: var(--panel-collapsed-height);
+  }
+
+  .workspace.panel-collapsed .empty-state,
+  .workspace.panel-collapsed .canvas-status {
     right: 0;
     bottom: var(--panel-collapsed-height);
   }
@@ -1479,6 +1503,8 @@ button {
     width: auto !important;
     height: var(--panel-height);
     max-height: min(72vh, 560px);
+    max-height: min(72dvh, 560px);
+    padding-bottom: var(--safe-area-bottom);
     z-index: 30;
     border-left: 0;
     border-top: 1px solid var(--line);

--- a/js/drawer-controller.js
+++ b/js/drawer-controller.js
@@ -14,6 +14,7 @@ export class DrawerController {
     this.resizeHandle = resizeHandle;
     this.toggleButton = toggleButton;
     this.dropZone = dropZone;
+    this.workspace = drawer.closest(".workspace");
     this.refreshIcons = refreshIcons;
     this.captureViewState = captureViewState;
     this.onResizeEnd = onResizeEnd;
@@ -69,11 +70,13 @@ export class DrawerController {
     if (this.isMobileLayout()) {
       this.drawer.classList.add("collapsed");
     }
+    this.syncPanelStateClasses();
     this.updateCanvasReservationForState();
     this.updateToggleState();
   }
 
-  syncLayout() {
+  syncLayout({ commitLayout = true } = {}) {
+    this.syncPanelStateClasses();
     if (this.drawer.classList.contains("collapsed")) {
       this.syncCollapsedLayout();
       this.updateCanvasReservationForState();
@@ -81,9 +84,17 @@ export class DrawerController {
     }
 
     if (this.isMobileLayout()) {
-      this.setHeight(this.currentHeight);
+      this.setHeight(this.currentHeight, {
+        commitLayout,
+        reserveCanvas: true,
+        trackPending: false,
+      });
     } else {
-      this.setWidth(this.currentWidth);
+      this.setWidth(this.currentWidth, {
+        commitLayout,
+        reserveCanvas: true,
+        trackPending: false,
+      });
     }
   }
 
@@ -100,6 +111,16 @@ export class DrawerController {
 
   isMobileLayout() {
     return this.window.matchMedia("(max-width: 760px)").matches;
+  }
+
+  syncPanelStateClasses() {
+    if (!this.workspace) {
+      return;
+    }
+
+    const isCollapsed = this.drawer.classList.contains("collapsed");
+    this.workspace.classList.toggle("panel-collapsed", isCollapsed);
+    this.workspace.classList.toggle("panel-open", !isCollapsed);
   }
 
   getCssPixelValue(propertyName, fallback) {
@@ -146,7 +167,14 @@ export class DrawerController {
     return Math.min(this.getMaxWidth(), Math.max(this.minWidth, width));
   }
 
-  setWidth(width, { commitLayout = true } = {}) {
+  setWidth(
+    width,
+    {
+      commitLayout = true,
+      reserveCanvas = commitLayout,
+      trackPending = !commitLayout,
+    } = {},
+  ) {
     const clampedWidth = this.clampWidth(width);
     this.dropZone.style.setProperty("--panel-overlay-width", `${clampedWidth}px`);
     if (commitLayout) {
@@ -158,7 +186,15 @@ export class DrawerController {
         `${clampedWidth}px`,
       );
     } else {
-      this.pendingWidth = clampedWidth;
+      if (trackPending) {
+        this.pendingWidth = clampedWidth;
+      }
+      if (reserveCanvas) {
+        this.dropZone.style.setProperty(
+          "--canvas-reserved-width",
+          `${clampedWidth}px`,
+        );
+      }
     }
     this.drawer.style.height = "";
     this.drawer.style.width = `${clampedWidth}px`;
@@ -167,9 +203,24 @@ export class DrawerController {
   getMaxHeight() {
     const viewportLimit = Math.max(
       1,
-      Math.floor(this.window.innerHeight * this.mobileMaxHeightRatio),
+      Math.floor(this.getViewportHeight() * this.mobileMaxHeightRatio),
     );
     return Math.min(this.maxHeight, viewportLimit);
+  }
+
+  getViewportHeight() {
+    const visualViewportHeight = this.window.visualViewport?.height;
+    return Number.isFinite(visualViewportHeight)
+      ? visualViewportHeight
+      : this.window.innerHeight;
+  }
+
+  getViewportBottom() {
+    const visualViewport = this.window.visualViewport;
+    if (visualViewport && Number.isFinite(visualViewport.height)) {
+      return visualViewport.offsetTop + visualViewport.height;
+    }
+    return this.window.innerHeight;
   }
 
   clampHeight(height) {
@@ -182,7 +233,14 @@ export class DrawerController {
     return Math.min(maxHeight, Math.max(minHeight, height));
   }
 
-  setHeight(height, { commitLayout = true } = {}) {
+  setHeight(
+    height,
+    {
+      commitLayout = true,
+      reserveCanvas = commitLayout,
+      trackPending = !commitLayout,
+    } = {},
+  ) {
     const clampedHeight = this.clampHeight(height);
     this.dropZone.style.setProperty("--panel-overlay-height", `${clampedHeight}px`);
     if (commitLayout) {
@@ -194,7 +252,15 @@ export class DrawerController {
         `${clampedHeight}px`,
       );
     } else {
-      this.pendingHeight = clampedHeight;
+      if (trackPending) {
+        this.pendingHeight = clampedHeight;
+      }
+      if (reserveCanvas) {
+        this.dropZone.style.setProperty(
+          "--canvas-reserved-height",
+          `${clampedHeight}px`,
+        );
+      }
     }
     this.drawer.style.width = "";
     this.drawer.style.height = `${clampedHeight}px`;
@@ -218,7 +284,7 @@ export class DrawerController {
 
     if (this.isMobileLayout()) {
       const clientY = event.touches ? event.touches[0].clientY : event.clientY;
-      this.previewResize(this.window.innerHeight - clientY, "height");
+      this.previewResize(this.getViewportBottom() - clientY, "height");
       return;
     }
 
@@ -244,6 +310,7 @@ export class DrawerController {
     }
 
     this.drawer.classList.remove("collapsed");
+    this.syncPanelStateClasses();
     if (axis === "height") {
       this.setHeight(rawSize, { commitLayout: false });
     } else {
@@ -256,6 +323,7 @@ export class DrawerController {
 
   collapsePreview(axis, collapsedSize) {
     this.drawer.classList.add("collapsed");
+    this.syncPanelStateClasses();
     if (axis === "height") {
       this.pendingHeight = null;
       this.dropZone.style.setProperty(
@@ -307,6 +375,7 @@ export class DrawerController {
 
     if (shouldOpen) {
       this.drawer.classList.remove("collapsed");
+      this.syncPanelStateClasses();
       if (this.isMobileLayout()) {
         this.setHeight(this.currentHeight);
       } else {
@@ -315,6 +384,7 @@ export class DrawerController {
     } else {
       this.captureCurrentSize();
       this.drawer.classList.add("collapsed");
+      this.syncPanelStateClasses();
     }
 
     this.updateCanvasReservationForState();

--- a/js/main.js
+++ b/js/main.js
@@ -261,8 +261,13 @@ function formatFeatureTypeLabel(feature, layer) {
       return "Aperture flash";
     case "aperture-draw":
       return "Aperture draw";
-    case "arc-draw":
+    case "arc-draw": {
+      const arcCommand = feature.properties?.arcCommand;
+      if (arcCommand === "G02" || arcCommand === "G03") {
+        return `${arcCommand} arc draw`;
+      }
       return "Arc draw";
+    }
     case "region":
       return "Region";
     case "drill-hit":
@@ -305,7 +310,7 @@ function formatFeaturePropertyParts(feature, unit) {
   }
 
   if (Number.isFinite(rotation) && rotation !== 0) {
-    parts.push(`rot ${((rotation * 180) / Math.PI).toFixed(2)} deg`);
+    parts.push(`rot ${((-rotation * 180) / Math.PI).toFixed(2)} deg`);
   }
   if (Number.isFinite(vertices) && vertices > 0) {
     parts.push(`${Math.trunc(vertices)} vertices`);

--- a/js/main.js
+++ b/js/main.js
@@ -782,13 +782,15 @@ export class GerberViewer {
 
     // Resize Canvas
     this.resizeCanvas();
-    window.addEventListener("resize", () => {
+    const handleViewportResize = () => {
       this.resizeCanvas();
       this.drawerController.updateToggleState();
       if (this.screenshotDialog.open) {
         this.updateScreenshotResolutionPreview();
       }
-    });
+    };
+    window.addEventListener("resize", handleViewportResize);
+    window.visualViewport?.addEventListener("resize", handleViewportResize);
 
     this.setupEventListeners();
 
@@ -914,8 +916,12 @@ export class GerberViewer {
     }
   }
 
-  resizeCanvas({ allowProcessorResize = false, preserveViewState = null } = {}) {
-    this.drawerController.syncLayout();
+  resizeCanvas({
+    allowProcessorResize = false,
+    preserveViewState = null,
+    commitDrawerLayout = false,
+  } = {}) {
+    this.drawerController.syncLayout({ commitLayout: commitDrawerLayout });
 
     const rect = this.canvas.getBoundingClientRect();
     const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,7 @@ import { renderLayerList as renderLayerListView } from "./layer-list.js";
 import {
   drawMeasurementsOnContext,
   formatDimensionPair,
+  formatMeasurementLength,
   renderMeasurements as renderMeasurementOverlay,
 } from "./measurements.js";
 import { NotificationCenter } from "./notifications.js";
@@ -63,6 +64,7 @@ const PTH_DRILL_TYPE = "pth";
 const NPTH_DRILL_TYPE = "npth";
 const DEFAULT_PTH_DRILL_COLOR = [1.0, 1.0, 0.0];
 const DEFAULT_NPTH_DRILL_COLOR = [1.0, 1.0, 1.0];
+const POINTER_TAP_MAX_MOVEMENT_PX = 6;
 
 class ParseWorkerUnavailableError extends Error {
   constructor(message) {
@@ -212,6 +214,101 @@ function normalizeLayerOffset(offset = {}) {
 
 function hasLayerOffset(offset) {
   return offset.x !== 0 || offset.y !== 0;
+}
+
+function formatSelectedFeatureSummary(selection, { unit = "mm" } = {}) {
+  if (!selection) return "";
+
+  const { layer } = selection;
+  const feature = selection.feature ?? selection;
+  const parts = [];
+  if (layer?.name) {
+    parts.push(layer.name);
+  }
+
+  if (isDrillLayer(layer)) {
+    parts.push(String(layer.drillType ?? PTH_DRILL_TYPE).toUpperCase());
+  } else if (feature.aperture) {
+    parts.push(feature.aperture);
+  }
+
+  parts.push(formatFeatureTypeLabel(feature, layer));
+
+  if (!isDrillLayer(layer) && feature.apertureType) {
+    parts.push(formatApertureTypeLabel(feature));
+  }
+
+  parts.push(...formatFeaturePropertyParts(feature, unit));
+  return parts.filter(Boolean).join(" | ");
+}
+
+function formatFeatureTypeLabel(feature, layer) {
+  if (isDrillLayer(layer)) {
+    return feature.aperture ?? "";
+  }
+
+  switch (feature.featureType) {
+    case "aperture-flash":
+      return "Aperture flash";
+    case "aperture-draw":
+      return "Aperture draw";
+    case "arc-draw":
+      return "Arc draw";
+    case "region":
+      return "Region";
+    case "drill-hit":
+      return "Drill hit";
+    case "drill-slot":
+      return "Drill slot";
+    default:
+      return "Feature";
+  }
+}
+
+function formatApertureTypeLabel(feature) {
+  if (feature.apertureType === "macro") {
+    return feature.macroName
+      ? `Macro aperture ${feature.macroName}`
+      : "Macro aperture";
+  }
+  return `${feature.apertureType} aperture`;
+}
+
+function formatFeaturePropertyParts(feature, unit) {
+  const properties = feature.properties ?? {};
+  const parts = [];
+  const diameter = Number(properties.diameter);
+  const width = Number(properties.width);
+  const height = Number(properties.height);
+  const rotation = Number(properties.rotation);
+  const vertices = Number(properties.vertices);
+  const toolCode = Number(properties.toolCode);
+
+  if (Number.isFinite(diameter) && diameter > 0) {
+    parts.push(`dia ${formatMeasurementLength(diameter, unit)}`);
+  } else if (
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width > 0 &&
+    height > 0
+  ) {
+    parts.push(`size ${formatDimensionPair(width, height, unit)}`);
+  }
+
+  if (Number.isFinite(rotation) && rotation !== 0) {
+    parts.push(`rot ${((rotation * 180) / Math.PI).toFixed(2)} deg`);
+  }
+  if (Number.isFinite(vertices) && vertices > 0) {
+    parts.push(`${Math.trunc(vertices)} vertices`);
+  }
+  const formattedToolCode = Number.isFinite(toolCode) && toolCode > 0
+    ? `T${String(Math.trunc(toolCode)).padStart(2, "0")}`
+    : "";
+  if (formattedToolCode && formattedToolCode !== feature.aperture) {
+    parts.push(formattedToolCode);
+  }
+
+  return parts;
 }
 
 function getParseWorkerCount(layerCount) {
@@ -514,6 +611,7 @@ export class GerberViewer {
     this.wasmModule = null;
     this.wasmExports = null;
     this.wasmProcessor = null;
+    this.interactionsEnabled = true;
     this.isWebGlContextLost = false;
     this.isRestoringWebGlContext = false;
     this.isRecoveringWasmProcessor = false;
@@ -545,6 +643,8 @@ export class GerberViewer {
     // Interaction
     this.isPanning = false;
     this.lastMousePos = { x: 0, y: 0 };
+    this.mouseDownPos = { x: 0, y: 0 };
+    this.selectedFeature = null;
 
     // Touch interaction
     this.isTouching = false;
@@ -552,6 +652,11 @@ export class GerberViewer {
     this.initialPinchDistance = null;
     this.lastPinchDistance = null;
     this.lastTouchCenter = { x: 0, y: 0 };
+    this.touchStartPoint = null;
+    this.touchTapPoint = null;
+    this.touchTapIdentifier = null;
+    this.touchTapCandidate = false;
+    this.touchGestureWasMultitouch = false;
     this.activeRulerTouchIdentifier = null;
     this.rulerTouchStartPoint = null;
     this.rulerTouchPoint = null;
@@ -687,7 +792,10 @@ export class GerberViewer {
   }
 
   createWebGlContext() {
-    const gl = this.canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+    const gl = this.canvas.getContext("webgl2", {
+      preserveDrawingBuffer: true,
+      stencil: true,
+    });
     if (!gl) {
       throw new Error("WebGL2 not supported");
     }
@@ -730,6 +838,10 @@ export class GerberViewer {
     if (typeof processor?.set_minimum_feature_pixels === "function") {
       processor.set_minimum_feature_pixels(this.minimumFeaturePixels);
     }
+
+    if (typeof processor?.set_interactions_enabled === "function") {
+      processor.set_interactions_enabled(this.interactionsEnabled);
+    }
   }
 
   normalizePersistedParserOptions() {
@@ -770,10 +882,10 @@ export class GerberViewer {
   ensureParserOptionsSupported({
     preserveArcRegions = this.preserveArcRegions,
     arcTessellationQuality = this.arcTessellationQuality,
-  } = {}) {
+  } = {}, processor = this.wasmProcessor) {
     if (
       !preserveArcRegions &&
-      typeof this.wasmProcessor?.set_preserve_arc_regions !== "function"
+      typeof processor?.set_preserve_arc_regions !== "function"
     ) {
       throw new Error("Region arc options require an updated WASM module");
     }
@@ -781,7 +893,7 @@ export class GerberViewer {
     if (
       !preserveArcRegions &&
       arcTessellationQuality !== "normal" &&
-      typeof this.wasmProcessor?.set_arc_tessellation_quality !== "function"
+      typeof processor?.set_arc_tessellation_quality !== "function"
     ) {
       throw new Error("Arc tessellation quality requires an updated WASM module");
     }
@@ -1130,6 +1242,7 @@ export class GerberViewer {
 
     this.disposeWasmProcessor();
     this.layers = [];
+    this.clearSelectedFeature({ refresh: false });
     this.createWebGlProcessor();
     this.isWebGlContextLost = false;
     this.resizeCanvas({ allowProcessorResize: true, preserveViewState: viewState });
@@ -1154,6 +1267,7 @@ export class GerberViewer {
     return {
       preserveArcRegions: this.preserveArcRegions,
       arcTessellationQuality: this.getArcTessellationQualityLevel(),
+      interactionsEnabled: this.interactionsEnabled,
     };
   }
 
@@ -1531,7 +1645,7 @@ export class GerberViewer {
           total: layerSnapshot.length,
         });
 
-        if (layer.kind === DRILL_LAYER_KIND) {
+        if (this.interactionsEnabled || layer.kind === DRILL_LAYER_KIND) {
           parsedLayers.push({ ...layer, parsedLayer: null });
         } else {
           try {
@@ -1583,6 +1697,13 @@ export class GerberViewer {
                   layerOptions,
                   stagedProcessor,
                 )
+              : this.interactionsEnabled
+                ? await this.createGerberLayerRecord(
+                    layer.name,
+                    layer.sourceContent,
+                    layerOptions,
+                    stagedProcessor,
+                  )
               : await this.createParsedLayerRecord(
                   layer.name,
                   layer.parsedLayer,
@@ -1604,6 +1725,7 @@ export class GerberViewer {
         this.wasmProcessor = stagedProcessor;
         stagedProcessor = null;
         this.layers = stagedLayers;
+        this.clearSelectedFeature({ refresh: false });
         this.disposeWasmProcessorInstance(previousProcessor, "previous processor");
       } catch (error) {
         this.nextLayerDomId = nextLayerDomId;
@@ -1740,6 +1862,12 @@ export class GerberViewer {
   }
 
   formatCombinedBounds() {
+    if (this.selectedFeature) {
+      return formatSelectedFeatureSummary(this.selectedFeature, {
+        unit: this.measurementUnit,
+      });
+    }
+
     if (this.layers.length === 0) {
       return "No bounds";
     }
@@ -2225,7 +2353,7 @@ export class GerberViewer {
 
   async loadLayerSources(layerSources, { title = "Loading files" } = {}) {
     const total = layerSources.length;
-    if (layerSources.some(isDrillSource)) {
+    if (this.interactionsEnabled || layerSources.some(isDrillSource)) {
       return this.loadLayerSourcesSerially(layerSources, { title, total });
     }
 
@@ -2554,6 +2682,10 @@ export class GerberViewer {
   async parseLayerContent(content, offset, parseWorkerPool) {
     const normalizedOffset = normalizeLayerOffset(offset);
     const parseOptions = this.getParseOptions();
+
+    if (parseOptions.interactionsEnabled) {
+      throw new Error("Interactive parsing must run inside the active WASM processor");
+    }
 
     if (parseWorkerPool) {
       return parseWorkerPool.parse(content, normalizedOffset, parseOptions);
@@ -2947,6 +3079,7 @@ export class GerberViewer {
     if (layerSnapshot.length === 0) {
       this.disposeWasmProcessor();
       this.createWebGlProcessor();
+      this.clearSelectedFeature({ refresh: false });
       this.clearRecoveredPendingLayerRecords(recoveredPendingLayerIds);
       return;
     }
@@ -2969,6 +3102,7 @@ export class GerberViewer {
     try {
       this.disposeWasmProcessor();
       this.layers = [];
+      this.clearSelectedFeature({ refresh: false });
       this.createWebGlProcessor();
       this.resizeCanvas({ allowProcessorResize: true, preserveViewState: viewState });
 
@@ -3084,32 +3218,42 @@ export class GerberViewer {
   }
 
   async addLayer(name, content, options = {}) {
+    const layer = await this.createGerberLayerRecord(name, content, options);
+    return this.commitLayerMetadata(layer);
+  }
+
+  async createGerberLayerRecord(
+    name,
+    content,
+    options = {},
+    processor = this.wasmProcessor,
+  ) {
     try {
       if (!options.skipFatalRecovery) {
         await this.waitForWasmProcessorRecovery();
       }
-      if (!this.wasmProcessor || this.isWebGlContextLost) {
+      if (!processor || this.isWebGlContextLost) {
         throw new Error("WebGL renderer is not available");
       }
 
       // add layer to WASM processor and get layer ID
-      this.ensureParserOptionsSupported();
+      this.ensureParserOptionsSupported({}, processor);
       this.reserveWasmInputCapacity(content);
       const offset = normalizeLayerOffset(options.offset);
       if (
         hasLayerOffset(offset) &&
-        typeof this.wasmProcessor.add_layer_with_offset !== "function"
+        typeof processor.add_layer_with_offset !== "function"
       ) {
         throw new Error("Layer offset requires an updated WASM module");
       }
       const layerId = hasLayerOffset(offset)
-        ? this.wasmProcessor.add_layer_with_offset(content, offset.x, offset.y)
-        : this.wasmProcessor.add_layer(content);
-      this.addLayerMetadata(name, layerId, {
+        ? processor.add_layer_with_offset(content, offset.x, offset.y)
+        : processor.add_layer(content);
+      return this.createLayerMetadata(name, layerId, {
         ...options,
         sourceContent: options.sourceContent ?? content,
         offset,
-      });
+      }, processor);
     } catch (error) {
       if (isNoGeometryError(getErrorMessage(error))) {
         console.warn(`[Layer] Skipped layer ${name}:`, error);
@@ -3301,6 +3445,7 @@ export class GerberViewer {
           this.globalAlpha,
         );
       }
+      this.renderSelectedFeatureHighlight();
       this.zoomReadout.textContent = this.formatZoom();
     } catch (error) {
       const message = getErrorMessage(error);
@@ -3309,6 +3454,34 @@ export class GerberViewer {
     }
 
     this.renderMeasurements();
+  }
+
+  renderSelectedFeatureHighlight() {
+    if (
+      !this.selectedFeature ||
+      typeof this.wasmProcessor?.render_interaction_highlight !== "function"
+    ) {
+      return;
+    }
+
+    try {
+      if (this.clearSelectedFeatureIfUnavailable()) {
+        return;
+      }
+      this.wasmProcessor.render_interaction_highlight(
+        this.selectedFeature.layerId,
+        this.selectedFeature.featureId,
+        this.getViewScaleX(),
+        this.getViewScaleY(),
+        this.camera.offsetX,
+        this.camera.offsetY,
+      );
+    } catch (error) {
+      const message = getErrorMessage(error);
+      console.error("[Render] Failed to render feature highlight:", error);
+      this.addDiagnostic("error", "Feature highlight failed", message);
+      this.clearSelectedFeature();
+    }
   }
 
   getRenderLayerPayload() {
@@ -3488,6 +3661,8 @@ export class GerberViewer {
     this.isPanning = true;
     this.lastMousePos.x = e.clientX;
     this.lastMousePos.y = e.clientY;
+    this.mouseDownPos.x = e.clientX;
+    this.mouseDownPos.y = e.clientY;
   }
 
   handleMouseMove(e) {
@@ -3576,6 +3751,16 @@ export class GerberViewer {
 
     const deltaX = e.clientX - this.lastMousePos.x;
     const deltaY = e.clientY - this.lastMousePos.y;
+    const totalDeltaX = e.clientX - this.mouseDownPos.x;
+    const totalDeltaY = e.clientY - this.mouseDownPos.y;
+    if (
+      e.type === "mouseup" &&
+      Math.hypot(totalDeltaX, totalDeltaY) <= POINTER_TAP_MAX_MOVEMENT_PX
+    ) {
+      this.selectFeatureAtCanvasPoint(e.clientX, e.clientY);
+      return;
+    }
+
     panCameraByScreenDelta({
       deltaX,
       deltaY,
@@ -3584,6 +3769,114 @@ export class GerberViewer {
     });
 
     this.requestRender();
+  }
+
+  selectFeatureAtCanvasPoint(clientX, clientY) {
+    const point = this.canvasPointToWorld(clientX, clientY);
+    if (
+      !point ||
+      !this.interactionsEnabled ||
+      typeof this.wasmProcessor?.pick_interaction_feature !== "function"
+    ) {
+      this.clearSelectedFeature();
+      return;
+    }
+
+    const hit = this.wasmProcessor.pick_interaction_feature(
+      this.getVisibleInteractionLayerIds(),
+      point.x,
+      point.y,
+      this.getFeatureHitToleranceWorld(clientX, clientY),
+    );
+    this.selectedFeature = hit ? this.attachLayerToSelectedFeature(hit) : null;
+    this.updateUiState();
+    this.renderMeasurements();
+    this.requestRender();
+  }
+
+  clearSelectedFeature({ refresh = true } = {}) {
+    if (!this.selectedFeature) return;
+    this.selectedFeature = null;
+    if (!refresh) return;
+    this.updateUiState();
+    this.renderMeasurements();
+    this.requestRender();
+  }
+
+  clearSelectedFeatureForHiddenLayer(layer) {
+    if (!layer.visible && this.selectedFeature?.layerId === this.getLayerInteractionLayerId(layer)) {
+      this.clearSelectedFeature();
+    }
+  }
+
+  attachLayerToSelectedFeature(feature) {
+    const layerId = Number(feature?.layerId);
+    const featureId = Number(feature?.featureId);
+    if (!Number.isFinite(layerId) || !Number.isFinite(featureId)) {
+      return null;
+    }
+
+    const layer = this.layers.find(
+      (candidate) => this.getLayerInteractionLayerId(candidate) === layerId,
+    );
+    if (!layer || !layer.visible) {
+      return null;
+    }
+
+    return {
+      ...feature,
+      layerId,
+      featureId,
+      layer,
+    };
+  }
+
+  getSelectedFeatureLayer() {
+    if (!this.selectedFeature) return null;
+    return this.layers.find(
+      (layer) =>
+        this.getLayerInteractionLayerId(layer) === this.selectedFeature.layerId,
+    ) ?? null;
+  }
+
+  clearSelectedFeatureIfUnavailable() {
+    const layer = this.getSelectedFeatureLayer();
+    if (this.selectedFeature && (!layer || !layer.visible)) {
+      this.clearSelectedFeature();
+      return true;
+    }
+    return false;
+  }
+
+  getVisibleInteractionLayerIds() {
+    const layerIds = [];
+    for (const layer of this.layers) {
+      if (layer.visible && !isDrillLayer(layer)) {
+        layerIds.push(layer.layerId);
+      }
+    }
+    for (const layer of this.layers) {
+      if (layer.visible && isDrillLayer(layer)) {
+        layerIds.push(layer.outlineLayerId);
+      }
+    }
+    return new Uint32Array(layerIds.filter(Number.isFinite));
+  }
+
+  getLayerInteractionLayerId(layer) {
+    return isDrillLayer(layer) ? layer?.outlineLayerId : layer?.layerId;
+  }
+
+  getFeatureHitToleranceWorld(clientX, clientY) {
+    const point = this.canvasPointToWorld(clientX, clientY);
+    const offsetPoint = this.canvasPointToWorld(clientX + 8, clientY);
+    if (!point || !offsetPoint) {
+      return 0.05;
+    }
+    return Math.max(
+      0.01,
+      Math.hypot(offsetPoint.x - point.x, offsetPoint.y - point.y),
+    );
   }
 
   // Touch event handlers
@@ -3603,6 +3896,8 @@ export class GerberViewer {
     }
 
     if (this.touches.length === 2) {
+      this.cancelTouchTapTracking();
+      this.touchGestureWasMultitouch = true;
       // Two-finger gesture: pinch-to-zoom
       this.initialPinchDistance = this.calculateTouchDistance(
         this.touches[0],
@@ -3613,11 +3908,15 @@ export class GerberViewer {
       const center = this.getTouchCenter(this.touches[0], this.touches[1]);
       this.lastTouchCenter = center;
     } else if (this.touches.length === 1) {
+      this.startTouchTapTracking(this.touches[0]);
       // Single finger: pan
       this.lastTouchCenter = {
         x: this.touches[0].clientX,
         y: this.touches[0].clientY,
       };
+    } else {
+      this.cancelTouchTapTracking();
+      this.touchGestureWasMultitouch = true;
     }
   }
 
@@ -3644,6 +3943,8 @@ export class GerberViewer {
     }
 
     if (this.touches.length === 2) {
+      this.cancelTouchTapTracking();
+      this.touchGestureWasMultitouch = true;
       // Two-finger gesture: pinch-to-zoom + pan
       const currentDistance = this.calculateTouchDistance(
         this.touches[0],
@@ -3684,6 +3985,10 @@ export class GerberViewer {
         x: this.touches[0].clientX,
         y: this.touches[0].clientY,
       };
+      this.updateTouchTapTracking(this.touches[0]);
+      if (this.touchTapCandidate) {
+        return;
+      }
 
       const deltaX = currentPos.x - this.lastTouchCenter.x;
       const deltaY = currentPos.y - this.lastTouchCenter.y;
@@ -3696,6 +4001,9 @@ export class GerberViewer {
 
       this.lastTouchCenter = currentPos;
       this.requestRender();
+    } else if (this.touches.length > 2) {
+      this.cancelTouchTapTracking();
+      this.touchGestureWasMultitouch = true;
     }
   }
 
@@ -3732,15 +4040,92 @@ export class GerberViewer {
     }
 
     if (this.touches.length === 0) {
+      this.commitTouchTapSelection(e);
+      this.resetTouchTapTracking();
       // All touches ended
       this.isTouching = false;
     } else if (this.touches.length === 1) {
+      this.cancelTouchTapTracking();
+      this.touchGestureWasMultitouch = true;
       // Transitioned from multi-touch to single touch
       this.lastTouchCenter = {
         x: this.touches[0].clientX,
         y: this.touches[0].clientY,
       };
     }
+  }
+
+  startTouchTapTracking(touch) {
+    const point = {
+      x: touch.clientX,
+      y: touch.clientY,
+    };
+    this.touchStartPoint = point;
+    this.touchTapPoint = point;
+    this.touchTapIdentifier = touch.identifier;
+    this.touchTapCandidate = true;
+    this.touchGestureWasMultitouch = false;
+  }
+
+  updateTouchTapTracking(touch) {
+    if (
+      !this.touchTapCandidate ||
+      this.touchTapIdentifier !== touch.identifier ||
+      !this.touchStartPoint
+    ) {
+      return;
+    }
+
+    const point = {
+      x: touch.clientX,
+      y: touch.clientY,
+    };
+    this.touchTapPoint = point;
+    if (
+      Math.hypot(
+        point.x - this.touchStartPoint.x,
+        point.y - this.touchStartPoint.y,
+      ) > POINTER_TAP_MAX_MOVEMENT_PX
+    ) {
+      this.touchTapCandidate = false;
+    }
+  }
+
+  commitTouchTapSelection(event) {
+    if (
+      event.type !== "touchend" ||
+      !this.touchTapCandidate ||
+      this.touchGestureWasMultitouch ||
+      this.touchTapIdentifier === null
+    ) {
+      return false;
+    }
+
+    const endedTouch = Array.from(event.changedTouches).find(
+      (touch) => touch.identifier === this.touchTapIdentifier,
+    );
+    if (!endedTouch) {
+      return false;
+    }
+
+    const point = this.touchTapPoint ?? {
+      x: endedTouch.clientX,
+      y: endedTouch.clientY,
+    };
+    this.selectFeatureAtCanvasPoint(point.x, point.y);
+    return true;
+  }
+
+  cancelTouchTapTracking() {
+    this.touchTapCandidate = false;
+  }
+
+  resetTouchTapTracking() {
+    this.touchStartPoint = null;
+    this.touchTapPoint = null;
+    this.touchTapIdentifier = null;
+    this.touchTapCandidate = false;
+    this.touchGestureWasMultitouch = false;
   }
 
   startRulerTouch(touch) {
@@ -3841,6 +4226,11 @@ export class GerberViewer {
 
         // remove from JS array only if WASM removal succeeded
         this.layers.splice(index, 1);
+        if (
+          this.selectedFeature?.layerId === this.getLayerInteractionLayerId(layer)
+        ) {
+          this.selectedFeature = null;
+        }
         if (this.layers.length === 0) {
           this.fitViewZoom = null;
         }
@@ -3877,6 +4267,7 @@ export class GerberViewer {
       }
 
       this.layers = [];
+      this.selectedFeature = null;
       this.nextColorIndex = 0;
       this.nextLayerDomId = 0;
       this.fitViewZoom = null;
@@ -3904,6 +4295,7 @@ export class GerberViewer {
         layer.visible = this.layerFilterStore.matches(layer, kind);
       }
     });
+    this.clearSelectedFeatureIfUnavailable();
     this.renderLayerList();
     this.requestRender();
     this.updateUiState();
@@ -3913,6 +4305,7 @@ export class GerberViewer {
     this.layers.forEach((layer) => {
       layer.visible = false;
     });
+    this.clearSelectedFeature();
     this.renderLayerList();
     this.requestRender();
     this.updateUiState();
@@ -4036,11 +4429,13 @@ export class GerberViewer {
       onColorChange: (layerId, color) => this.updateLayerColor(layerId, color),
       onVisibilityChange: (layer, visible) => {
         layer.visible = visible;
+        this.clearSelectedFeatureForHiddenLayer(layer);
         this.requestRender();
         this.updateUiState();
       },
       onToggleVisibility: (layer) => {
         layer.visible = !layer.visible;
+        this.clearSelectedFeatureForHiddenLayer(layer);
         this.requestRender();
         this.updateUiState();
       },

--- a/js/main.js
+++ b/js/main.js
@@ -64,7 +64,12 @@ const PTH_DRILL_TYPE = "pth";
 const NPTH_DRILL_TYPE = "npth";
 const DEFAULT_PTH_DRILL_COLOR = [1.0, 1.0, 0.0];
 const DEFAULT_NPTH_DRILL_COLOR = [1.0, 1.0, 1.0];
-const POINTER_TAP_MAX_MOVEMENT_PX = 6;
+const POINTER_TAP_MAX_MOVEMENT_VIEWPORT_RATIO = 0.006;
+const TOUCH_TAP_MAX_MOVEMENT_VIEWPORT_RATIO = 0.024;
+const FEATURE_PICK_MOUSE_VIEWPORT_RATIO = 0.008;
+const FEATURE_PICK_TOUCH_VIEWPORT_RATIO = 0.032;
+const FEATURE_CYCLE_MOUSE_VIEWPORT_RATIO = 0.006;
+const FEATURE_CYCLE_TOUCH_VIEWPORT_RATIO = 0.025;
 
 class ParseWorkerUnavailableError extends Error {
   constructor(message) {
@@ -234,7 +239,11 @@ function formatSelectedFeatureSummary(selection, { unit = "mm" } = {}) {
 
   parts.push(formatFeatureTypeLabel(feature, layer));
 
-  if (!isDrillLayer(layer) && feature.apertureType) {
+  if (
+    !isDrillLayer(layer) &&
+    feature.featureType !== "region" &&
+    feature.apertureType
+  ) {
     parts.push(formatApertureTypeLabel(feature));
   }
 
@@ -645,6 +654,7 @@ export class GerberViewer {
     this.lastMousePos = { x: 0, y: 0 };
     this.mouseDownPos = { x: 0, y: 0 };
     this.selectedFeature = null;
+    this.lastFeaturePick = null;
 
     // Touch interaction
     this.isTouching = false;
@@ -3568,6 +3578,7 @@ export class GerberViewer {
     this.camera.offsetY =
       fitView.targetY - fitView.centerY * this.getViewScaleY();
 
+    this.resetSelectionCycle();
     this.requestRender();
     this.updateUiState();
   }
@@ -3645,6 +3656,7 @@ export class GerberViewer {
       maxZoom: this.maxZoom,
     });
     if (didZoom) {
+      this.resetSelectionCycle();
       this.requestRender();
     }
   }
@@ -3755,12 +3767,16 @@ export class GerberViewer {
     const totalDeltaY = e.clientY - this.mouseDownPos.y;
     if (
       e.type === "mouseup" &&
-      Math.hypot(totalDeltaX, totalDeltaY) <= POINTER_TAP_MAX_MOVEMENT_PX
+      Math.hypot(totalDeltaX, totalDeltaY) <=
+        this.getViewportRelativeDistance(POINTER_TAP_MAX_MOVEMENT_VIEWPORT_RATIO)
     ) {
-      this.selectFeatureAtCanvasPoint(e.clientX, e.clientY);
+      this.selectFeatureAtCanvasPoint(e.clientX, e.clientY, {
+        inputType: "mouse",
+      });
       return;
     }
 
+    this.resetSelectionCycle();
     panCameraByScreenDelta({
       deltaX,
       deltaY,
@@ -3771,7 +3787,7 @@ export class GerberViewer {
     this.requestRender();
   }
 
-  selectFeatureAtCanvasPoint(clientX, clientY) {
+  selectFeatureAtCanvasPoint(clientX, clientY, { inputType = "mouse" } = {}) {
     const point = this.canvasPointToWorld(clientX, clientY);
     if (
       !point ||
@@ -3782,25 +3798,85 @@ export class GerberViewer {
       return;
     }
 
-    const hit = this.wasmProcessor.pick_interaction_feature(
-      this.getVisibleInteractionLayerIds(),
-      point.x,
-      point.y,
-      this.getFeatureHitToleranceWorld(clientX, clientY),
-    );
+    const layerIds = this.getVisibleInteractionLayerIds();
+    const tolerance = this.getFeatureHitToleranceWorld(clientX, clientY, inputType);
+    const shouldCycle = this.shouldCycleFeatureSelection(clientX, clientY, inputType);
+    const hit =
+      shouldCycle &&
+      typeof this.wasmProcessor.pick_interaction_feature_after === "function"
+        ? this.wasmProcessor.pick_interaction_feature_after(
+            layerIds,
+            point.x,
+            point.y,
+            tolerance,
+            this.selectedFeature.layerId,
+            this.selectedFeature.featureId,
+          )
+        : this.wasmProcessor.pick_interaction_feature(
+            layerIds,
+            point.x,
+            point.y,
+            tolerance,
+          );
     this.selectedFeature = hit ? this.attachLayerToSelectedFeature(hit) : null;
+    if (this.selectedFeature) {
+      this.lastFeaturePick = { x: clientX, y: clientY, inputType };
+    } else {
+      this.resetSelectionCycle();
+    }
     this.updateUiState();
     this.renderMeasurements();
     this.requestRender();
   }
 
-  clearSelectedFeature({ refresh = true } = {}) {
-    if (!this.selectedFeature) return;
+  clearSelectedFeature({ refresh = true, resetCycle = true } = {}) {
+    if (!this.selectedFeature) {
+      if (resetCycle) {
+        this.resetSelectionCycle();
+      }
+      return;
+    }
     this.selectedFeature = null;
+    if (resetCycle) {
+      this.resetSelectionCycle();
+    }
     if (!refresh) return;
     this.updateUiState();
     this.renderMeasurements();
     this.requestRender();
+  }
+
+  resetSelectionCycle() {
+    this.lastFeaturePick = null;
+  }
+
+  getViewportRelativeDistance(ratio) {
+    const rect = this.canvas.getBoundingClientRect();
+    const basis = Math.min(rect.width, rect.height);
+    if (!Number.isFinite(basis) || basis <= 0) {
+      return 0;
+    }
+    return basis * ratio;
+  }
+
+  shouldCycleFeatureSelection(clientX, clientY, inputType) {
+    if (!this.selectedFeature || !this.lastFeaturePick) {
+      return false;
+    }
+    if (this.lastFeaturePick.inputType !== inputType) {
+      return false;
+    }
+
+    const radius = inputType === "touch"
+      ? this.getViewportRelativeDistance(FEATURE_CYCLE_TOUCH_VIEWPORT_RATIO)
+      : this.getViewportRelativeDistance(FEATURE_CYCLE_MOUSE_VIEWPORT_RATIO);
+    return (
+      radius > 0 &&
+      Math.hypot(
+        clientX - this.lastFeaturePick.x,
+        clientY - this.lastFeaturePick.y,
+      ) <= radius
+    );
   }
 
   clearSelectedFeatureForHiddenLayer(layer) {
@@ -3867,9 +3943,12 @@ export class GerberViewer {
     return isDrillLayer(layer) ? layer?.outlineLayerId : layer?.layerId;
   }
 
-  getFeatureHitToleranceWorld(clientX, clientY) {
+  getFeatureHitToleranceWorld(clientX, clientY, inputType = "mouse") {
     const point = this.canvasPointToWorld(clientX, clientY);
-    const offsetPoint = this.canvasPointToWorld(clientX + 8, clientY);
+    const radius = inputType === "touch"
+      ? this.getViewportRelativeDistance(FEATURE_PICK_TOUCH_VIEWPORT_RATIO)
+      : this.getViewportRelativeDistance(FEATURE_PICK_MOUSE_VIEWPORT_RATIO);
+    const offsetPoint = this.canvasPointToWorld(clientX + radius, clientY);
     if (!point || !offsetPoint) {
       return 0.05;
     }
@@ -3897,6 +3976,7 @@ export class GerberViewer {
 
     if (this.touches.length === 2) {
       this.cancelTouchTapTracking();
+      this.resetSelectionCycle();
       this.touchGestureWasMultitouch = true;
       // Two-finger gesture: pinch-to-zoom
       this.initialPinchDistance = this.calculateTouchDistance(
@@ -3916,6 +3996,7 @@ export class GerberViewer {
       };
     } else {
       this.cancelTouchTapTracking();
+      this.resetSelectionCycle();
       this.touchGestureWasMultitouch = true;
     }
   }
@@ -3944,6 +4025,7 @@ export class GerberViewer {
 
     if (this.touches.length === 2) {
       this.cancelTouchTapTracking();
+      this.resetSelectionCycle();
       this.touchGestureWasMultitouch = true;
       // Two-finger gesture: pinch-to-zoom + pan
       const currentDistance = this.calculateTouchDistance(
@@ -3990,6 +4072,7 @@ export class GerberViewer {
         return;
       }
 
+      this.resetSelectionCycle();
       const deltaX = currentPos.x - this.lastTouchCenter.x;
       const deltaY = currentPos.y - this.lastTouchCenter.y;
       panCameraByScreenDelta({
@@ -4003,6 +4086,7 @@ export class GerberViewer {
       this.requestRender();
     } else if (this.touches.length > 2) {
       this.cancelTouchTapTracking();
+      this.resetSelectionCycle();
       this.touchGestureWasMultitouch = true;
     }
   }
@@ -4046,6 +4130,7 @@ export class GerberViewer {
       this.isTouching = false;
     } else if (this.touches.length === 1) {
       this.cancelTouchTapTracking();
+      this.resetSelectionCycle();
       this.touchGestureWasMultitouch = true;
       // Transitioned from multi-touch to single touch
       this.lastTouchCenter = {
@@ -4085,7 +4170,7 @@ export class GerberViewer {
       Math.hypot(
         point.x - this.touchStartPoint.x,
         point.y - this.touchStartPoint.y,
-      ) > POINTER_TAP_MAX_MOVEMENT_PX
+      ) > this.getViewportRelativeDistance(TOUCH_TAP_MAX_MOVEMENT_VIEWPORT_RATIO)
     ) {
       this.touchTapCandidate = false;
     }
@@ -4112,7 +4197,7 @@ export class GerberViewer {
       x: endedTouch.clientX,
       y: endedTouch.clientY,
     };
-    this.selectFeatureAtCanvasPoint(point.x, point.y);
+    this.selectFeatureAtCanvasPoint(point.x, point.y, { inputType: "touch" });
     return true;
   }
 
@@ -4229,7 +4314,7 @@ export class GerberViewer {
         if (
           this.selectedFeature?.layerId === this.getLayerInteractionLayerId(layer)
         ) {
-          this.selectedFeature = null;
+          this.clearSelectedFeature({ refresh: false });
         }
         if (this.layers.length === 0) {
           this.fitViewZoom = null;
@@ -4267,7 +4352,7 @@ export class GerberViewer {
       }
 
       this.layers = [];
-      this.selectedFeature = null;
+      this.clearSelectedFeature({ refresh: false });
       this.nextColorIndex = 0;
       this.nextLayerDomId = 0;
       this.fitViewZoom = null;

--- a/js/main.js
+++ b/js/main.js
@@ -4204,7 +4204,12 @@ export class GerberViewer {
       return false;
     }
 
-    const point = this.touchTapPoint ?? {
+    this.updateTouchTapTracking(endedTouch);
+    if (!this.touchTapCandidate) {
+      return false;
+    }
+
+    const point = {
       x: endedTouch.clientX,
       y: endedTouch.clientY,
     };

--- a/js/measurements.js
+++ b/js/measurements.js
@@ -41,7 +41,13 @@ function formatImperialLength(lengthMm) {
 
 export function drawMeasurementsOnContext(
   context,
-  { measurements, rulerStartPoint, rulerHoverPoint, worldToCanvasPoint, unit },
+  {
+    measurements,
+    rulerStartPoint,
+    rulerHoverPoint,
+    worldToCanvasPoint,
+    unit,
+  },
 ) {
   for (const measurement of measurements) {
     drawMeasurementOnContext({

--- a/wasm/src/drill.rs
+++ b/wasm/src/drill.rs
@@ -1,8 +1,10 @@
+use crate::interaction::{drill_hit_feature, drill_slot_feature, InteractionLayer};
 use crate::parse_common::{
     find_g_code_index, line_has_g_code, parse_coordinate_number as parse_common_coordinate_number,
     parse_decimal_number as parse_common_decimal_number, parse_g_code, read_number,
     CoordinateFormat, ZeroSuppression,
 };
+use crate::parser::geometry::Primitive;
 use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
     Triangles,
@@ -145,6 +147,7 @@ pub struct DrillParseResult {
     pub fill_layer: GerberData,
     pub outline_layer: GerberData,
     pub metadata: DrillMetadata,
+    pub interaction_layer: Option<InteractionLayer>,
 }
 
 #[derive(Default)]
@@ -373,10 +376,16 @@ struct DrillParser {
     outline_width_mm: f32,
     offset_x: f32,
     offset_y: f32,
+    interaction_layer: Option<InteractionLayer>,
 }
 
 impl DrillParser {
-    fn new(outline_width_mm: f32, offset_x: f32, offset_y: f32) -> Result<Self, JsValue> {
+    fn new(
+        outline_width_mm: f32,
+        offset_x: f32,
+        offset_y: f32,
+        collect_interactions: bool,
+    ) -> Result<Self, JsValue> {
         if !offset_x.is_finite() || !offset_y.is_finite() {
             return Err(JsValue::from_str("Drill layer offset must be finite"));
         }
@@ -400,6 +409,7 @@ impl DrillParser {
             outline_width_mm: outline_width_mm.max(0.0),
             offset_x,
             offset_y,
+            interaction_layer: collect_interactions.then(InteractionLayer::new),
         })
     }
 
@@ -447,6 +457,7 @@ impl DrillParser {
                 hit_count,
                 slot_count,
             },
+            interaction_layer: self.interaction_layer,
         })
     }
 
@@ -797,6 +808,11 @@ impl DrillParser {
         self.outline
             .push_circle(x, y, radius + self.outline_width_mm);
         self.fill.push_circle(x, y, radius);
+        if let Some(interaction_layer) = &mut self.interaction_layer {
+            if let Some(feature) = drill_hit_feature(code, diameter_mm, x, y) {
+                interaction_layer.push(feature);
+            }
+        }
         if let Some(tool) = self.tools.get_mut(&code) {
             tool.hit_count = tool.hit_count.saturating_add(1);
         }
@@ -841,6 +857,42 @@ impl DrillParser {
             .push_line(start_x, start_y, end_x, end_y, diameter_mm);
         self.fill.push_circle(start_x, start_y, fill_radius);
         self.fill.push_circle(end_x, end_y, fill_radius);
+        if let Some(interaction_layer) = &mut self.interaction_layer {
+            if let Some(feature) = drill_slot_feature(
+                code,
+                diameter_mm,
+                vec![
+                    Primitive::Line {
+                        start_x,
+                        start_y,
+                        end_x,
+                        end_y,
+                        width: diameter_mm,
+                        exposure: 1.0,
+                    },
+                    Primitive::Circle {
+                        x: start_x,
+                        y: start_y,
+                        radius: fill_radius,
+                        exposure: 1.0,
+                        hole_x: 0.0,
+                        hole_y: 0.0,
+                        hole_radius: 0.0,
+                    },
+                    Primitive::Circle {
+                        x: end_x,
+                        y: end_y,
+                        radius: fill_radius,
+                        exposure: 1.0,
+                        hole_x: 0.0,
+                        hole_y: 0.0,
+                        hole_radius: 0.0,
+                    },
+                ],
+            ) {
+                interaction_layer.push(feature);
+            }
+        }
         if let Some(tool) = self.tools.get_mut(&code) {
             tool.slot_count = tool.slot_count.saturating_add(1);
         }
@@ -889,6 +941,48 @@ impl DrillParser {
             arc.sweep_angle,
             diameter_mm,
         );
+        if let Some(interaction_layer) = &mut self.interaction_layer {
+            let start_x = self.current_x + self.offset_x;
+            let start_y = self.current_y + self.offset_y;
+            let end_x = end_x + self.offset_x;
+            let end_y = end_y + self.offset_y;
+            let fill_radius = diameter_mm * 0.5;
+            if let Some(feature) = drill_slot_feature(
+                code,
+                diameter_mm,
+                vec![
+                    Primitive::Arc {
+                        x: center_x,
+                        y: center_y,
+                        radius: arc.radius,
+                        start_angle: arc.start_angle,
+                        end_angle: arc.start_angle + arc.sweep_angle,
+                        thickness: diameter_mm,
+                        exposure: 1.0,
+                    },
+                    Primitive::Circle {
+                        x: start_x,
+                        y: start_y,
+                        radius: fill_radius,
+                        exposure: 1.0,
+                        hole_x: 0.0,
+                        hole_y: 0.0,
+                        hole_radius: 0.0,
+                    },
+                    Primitive::Circle {
+                        x: end_x,
+                        y: end_y,
+                        radius: fill_radius,
+                        exposure: 1.0,
+                        hole_x: 0.0,
+                        hole_y: 0.0,
+                        hole_radius: 0.0,
+                    },
+                ],
+            ) {
+                interaction_layer.push(feature);
+            }
+        }
         if let Some(tool) = self.tools.get_mut(&code) {
             tool.slot_count = tool.slot_count.saturating_add(1);
         }
@@ -910,7 +1004,16 @@ pub fn parse_drill_with_offset(
     offset_x: f32,
     offset_y: f32,
 ) -> Result<DrillParseResult, JsValue> {
-    DrillParser::new(outline_width_mm, offset_x, offset_y)?.parse(content)
+    DrillParser::new(outline_width_mm, offset_x, offset_y, false)?.parse(content)
+}
+
+pub fn parse_drill_with_offset_and_interactions(
+    content: &str,
+    outline_width_mm: f32,
+    offset_x: f32,
+    offset_y: f32,
+) -> Result<DrillParseResult, JsValue> {
+    DrillParser::new(outline_width_mm, offset_x, offset_y, true)?.parse(content)
 }
 
 fn set_property(object: &Object, key: &str, value: JsValue) -> Result<(), JsValue> {

--- a/wasm/src/interaction.rs
+++ b/wasm/src/interaction.rs
@@ -1,0 +1,970 @@
+use crate::parser::geometry::{offset_primitive_by, Primitive};
+use crate::parser::{Aperture, Polarity};
+use crate::shape::{Boundary, PathRegions};
+use js_sys::{Object, Reflect};
+use wasm_bindgen::prelude::*;
+
+const CIRCLE_SEGMENTS: usize = 48;
+const ARC_SEGMENT_RADIANS: f32 = std::f32::consts::PI / 48.0;
+const MAX_ARC_SEGMENTS: usize = 256;
+const TWO_PI: f32 = std::f32::consts::PI * 2.0;
+
+pub struct HighlightBatch {
+    pub vertices: Vec<f32>,
+    pub clear: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InteractionLayer {
+    pub features: Vec<InteractionFeature>,
+}
+
+#[derive(Clone, Debug)]
+pub struct InteractionFeature {
+    pub kind: FeatureKind,
+    pub aperture: Option<String>,
+    pub aperture_type: String,
+    pub macro_name: Option<String>,
+    pub polarity: Polarity,
+    pub primitives: Vec<Primitive>,
+    pub path_regions: PathRegions,
+    pub bounds: Boundary,
+    pub properties: FeatureProperties,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum FeatureKind {
+    Flash,
+    Draw,
+    ArcDraw,
+    Region,
+    DrillHit,
+    DrillSlot,
+}
+
+impl FeatureKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FeatureKind::Flash => "aperture-flash",
+            FeatureKind::Draw => "aperture-draw",
+            FeatureKind::ArcDraw => "arc-draw",
+            FeatureKind::Region => "region",
+            FeatureKind::DrillHit => "drill-hit",
+            FeatureKind::DrillSlot => "drill-slot",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FeatureProperties {
+    pub diameter: Option<f32>,
+    pub width: Option<f32>,
+    pub height: Option<f32>,
+    pub rotation: Option<f32>,
+    pub vertices: Option<u32>,
+    pub tool_code: Option<u32>,
+    pub primitive_count: Option<u32>,
+}
+
+impl InteractionLayer {
+    pub fn new() -> Self {
+        Self {
+            features: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, feature: InteractionFeature) {
+        self.features.push(feature);
+    }
+
+    pub fn translate(&mut self, dx: f32, dy: f32) {
+        if dx == 0.0 && dy == 0.0 {
+            return;
+        }
+
+        for feature in &mut self.features {
+            feature.bounds.translate(dx, dy);
+            for primitive in &mut feature.primitives {
+                *primitive = offset_primitive_by(primitive, dx, dy);
+            }
+            feature.path_regions.translate(dx, dy);
+        }
+    }
+
+    pub fn pick(&self, x: f32, y: f32, tolerance: f32) -> Option<(usize, &InteractionFeature)> {
+        let point = [x, y];
+        let tolerance = tolerance.max(0.0);
+
+        for (feature_id, feature) in self.features.iter().enumerate().rev() {
+            if !bounds_contains(&feature.bounds, point, tolerance) {
+                continue;
+            }
+            if feature.hit(point, tolerance) {
+                if feature.polarity == Polarity::Negative {
+                    return None;
+                }
+                return Some((feature_id, feature));
+            }
+        }
+
+        None
+    }
+}
+
+impl InteractionFeature {
+    pub fn from_primitives(
+        kind: FeatureKind,
+        aperture: Option<String>,
+        aperture_type: String,
+        macro_name: Option<String>,
+        polarity: Polarity,
+        primitives: Vec<Primitive>,
+        properties: FeatureProperties,
+    ) -> Option<Self> {
+        Self::from_geometry(
+            kind,
+            aperture,
+            aperture_type,
+            macro_name,
+            polarity,
+            primitives,
+            PathRegions::empty(),
+            properties,
+        )
+    }
+
+    pub fn from_geometry(
+        kind: FeatureKind,
+        aperture: Option<String>,
+        aperture_type: String,
+        macro_name: Option<String>,
+        polarity: Polarity,
+        primitives: Vec<Primitive>,
+        path_regions: PathRegions,
+        properties: FeatureProperties,
+    ) -> Option<Self> {
+        let bounds = combined_bounds(&primitives, &path_regions)?;
+        Some(Self {
+            kind,
+            aperture,
+            aperture_type,
+            macro_name,
+            polarity,
+            primitives,
+            path_regions,
+            bounds,
+            properties,
+        })
+    }
+
+    pub fn gerber_properties(aperture: &Aperture) -> FeatureProperties {
+        let primitive_count = u32::try_from(aperture.primitives.len()).ok();
+        FeatureProperties {
+            diameter: (aperture.width > 0.0 && (aperture.width - aperture.height).abs() < 1.0e-6)
+                .then_some(aperture.width),
+            width: (aperture.width > 0.0).then_some(aperture.width),
+            height: (aperture.height > 0.0).then_some(aperture.height),
+            rotation: (aperture.rotation != 0.0).then_some(aperture.rotation),
+            vertices: (aperture.vertices > 0).then_some(aperture.vertices),
+            tool_code: None,
+            primitive_count,
+        }
+    }
+
+    pub fn drill_properties(tool_code: u32, diameter: f32) -> FeatureProperties {
+        FeatureProperties {
+            diameter: Some(diameter),
+            width: Some(diameter),
+            height: Some(diameter),
+            tool_code: Some(tool_code),
+            ..FeatureProperties::default()
+        }
+    }
+
+    pub fn info_to_js(&self, layer_id: u32, feature_id: usize) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(&object, "layerId", JsValue::from_f64(layer_id as f64))?;
+        set_property(&object, "featureId", JsValue::from_f64(feature_id as f64))?;
+        set_property(
+            &object,
+            "featureType",
+            JsValue::from_str(self.kind.as_str()),
+        )?;
+        set_property(
+            &object,
+            "polarity",
+            JsValue::from_str(if self.polarity == Polarity::Negative {
+                "clear"
+            } else {
+                "dark"
+            }),
+        )?;
+        if let Some(aperture) = &self.aperture {
+            set_property(&object, "aperture", JsValue::from_str(aperture))?;
+        }
+        set_property(
+            &object,
+            "apertureType",
+            JsValue::from_str(&self.aperture_type),
+        )?;
+        if let Some(macro_name) = &self.macro_name {
+            set_property(&object, "macroName", JsValue::from_str(macro_name))?;
+        }
+        set_property(&object, "bounds", self.bounds_to_js()?)?;
+        set_property(&object, "properties", self.properties.to_js()?)?;
+        Ok(object.into())
+    }
+
+    pub fn highlight_batches(&self) -> Vec<HighlightBatch> {
+        let mut batches = Vec::new();
+        for primitive in &self.primitives {
+            append_primitive_highlight_batches(&mut batches, primitive);
+        }
+        batches
+    }
+
+    fn hit(&self, point: [f32; 2], tolerance: f32) -> bool {
+        let mut is_hit = false;
+        for primitive in &self.primitives {
+            if primitive_hit(primitive, point, tolerance) {
+                is_hit = primitive_exposure(primitive) >= 0.5;
+            }
+        }
+        if path_regions_hit(&self.path_regions, point, tolerance) {
+            is_hit = true;
+        }
+        is_hit
+    }
+
+    fn bounds_to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        set_property(
+            &object,
+            "minX",
+            JsValue::from_f64(self.bounds.min_x() as f64),
+        )?;
+        set_property(
+            &object,
+            "maxX",
+            JsValue::from_f64(self.bounds.max_x() as f64),
+        )?;
+        set_property(
+            &object,
+            "minY",
+            JsValue::from_f64(self.bounds.min_y() as f64),
+        )?;
+        set_property(
+            &object,
+            "maxY",
+            JsValue::from_f64(self.bounds.max_y() as f64),
+        )?;
+        Ok(object.into())
+    }
+}
+
+impl FeatureProperties {
+    fn to_js(&self) -> Result<JsValue, JsValue> {
+        let object = Object::new();
+        if let Some(value) = self.diameter {
+            set_property(&object, "diameter", JsValue::from_f64(value as f64))?;
+        }
+        if let Some(value) = self.width {
+            set_property(&object, "width", JsValue::from_f64(value as f64))?;
+        }
+        if let Some(value) = self.height {
+            set_property(&object, "height", JsValue::from_f64(value as f64))?;
+        }
+        if let Some(value) = self.rotation {
+            set_property(&object, "rotation", JsValue::from_f64(value as f64))?;
+        }
+        if let Some(value) = self.vertices {
+            set_property(&object, "vertices", JsValue::from_f64(value as f64))?;
+        }
+        if let Some(value) = self.tool_code {
+            set_property(&object, "toolCode", JsValue::from_f64(value as f64))?;
+        }
+        if let Some(value) = self.primitive_count {
+            set_property(&object, "primitiveCount", JsValue::from_f64(value as f64))?;
+        }
+        Ok(object.into())
+    }
+}
+
+pub fn aperture_name(code: &str) -> Option<String> {
+    (!code.is_empty()).then(|| format!("D{code}"))
+}
+
+pub fn aperture_type(aperture: &Aperture) -> String {
+    aperture.kind.as_str().to_string()
+}
+
+pub fn feature_from_primitive_delta(
+    kind: FeatureKind,
+    aperture_code: &str,
+    aperture: &Aperture,
+    polarity: Polarity,
+    primitives: &[Primitive],
+) -> Option<InteractionFeature> {
+    InteractionFeature::from_primitives(
+        kind,
+        aperture_name(aperture_code),
+        aperture_type(aperture),
+        aperture.macro_name.clone(),
+        polarity,
+        primitives.to_vec(),
+        InteractionFeature::gerber_properties(aperture),
+    )
+}
+
+pub fn drill_hit_feature(
+    tool_code: u32,
+    diameter: f32,
+    x: f32,
+    y: f32,
+) -> Option<InteractionFeature> {
+    let radius = diameter * 0.5;
+    InteractionFeature::from_primitives(
+        FeatureKind::DrillHit,
+        Some(format!("T{tool_code:02}")),
+        "drill".to_string(),
+        None,
+        Polarity::Positive,
+        vec![Primitive::Circle {
+            x,
+            y,
+            radius,
+            exposure: 1.0,
+            hole_x: 0.0,
+            hole_y: 0.0,
+            hole_radius: 0.0,
+        }],
+        InteractionFeature::drill_properties(tool_code, diameter),
+    )
+}
+
+pub fn drill_slot_feature(
+    tool_code: u32,
+    diameter: f32,
+    primitives: Vec<Primitive>,
+) -> Option<InteractionFeature> {
+    InteractionFeature::from_primitives(
+        FeatureKind::DrillSlot,
+        Some(format!("T{tool_code:02}")),
+        "drill".to_string(),
+        None,
+        Polarity::Positive,
+        primitives,
+        InteractionFeature::drill_properties(tool_code, diameter),
+    )
+}
+
+fn combined_bounds(primitives: &[Primitive], path_regions: &PathRegions) -> Option<Boundary> {
+    match (
+        primitive_bounds(primitives),
+        path_regions_bounds(path_regions),
+    ) {
+        (Some(mut primitive_bounds), Some(path_bounds)) => {
+            primitive_bounds.include_boundary(&path_bounds);
+            Some(primitive_bounds)
+        }
+        (Some(bounds), None) | (None, Some(bounds)) => Some(bounds),
+        (None, None) => None,
+    }
+}
+
+fn primitive_bounds(primitives: &[Primitive]) -> Option<Boundary> {
+    let mut min_x = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+
+    for primitive in primitives {
+        include_primitive_bounds(primitive, &mut min_x, &mut max_x, &mut min_y, &mut max_y);
+    }
+
+    min_x
+        .is_finite()
+        .then_some(Boundary::new(min_x, max_x, min_y, max_y))
+}
+
+fn path_regions_bounds(path_regions: &PathRegions) -> Option<Boundary> {
+    let mut min_x = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+
+    for point in path_regions.cover_vertices.chunks_exact(2) {
+        include_point_bounds(
+            point[0], point[1], &mut min_x, &mut max_x, &mut min_y, &mut max_y,
+        );
+    }
+
+    min_x
+        .is_finite()
+        .then_some(Boundary::new(min_x, max_x, min_y, max_y))
+}
+
+fn include_primitive_bounds(
+    primitive: &Primitive,
+    min_x: &mut f32,
+    max_x: &mut f32,
+    min_y: &mut f32,
+    max_y: &mut f32,
+) {
+    match primitive {
+        Primitive::Triangle { vertices, .. } => {
+            for vertex in vertices {
+                include_point_bounds(vertex[0], vertex[1], min_x, max_x, min_y, max_y);
+            }
+        }
+        Primitive::Circle { x, y, radius, .. } => {
+            *min_x = min_x.min(*x - *radius);
+            *max_x = max_x.max(*x + *radius);
+            *min_y = min_y.min(*y - *radius);
+            *max_y = max_y.max(*y + *radius);
+        }
+        Primitive::Arc {
+            x,
+            y,
+            radius,
+            start_angle,
+            end_angle,
+            thickness,
+            ..
+        } => {
+            let half_width = *thickness * 0.5;
+            let sweep = *end_angle - *start_angle;
+            for angle in arc_bounds_angles(*start_angle, sweep) {
+                let px = *x + angle.cos() * *radius;
+                let py = *y + angle.sin() * *radius;
+                include_circle_bounds(px, py, half_width, min_x, max_x, min_y, max_y);
+            }
+        }
+        Primitive::Thermal {
+            x,
+            y,
+            outer_diameter,
+            ..
+        } => {
+            include_circle_bounds(*x, *y, *outer_diameter * 0.5, min_x, max_x, min_y, max_y);
+        }
+        Primitive::TriangleTemplateFlash { template, x, y } => {
+            for point in template.chunks_exact(2) {
+                include_point_bounds(point[0] + *x, point[1] + *y, min_x, max_x, min_y, max_y);
+            }
+        }
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+            ..
+        } => {
+            let radius = *width * 0.5;
+            include_circle_bounds(*start_x, *start_y, radius, min_x, max_x, min_y, max_y);
+            include_circle_bounds(*end_x, *end_y, radius, min_x, max_x, min_y, max_y);
+        }
+    }
+}
+
+fn include_circle_bounds(
+    x: f32,
+    y: f32,
+    radius: f32,
+    min_x: &mut f32,
+    max_x: &mut f32,
+    min_y: &mut f32,
+    max_y: &mut f32,
+) {
+    *min_x = min_x.min(x - radius);
+    *max_x = max_x.max(x + radius);
+    *min_y = min_y.min(y - radius);
+    *max_y = max_y.max(y + radius);
+}
+
+fn include_point_bounds(
+    x: f32,
+    y: f32,
+    min_x: &mut f32,
+    max_x: &mut f32,
+    min_y: &mut f32,
+    max_y: &mut f32,
+) {
+    *min_x = min_x.min(x);
+    *max_x = max_x.max(x);
+    *min_y = min_y.min(y);
+    *max_y = max_y.max(y);
+}
+
+fn bounds_contains(bounds: &Boundary, point: [f32; 2], tolerance: f32) -> bool {
+    point[0] >= bounds.min_x() - tolerance
+        && point[0] <= bounds.max_x() + tolerance
+        && point[1] >= bounds.min_y() - tolerance
+        && point[1] <= bounds.max_y() + tolerance
+}
+
+fn primitive_hit(primitive: &Primitive, point: [f32; 2], tolerance: f32) -> bool {
+    match primitive {
+        Primitive::Triangle {
+            vertices,
+            hole_x,
+            hole_y,
+            hole_radius,
+            ..
+        } => {
+            if *hole_radius > 0.0 {
+                let dx = point[0] - *hole_x;
+                let dy = point[1] - *hole_y;
+                if dx * dx + dy * dy <= (*hole_radius + tolerance).powi(2) {
+                    return false;
+                }
+            }
+            point_in_triangle(point, vertices) || triangle_edges_hit(point, vertices, tolerance)
+        }
+        Primitive::Circle {
+            x,
+            y,
+            radius,
+            hole_x,
+            hole_y,
+            hole_radius,
+            ..
+        } => {
+            let dx = point[0] - *x;
+            let dy = point[1] - *y;
+            if dx * dx + dy * dy > (*radius + tolerance).powi(2) {
+                return false;
+            }
+            if *hole_radius > 0.0 {
+                let hx = point[0] - *hole_x;
+                let hy = point[1] - *hole_y;
+                if hx * hx + hy * hy <= (*hole_radius + tolerance).powi(2) {
+                    return false;
+                }
+            }
+            true
+        }
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+            ..
+        } => {
+            distance_to_segment(point, [*start_x, *start_y], [*end_x, *end_y])
+                <= *width * 0.5 + tolerance
+        }
+        Primitive::Arc {
+            x,
+            y,
+            radius,
+            start_angle,
+            end_angle,
+            thickness,
+            ..
+        } => {
+            let angle = (point[1] - *y).atan2(point[0] - *x);
+            let sweep = *end_angle - *start_angle;
+            if !angle_in_sweep(angle, *start_angle, sweep) {
+                return false;
+            }
+            let radial_distance =
+                ((point[0] - *x).powi(2) + (point[1] - *y).powi(2)).sqrt() - *radius;
+            radial_distance.abs() <= *thickness * 0.5 + tolerance
+        }
+        Primitive::Thermal {
+            x,
+            y,
+            outer_diameter,
+            inner_diameter,
+            ..
+        } => {
+            let distance = ((point[0] - *x).powi(2) + (point[1] - *y).powi(2)).sqrt();
+            distance <= *outer_diameter * 0.5 + tolerance
+                && distance >= (*inner_diameter * 0.5 - tolerance).max(0.0)
+        }
+        Primitive::TriangleTemplateFlash { template, x, y } => {
+            for triangle in template.chunks_exact(6) {
+                let vertices = [
+                    [triangle[0] + *x, triangle[1] + *y],
+                    [triangle[2] + *x, triangle[3] + *y],
+                    [triangle[4] + *x, triangle[5] + *y],
+                ];
+                if point_in_triangle(point, &vertices)
+                    || triangle_edges_hit(point, &vertices, tolerance)
+                {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}
+
+fn path_regions_hit(path_regions: &PathRegions, point: [f32; 2], tolerance: f32) -> bool {
+    for region in &path_regions.pick_contours {
+        if region.is_empty() {
+            continue;
+        }
+
+        let mut inside = false;
+        for contour in region {
+            if contour.len() < 3 {
+                continue;
+            }
+            if contour_edges_hit(point, contour, tolerance) {
+                return true;
+            }
+            if point_in_contour(point, contour) {
+                inside = !inside;
+            }
+        }
+
+        if inside {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn append_primitive_triangles(vertices: &mut Vec<f32>, primitive: &Primitive) {
+    match primitive {
+        Primitive::Triangle { vertices: tri, .. } => {
+            push_triangle(vertices, tri[0], tri[1], tri[2]);
+        }
+        Primitive::Circle { x, y, radius, .. } => {
+            append_circle(vertices, [*x, *y], *radius, CIRCLE_SEGMENTS);
+        }
+        Primitive::Line {
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            width,
+            ..
+        } => {
+            append_capsule(
+                vertices,
+                [*start_x, *start_y],
+                [*end_x, *end_y],
+                *width * 0.5,
+            );
+        }
+        Primitive::Arc {
+            x,
+            y,
+            radius,
+            start_angle,
+            end_angle,
+            thickness,
+            ..
+        } => {
+            append_arc(
+                vertices,
+                [*x, *y],
+                *radius,
+                *start_angle,
+                *end_angle,
+                *thickness,
+            );
+        }
+        Primitive::Thermal {
+            x,
+            y,
+            outer_diameter,
+            ..
+        } => {
+            append_circle(vertices, [*x, *y], *outer_diameter * 0.5, CIRCLE_SEGMENTS);
+        }
+        Primitive::TriangleTemplateFlash { template, x, y } => {
+            for triangle in template.chunks_exact(6) {
+                vertices.extend_from_slice(&[
+                    triangle[0] + *x,
+                    triangle[1] + *y,
+                    triangle[2] + *x,
+                    triangle[3] + *y,
+                    triangle[4] + *x,
+                    triangle[5] + *y,
+                ]);
+            }
+        }
+    }
+}
+
+fn append_primitive_highlight_batches(batches: &mut Vec<HighlightBatch>, primitive: &Primitive) {
+    let mut vertices = Vec::new();
+    append_primitive_triangles(&mut vertices, primitive);
+    append_highlight_batch(batches, vertices, primitive_exposure(primitive) < 0.5);
+
+    if primitive_exposure(primitive) < 0.5 {
+        return;
+    }
+
+    match primitive {
+        Primitive::Circle {
+            hole_x,
+            hole_y,
+            hole_radius,
+            ..
+        }
+        | Primitive::Triangle {
+            hole_x,
+            hole_y,
+            hole_radius,
+            ..
+        } if *hole_radius > 0.0 => {
+            let mut clear_vertices = Vec::new();
+            append_circle(
+                &mut clear_vertices,
+                [*hole_x, *hole_y],
+                *hole_radius,
+                CIRCLE_SEGMENTS,
+            );
+            append_highlight_batch(batches, clear_vertices, true);
+        }
+        _ => {}
+    }
+}
+
+fn append_highlight_batch(batches: &mut Vec<HighlightBatch>, vertices: Vec<f32>, clear: bool) {
+    if vertices.len() < 6 {
+        return;
+    }
+
+    if let Some(last) = batches.last_mut() {
+        if last.clear == clear {
+            last.vertices.extend_from_slice(&vertices);
+            return;
+        }
+    }
+
+    batches.push(HighlightBatch { vertices, clear });
+}
+
+fn primitive_exposure(primitive: &Primitive) -> f32 {
+    match primitive {
+        Primitive::Triangle { exposure, .. }
+        | Primitive::Circle { exposure, .. }
+        | Primitive::Arc { exposure, .. }
+        | Primitive::Thermal { exposure, .. }
+        | Primitive::Line { exposure, .. } => *exposure,
+        Primitive::TriangleTemplateFlash { .. } => 1.0,
+    }
+}
+
+fn append_arc(
+    vertices: &mut Vec<f32>,
+    center: [f32; 2],
+    radius: f32,
+    start_angle: f32,
+    end_angle: f32,
+    thickness: f32,
+) {
+    let sweep = end_angle - start_angle;
+    let half_width = thickness * 0.5;
+    let outer_radius = radius + half_width;
+    let inner_radius = (radius - half_width).max(0.0);
+    let segment_count =
+        ((sweep.abs() / ARC_SEGMENT_RADIANS).ceil() as usize).clamp(8, MAX_ARC_SEGMENTS);
+
+    for index in 0..segment_count {
+        let t0 = index as f32 / segment_count as f32;
+        let t1 = (index + 1) as f32 / segment_count as f32;
+        let a0 = start_angle + sweep * t0;
+        let a1 = start_angle + sweep * t1;
+        let outer0 = polar_point(center, outer_radius, a0);
+        let outer1 = polar_point(center, outer_radius, a1);
+        let inner0 = polar_point(center, inner_radius, a0);
+        let inner1 = polar_point(center, inner_radius, a1);
+        push_triangle(vertices, outer0, outer1, inner1);
+        push_triangle(vertices, outer0, inner1, inner0);
+    }
+
+    append_circle(
+        vertices,
+        polar_point(center, radius, start_angle),
+        half_width,
+        24,
+    );
+    append_circle(
+        vertices,
+        polar_point(center, radius, end_angle),
+        half_width,
+        24,
+    );
+}
+
+fn append_capsule(vertices: &mut Vec<f32>, start: [f32; 2], end: [f32; 2], radius: f32) {
+    let dx = end[0] - start[0];
+    let dy = end[1] - start[1];
+    let length = (dx * dx + dy * dy).sqrt();
+    if length <= f32::EPSILON {
+        append_circle(vertices, start, radius, CIRCLE_SEGMENTS);
+        return;
+    }
+
+    let nx = -dy / length * radius;
+    let ny = dx / length * radius;
+    push_triangle(
+        vertices,
+        [start[0] + nx, start[1] + ny],
+        [start[0] - nx, start[1] - ny],
+        [end[0] + nx, end[1] + ny],
+    );
+    push_triangle(
+        vertices,
+        [start[0] - nx, start[1] - ny],
+        [end[0] - nx, end[1] - ny],
+        [end[0] + nx, end[1] + ny],
+    );
+    append_circle(vertices, start, radius, 24);
+    append_circle(vertices, end, radius, 24);
+}
+
+fn append_circle(vertices: &mut Vec<f32>, center: [f32; 2], radius: f32, segments: usize) {
+    if radius <= 0.0 || !radius.is_finite() {
+        return;
+    }
+    for index in 0..segments {
+        let a0 = TWO_PI * index as f32 / segments as f32;
+        let a1 = TWO_PI * (index + 1) as f32 / segments as f32;
+        push_triangle(
+            vertices,
+            center,
+            polar_point(center, radius, a0),
+            polar_point(center, radius, a1),
+        );
+    }
+}
+
+fn push_triangle(vertices: &mut Vec<f32>, a: [f32; 2], b: [f32; 2], c: [f32; 2]) {
+    vertices.extend_from_slice(&[a[0], a[1], b[0], b[1], c[0], c[1]]);
+}
+
+fn polar_point(center: [f32; 2], radius: f32, angle: f32) -> [f32; 2] {
+    [
+        center[0] + radius * angle.cos(),
+        center[1] + radius * angle.sin(),
+    ]
+}
+
+fn point_in_triangle(point: [f32; 2], vertices: &[[f32; 2]; 3]) -> bool {
+    let [a, b, c] = *vertices;
+    let d1 = sign(point, a, b);
+    let d2 = sign(point, b, c);
+    let d3 = sign(point, c, a);
+    let has_neg = d1 < 0.0 || d2 < 0.0 || d3 < 0.0;
+    let has_pos = d1 > 0.0 || d2 > 0.0 || d3 > 0.0;
+    !(has_neg && has_pos)
+}
+
+fn triangle_edges_hit(point: [f32; 2], vertices: &[[f32; 2]; 3], tolerance: f32) -> bool {
+    if tolerance <= 0.0 {
+        return false;
+    }
+    distance_to_segment(point, vertices[0], vertices[1]) <= tolerance
+        || distance_to_segment(point, vertices[1], vertices[2]) <= tolerance
+        || distance_to_segment(point, vertices[2], vertices[0]) <= tolerance
+}
+
+fn contour_edges_hit(point: [f32; 2], contour: &[[f32; 2]], tolerance: f32) -> bool {
+    if tolerance <= 0.0 || contour.len() < 2 {
+        return false;
+    }
+
+    for index in 0..contour.len() {
+        let start = contour[index];
+        let end = contour[(index + 1) % contour.len()];
+        if distance_to_segment(point, start, end) <= tolerance {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn point_in_contour(point: [f32; 2], contour: &[[f32; 2]]) -> bool {
+    if contour.len() < 3 {
+        return false;
+    }
+
+    let mut inside = false;
+    let mut previous = contour[contour.len() - 1];
+    for current in contour {
+        let crosses_y = (current[1] > point[1]) != (previous[1] > point[1]);
+        if crosses_y {
+            let x_intersection = (previous[0] - current[0]) * (point[1] - current[1])
+                / (previous[1] - current[1])
+                + current[0];
+            if point[0] < x_intersection {
+                inside = !inside;
+            }
+        }
+        previous = *current;
+    }
+
+    inside
+}
+
+fn sign(p1: [f32; 2], p2: [f32; 2], p3: [f32; 2]) -> f32 {
+    (p1[0] - p3[0]) * (p2[1] - p3[1]) - (p2[0] - p3[0]) * (p1[1] - p3[1])
+}
+
+fn distance_to_segment(point: [f32; 2], start: [f32; 2], end: [f32; 2]) -> f32 {
+    let dx = end[0] - start[0];
+    let dy = end[1] - start[1];
+    let length_sq = dx * dx + dy * dy;
+    if length_sq <= f32::EPSILON {
+        return ((point[0] - start[0]).powi(2) + (point[1] - start[1]).powi(2)).sqrt();
+    }
+    let t = (((point[0] - start[0]) * dx + (point[1] - start[1]) * dy) / length_sq).clamp(0.0, 1.0);
+    let x = start[0] + t * dx;
+    let y = start[1] + t * dy;
+    ((point[0] - x).powi(2) + (point[1] - y).powi(2)).sqrt()
+}
+
+fn arc_bounds_angles(start_angle: f32, sweep_angle: f32) -> Vec<f32> {
+    let mut angles = vec![start_angle, start_angle + sweep_angle];
+    for angle in [
+        0.0,
+        std::f32::consts::FRAC_PI_2,
+        std::f32::consts::PI,
+        std::f32::consts::PI * 1.5,
+    ] {
+        if angle_in_sweep(angle, start_angle, sweep_angle) {
+            angles.push(angle);
+        }
+    }
+    angles
+}
+
+fn angle_in_sweep(angle: f32, start_angle: f32, sweep_angle: f32) -> bool {
+    if sweep_angle.abs() >= TWO_PI - 0.00001 {
+        return true;
+    }
+    let angle = normalize_angle(angle);
+    let start = normalize_angle(start_angle);
+    let delta = if sweep_angle >= 0.0 {
+        normalize_angle(angle - start)
+    } else {
+        normalize_angle(start - angle)
+    };
+    delta <= sweep_angle.abs() + 1.0e-6
+}
+
+fn normalize_angle(angle: f32) -> f32 {
+    let mut angle = angle % TWO_PI;
+    if angle < 0.0 {
+        angle += TWO_PI;
+    }
+    angle
+}
+
+fn set_property(object: &Object, key: &str, value: JsValue) -> Result<(), JsValue> {
+    Reflect::set(object, &JsValue::from_str(key), &value)
+        .map(|_| ())
+        .map_err(|_| JsValue::from_str(&format!("Failed to set interaction field `{key}`")))
+}

--- a/wasm/src/interaction.rs
+++ b/wasm/src/interaction.rs
@@ -64,6 +64,7 @@ pub struct FeatureProperties {
     pub vertices: Option<u32>,
     pub tool_code: Option<u32>,
     pub primitive_count: Option<u32>,
+    pub arc_command: Option<String>,
 }
 
 impl InteractionLayer {
@@ -175,17 +176,29 @@ impl InteractionFeature {
         })
     }
 
-    pub fn gerber_properties(aperture: &Aperture) -> FeatureProperties {
+    pub fn gerber_properties_with_transform(
+        aperture: &Aperture,
+        layer_scale: f32,
+        layer_rotation: f32,
+    ) -> FeatureProperties {
         let primitive_count = u32::try_from(aperture.primitives.len()).ok();
+        let scale = layer_scale.abs();
+        let width = aperture.width * scale;
+        let height = aperture.height * scale;
+        let rotation = if aperture_has_orientation(aperture) {
+            normalize_rotation(aperture.rotation + layer_rotation)
+        } else {
+            None
+        };
         FeatureProperties {
-            diameter: (aperture.width > 0.0 && (aperture.width - aperture.height).abs() < 1.0e-6)
-                .then_some(aperture.width),
-            width: (aperture.width > 0.0).then_some(aperture.width),
-            height: (aperture.height > 0.0).then_some(aperture.height),
-            rotation: (aperture.rotation != 0.0).then_some(aperture.rotation),
+            diameter: (aperture.kind.as_str() == "circle" && width > 0.0).then_some(width),
+            width: (width > 0.0).then_some(width),
+            height: (height > 0.0).then_some(height),
+            rotation,
             vertices: (aperture.vertices > 0).then_some(aperture.vertices),
             tool_code: None,
             primitive_count,
+            arc_command: None,
         }
     }
 
@@ -302,6 +315,9 @@ impl FeatureProperties {
         if let Some(value) = self.primitive_count {
             set_property(&object, "primitiveCount", JsValue::from_f64(value as f64))?;
         }
+        if let Some(value) = &self.arc_command {
+            set_property(&object, "arcCommand", JsValue::from_str(value))?;
+        }
         Ok(object.into())
     }
 }
@@ -314,12 +330,32 @@ pub fn aperture_type(aperture: &Aperture) -> String {
     aperture.kind.as_str().to_string()
 }
 
+fn aperture_has_orientation(aperture: &Aperture) -> bool {
+    matches!(
+        aperture.kind.as_str(),
+        "rectangle" | "obround" | "polygon" | "macro" | "block"
+    )
+}
+
+fn normalize_rotation(rotation: f32) -> Option<f32> {
+    const EPSILON: f32 = 1.0e-6;
+    let full_turn = std::f32::consts::PI * 2.0;
+    let mut normalized = rotation % full_turn;
+    if normalized <= -std::f32::consts::PI {
+        normalized += full_turn;
+    } else if normalized > std::f32::consts::PI {
+        normalized -= full_turn;
+    }
+    (normalized.abs() > EPSILON).then_some(normalized)
+}
+
 pub fn feature_from_primitive_delta(
     kind: FeatureKind,
     aperture_code: &str,
     aperture: &Aperture,
     polarity: Polarity,
     primitives: &[Primitive],
+    properties: FeatureProperties,
 ) -> Option<InteractionFeature> {
     InteractionFeature::from_primitives(
         kind,
@@ -328,7 +364,7 @@ pub fn feature_from_primitive_delta(
         aperture.macro_name.clone(),
         polarity,
         primitives.to_vec(),
-        InteractionFeature::gerber_properties(aperture),
+        properties,
     )
 }
 

--- a/wasm/src/interaction.rs
+++ b/wasm/src/interaction.rs
@@ -23,7 +23,7 @@ pub struct InteractionLayer {
 pub struct InteractionFeature {
     pub kind: FeatureKind,
     pub aperture: Option<String>,
-    pub aperture_type: String,
+    pub aperture_type: Option<String>,
     pub macro_name: Option<String>,
     pub polarity: Polarity,
     pub primitives: Vec<Primitive>,
@@ -92,8 +92,20 @@ impl InteractionLayer {
     }
 
     pub fn pick(&self, x: f32, y: f32, tolerance: f32) -> Option<(usize, &InteractionFeature)> {
+        self.pick_after(x, y, tolerance, None).0
+    }
+
+    pub fn pick_after(
+        &self,
+        x: f32,
+        y: f32,
+        tolerance: f32,
+        after_feature_id: Option<usize>,
+    ) -> (Option<(usize, &InteractionFeature)>, bool) {
         let point = [x, y];
         let tolerance = tolerance.max(0.0);
+        let mut return_next_hit = after_feature_id.is_none();
+        let mut saw_after_feature = false;
 
         for (feature_id, feature) in self.features.iter().enumerate().rev() {
             if !bounds_contains(&feature.bounds, point, tolerance) {
@@ -101,13 +113,19 @@ impl InteractionLayer {
             }
             if feature.hit(point, tolerance) {
                 if feature.polarity == Polarity::Negative {
-                    return None;
+                    return (None, saw_after_feature);
                 }
-                return Some((feature_id, feature));
+                if return_next_hit {
+                    return (Some((feature_id, feature)), saw_after_feature);
+                }
+                if Some(feature_id) == after_feature_id {
+                    saw_after_feature = true;
+                    return_next_hit = true;
+                }
             }
         }
 
-        None
+        (None, saw_after_feature)
     }
 }
 
@@ -115,7 +133,7 @@ impl InteractionFeature {
     pub fn from_primitives(
         kind: FeatureKind,
         aperture: Option<String>,
-        aperture_type: String,
+        aperture_type: Option<String>,
         macro_name: Option<String>,
         polarity: Polarity,
         primitives: Vec<Primitive>,
@@ -136,7 +154,7 @@ impl InteractionFeature {
     pub fn from_geometry(
         kind: FeatureKind,
         aperture: Option<String>,
-        aperture_type: String,
+        aperture_type: Option<String>,
         macro_name: Option<String>,
         polarity: Polarity,
         primitives: Vec<Primitive>,
@@ -202,11 +220,9 @@ impl InteractionFeature {
         if let Some(aperture) = &self.aperture {
             set_property(&object, "aperture", JsValue::from_str(aperture))?;
         }
-        set_property(
-            &object,
-            "apertureType",
-            JsValue::from_str(&self.aperture_type),
-        )?;
+        if let Some(aperture_type) = &self.aperture_type {
+            set_property(&object, "apertureType", JsValue::from_str(aperture_type))?;
+        }
         if let Some(macro_name) = &self.macro_name {
             set_property(&object, "macroName", JsValue::from_str(macro_name))?;
         }
@@ -308,7 +324,7 @@ pub fn feature_from_primitive_delta(
     InteractionFeature::from_primitives(
         kind,
         aperture_name(aperture_code),
-        aperture_type(aperture),
+        Some(aperture_type(aperture)),
         aperture.macro_name.clone(),
         polarity,
         primitives.to_vec(),
@@ -326,7 +342,7 @@ pub fn drill_hit_feature(
     InteractionFeature::from_primitives(
         FeatureKind::DrillHit,
         Some(format!("T{tool_code:02}")),
-        "drill".to_string(),
+        None,
         None,
         Polarity::Positive,
         vec![Primitive::Circle {
@@ -350,7 +366,7 @@ pub fn drill_slot_feature(
     InteractionFeature::from_primitives(
         FeatureKind::DrillSlot,
         Some(format!("T{tool_code:02}")),
-        "drill".to_string(),
+        None,
         None,
         Polarity::Positive,
         primitives,
@@ -967,4 +983,85 @@ fn set_property(object: &Object, key: &str, value: JsValue) -> Result<(), JsValu
     Reflect::set(object, &JsValue::from_str(key), &value)
         .map(|_| ())
         .map_err(|_| JsValue::from_str(&format!("Failed to set interaction field `{key}`")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn circle_feature(x: f32, radius: f32, polarity: Polarity) -> InteractionFeature {
+        InteractionFeature::from_primitives(
+            FeatureKind::Flash,
+            Some("D10".to_string()),
+            Some("circle".to_string()),
+            None,
+            polarity,
+            vec![Primitive::Circle {
+                x,
+                y: 0.0,
+                radius,
+                exposure: 1.0,
+                hole_x: 0.0,
+                hole_y: 0.0,
+                hole_radius: 0.0,
+            }],
+            FeatureProperties::default(),
+        )
+        .expect("circle feature should have bounds")
+    }
+
+    #[test]
+    fn pick_after_returns_next_hit_in_render_order() {
+        let mut layer = InteractionLayer::new();
+        layer.push(circle_feature(0.0, 2.0, Polarity::Positive));
+        layer.push(circle_feature(0.0, 2.0, Polarity::Positive));
+        layer.push(circle_feature(0.0, 2.0, Polarity::Positive));
+
+        let (hit, saw_after) = layer.pick_after(0.0, 0.0, 0.0, None);
+        assert_eq!(hit.map(|(feature_id, _)| feature_id), Some(2));
+        assert!(!saw_after);
+
+        let (hit, saw_after) = layer.pick_after(0.0, 0.0, 0.0, Some(2));
+        assert_eq!(hit.map(|(feature_id, _)| feature_id), Some(1));
+        assert!(saw_after);
+
+        let (hit, saw_after) = layer.pick_after(0.0, 0.0, 0.0, Some(0));
+        assert!(hit.is_none());
+        assert!(saw_after);
+    }
+
+    #[test]
+    fn pick_after_stops_at_hit_clear_feature() {
+        let mut layer = InteractionLayer::new();
+        layer.push(circle_feature(0.0, 2.0, Polarity::Positive));
+        layer.push(circle_feature(0.0, 2.0, Polarity::Negative));
+
+        let (hit, saw_after) = layer.pick_after(0.0, 0.0, 0.0, None);
+        assert!(hit.is_none());
+        assert!(!saw_after);
+    }
+
+    #[test]
+    fn non_aperture_features_do_not_report_aperture_type() {
+        let region = InteractionFeature::from_primitives(
+            FeatureKind::Region,
+            None,
+            None,
+            None,
+            Polarity::Positive,
+            vec![Primitive::Triangle {
+                vertices: [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+                exposure: 1.0,
+                hole_x: 0.0,
+                hole_y: 0.0,
+                hole_radius: 0.0,
+            }],
+            FeatureProperties::default(),
+        )
+        .expect("region feature should have bounds");
+        let drill = drill_hit_feature(1, 0.5, 0.0, 0.0).expect("drill hit should have bounds");
+
+        assert!(region.aperture_type.is_none());
+        assert!(drill.aperture_type.is_none());
+    }
 }

--- a/wasm/src/interaction.rs
+++ b/wasm/src/interaction.rs
@@ -631,12 +631,18 @@ fn primitive_hit(primitive: &Primitive, point: [f32; 2], tolerance: f32) -> bool
             y,
             outer_diameter,
             inner_diameter,
+            gap_thickness,
+            rotation,
             ..
-        } => {
-            let distance = ((point[0] - *x).powi(2) + (point[1] - *y).powi(2)).sqrt();
-            distance <= *outer_diameter * 0.5 + tolerance
-                && distance >= (*inner_diameter * 0.5 - tolerance).max(0.0)
-        }
+        } => thermal_hit(
+            point,
+            [*x, *y],
+            *outer_diameter,
+            *inner_diameter,
+            *gap_thickness,
+            *rotation,
+            tolerance,
+        ),
         Primitive::TriangleTemplateFlash { template, x, y } => {
             for triangle in template.chunks_exact(6) {
                 let vertices = [
@@ -779,6 +785,39 @@ fn append_primitive_highlight_batches(batches: &mut Vec<HighlightBatch>, primiti
         }
         _ => {}
     }
+
+    if let Primitive::Thermal {
+        x,
+        y,
+        outer_diameter,
+        inner_diameter,
+        gap_thickness,
+        rotation,
+        ..
+    } = primitive
+    {
+        if *inner_diameter > 0.0 {
+            let mut clear_vertices = Vec::new();
+            append_circle(
+                &mut clear_vertices,
+                [*x, *y],
+                *inner_diameter * 0.5,
+                CIRCLE_SEGMENTS,
+            );
+            append_highlight_batch(batches, clear_vertices, true);
+        }
+        if *gap_thickness > 0.0 && *outer_diameter > 0.0 {
+            let mut clear_vertices = Vec::new();
+            append_thermal_gap_rectangles(
+                &mut clear_vertices,
+                [*x, *y],
+                *outer_diameter,
+                *gap_thickness,
+                *rotation,
+            );
+            append_highlight_batch(batches, clear_vertices, true);
+        }
+    }
 }
 
 fn append_highlight_batch(batches: &mut Vec<HighlightBatch>, vertices: Vec<f32>, clear: bool) {
@@ -874,6 +913,84 @@ fn append_capsule(vertices: &mut Vec<f32>, start: [f32; 2], end: [f32; 2], radiu
     );
     append_circle(vertices, start, radius, 24);
     append_circle(vertices, end, radius, 24);
+}
+
+fn thermal_hit(
+    point: [f32; 2],
+    center: [f32; 2],
+    outer_diameter: f32,
+    inner_diameter: f32,
+    gap_thickness: f32,
+    rotation: f32,
+    tolerance: f32,
+) -> bool {
+    if outer_diameter <= 0.0 {
+        return false;
+    }
+
+    let dx = point[0] - center[0];
+    let dy = point[1] - center[1];
+    let distance = (dx * dx + dy * dy).sqrt();
+    let outer_radius = outer_diameter * 0.5;
+    let inner_radius = (inner_diameter * 0.5).max(0.0);
+    if distance > outer_radius + tolerance || distance < (inner_radius - tolerance).max(0.0) {
+        return false;
+    }
+
+    let half_gap = (gap_thickness * 0.5).max(0.0);
+    if half_gap <= tolerance {
+        return true;
+    }
+
+    let cos_r = rotation.cos();
+    let sin_r = rotation.sin();
+    let local_x = dx * cos_r + dy * sin_r;
+    let local_y = -dx * sin_r + dy * cos_r;
+    local_x.abs() >= half_gap - tolerance && local_y.abs() >= half_gap - tolerance
+}
+
+fn append_thermal_gap_rectangles(
+    vertices: &mut Vec<f32>,
+    center: [f32; 2],
+    outer_diameter: f32,
+    gap_thickness: f32,
+    rotation: f32,
+) {
+    let outer_radius = outer_diameter * 0.5;
+    let half_gap = gap_thickness * 0.5;
+    if outer_radius <= 0.0 || half_gap <= 0.0 {
+        return;
+    }
+
+    append_rotated_rect(vertices, center, half_gap, outer_radius, rotation);
+    append_rotated_rect(vertices, center, outer_radius, half_gap, rotation);
+}
+
+fn append_rotated_rect(
+    vertices: &mut Vec<f32>,
+    center: [f32; 2],
+    half_width: f32,
+    half_height: f32,
+    rotation: f32,
+) {
+    let local = [
+        [-half_width, -half_height],
+        [half_width, -half_height],
+        [half_width, half_height],
+        [-half_width, half_height],
+    ];
+    let cos_r = rotation.cos();
+    let sin_r = rotation.sin();
+    let mut points = [[0.0; 2]; 4];
+    for (idx, point) in local.iter().enumerate() {
+        points[idx] = [
+            center[0] + point[0] * cos_r - point[1] * sin_r,
+            center[1] + point[0] * sin_r + point[1] * cos_r,
+        ];
+    }
+
+    push_triangle(vertices, points[0], points[1], points[2]);
+    push_triangle(vertices, points[0], points[2], points[3]);
 }
 
 fn append_circle(vertices: &mut Vec<f32>, center: [f32; 2], radius: f32, segments: usize) {
@@ -1046,6 +1163,27 @@ mod tests {
         .expect("circle feature should have bounds")
     }
 
+    fn thermal_feature(rotation: f32) -> InteractionFeature {
+        InteractionFeature::from_primitives(
+            FeatureKind::Flash,
+            Some("D10".to_string()),
+            Some("macro".to_string()),
+            Some("THERM".to_string()),
+            Polarity::Positive,
+            vec![Primitive::Thermal {
+                x: 0.0,
+                y: 0.0,
+                outer_diameter: 2.0,
+                inner_diameter: 0.5,
+                gap_thickness: 0.4,
+                rotation,
+                exposure: 1.0,
+            }],
+            FeatureProperties::default(),
+        )
+        .expect("thermal feature should have bounds")
+    }
+
     #[test]
     fn pick_after_returns_next_hit_in_render_order() {
         let mut layer = InteractionLayer::new();
@@ -1099,5 +1237,26 @@ mod tests {
 
         assert!(region.aperture_type.is_none());
         assert!(drill.aperture_type.is_none());
+    }
+
+    #[test]
+    fn thermal_hit_respects_inner_hole_and_rotated_gaps() {
+        let feature = thermal_feature(0.0);
+        assert!(feature.hit([0.5, 0.5], 0.0));
+        assert!(!feature.hit([0.0, 0.5], 0.0));
+        assert!(!feature.hit([0.1, 0.1], 0.0));
+
+        let rotated = thermal_feature(std::f32::consts::FRAC_PI_4);
+        assert!(!rotated.hit([0.5, 0.5], 0.0));
+        assert!(rotated.hit([0.7, 0.0], 0.0));
+    }
+
+    #[test]
+    fn thermal_highlight_batches_clear_hole_and_gaps() {
+        let batches = thermal_feature(0.0).highlight_batches();
+        assert_eq!(batches.len(), 2);
+        assert!(!batches[0].clear);
+        assert!(batches[1].clear);
+        assert!(batches[1].vertices.len() > CIRCLE_SEGMENTS * 6);
     }
 }

--- a/wasm/src/interaction.rs
+++ b/wasm/src/interaction.rs
@@ -179,6 +179,8 @@ impl InteractionFeature {
     pub fn gerber_properties_with_transform(
         aperture: &Aperture,
         layer_scale: f32,
+        mirror_x: bool,
+        mirror_y: bool,
         layer_rotation: f32,
     ) -> FeatureProperties {
         let primitive_count = u32::try_from(aperture.primitives.len()).ok();
@@ -186,7 +188,12 @@ impl InteractionFeature {
         let width = aperture.width * scale;
         let height = aperture.height * scale;
         let rotation = if aperture_has_orientation(aperture) {
-            normalize_rotation(aperture.rotation + layer_rotation)
+            normalize_rotation(transform_aperture_rotation(
+                aperture.rotation,
+                mirror_x,
+                mirror_y,
+                layer_rotation,
+            ))
         } else {
             None
         };
@@ -335,6 +342,21 @@ fn aperture_has_orientation(aperture: &Aperture) -> bool {
         aperture.kind.as_str(),
         "rectangle" | "obround" | "polygon" | "macro" | "block"
     )
+}
+
+fn transform_aperture_rotation(
+    mut rotation: f32,
+    mirror_x: bool,
+    mirror_y: bool,
+    layer_rotation: f32,
+) -> f32 {
+    if mirror_x {
+        rotation = std::f32::consts::PI - rotation;
+    }
+    if mirror_y {
+        rotation = -rotation;
+    }
+    rotation + layer_rotation
 }
 
 fn normalize_rotation(rotation: f32) -> Option<f32> {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -304,6 +304,67 @@ impl GerberProcessor {
             *slot = None;
         }
     }
+
+    fn pick_interaction_feature_internal(
+        &self,
+        layer_ids: &[u32],
+        x: f32,
+        y: f32,
+        tolerance: f32,
+        after: Option<(u32, usize)>,
+    ) -> Result<JsValue, JsValue> {
+        if !self.interaction_enabled {
+            return Ok(JsValue::NULL);
+        }
+        if !x.is_finite() || !y.is_finite() || !tolerance.is_finite() {
+            return Err(JsValue::from_str("Pick coordinates must be finite"));
+        }
+
+        let mut first_hit = None;
+        let mut found_after = after.is_none();
+
+        for &layer_id in layer_ids.iter().rev() {
+            let Some(Some(interaction_layer)) = self.interaction_layers.get(layer_id as usize)
+            else {
+                continue;
+            };
+
+            if let Some((after_layer_id, after_feature_id)) = after {
+                if layer_id == after_layer_id && !found_after {
+                    if first_hit.is_none() {
+                        first_hit = interaction_layer
+                            .pick(x, y, tolerance)
+                            .map(|(feature_id, feature)| (layer_id, feature_id, feature));
+                    }
+
+                    let (hit, saw_after) =
+                        interaction_layer.pick_after(x, y, tolerance, Some(after_feature_id));
+                    if let Some((feature_id, feature)) = hit {
+                        return feature.info_to_js(layer_id, feature_id);
+                    }
+                    if saw_after {
+                        found_after = true;
+                    }
+                    continue;
+                }
+            }
+
+            if let Some((feature_id, feature)) = interaction_layer.pick(x, y, tolerance) {
+                if first_hit.is_none() {
+                    first_hit = Some((layer_id, feature_id, feature));
+                }
+                if found_after {
+                    return feature.info_to_js(layer_id, feature_id);
+                }
+            }
+        }
+
+        if let Some((layer_id, feature_id, feature)) = first_hit {
+            return feature.info_to_js(layer_id, feature_id);
+        }
+
+        Ok(JsValue::NULL)
+    }
 }
 
 #[wasm_bindgen]
@@ -736,24 +797,25 @@ impl GerberProcessor {
         y: f32,
         tolerance: f32,
     ) -> Result<JsValue, JsValue> {
-        if !self.interaction_enabled {
-            return Ok(JsValue::NULL);
-        }
-        if !x.is_finite() || !y.is_finite() || !tolerance.is_finite() {
-            return Err(JsValue::from_str("Pick coordinates must be finite"));
-        }
+        self.pick_interaction_feature_internal(layer_ids, x, y, tolerance, None)
+    }
 
-        for &layer_id in layer_ids.iter().rev() {
-            let Some(Some(interaction_layer)) = self.interaction_layers.get(layer_id as usize)
-            else {
-                continue;
-            };
-            if let Some((feature_id, feature)) = interaction_layer.pick(x, y, tolerance) {
-                return feature.info_to_js(layer_id, feature_id);
-            }
-        }
-
-        Ok(JsValue::NULL)
+    pub fn pick_interaction_feature_after(
+        &self,
+        layer_ids: &[u32],
+        x: f32,
+        y: f32,
+        tolerance: f32,
+        after_layer_id: u32,
+        after_feature_id: u32,
+    ) -> Result<JsValue, JsValue> {
+        self.pick_interaction_feature_internal(
+            layer_ids,
+            x,
+            y,
+            tolerance,
+            Some((after_layer_id, after_feature_id as usize)),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,12 +1,18 @@
 mod drill;
+mod interaction;
 mod parse_common;
 mod parser;
 mod renderer;
 mod shape;
 mod util;
 
-use crate::drill::{parse_drill_with_offset, DrillParseResult};
-use crate::parser::parse_gerber_with_options;
+use crate::drill::{
+    parse_drill_with_offset, parse_drill_with_offset_and_interactions, DrillParseResult,
+};
+use crate::interaction::InteractionLayer;
+use crate::parser::{
+    parse_gerber_payload_with_options, parse_gerber_with_options, ParsedGerberLayer,
+};
 use crate::renderer::Renderer;
 use crate::shape::{gerber_data_layers_from_js, gerber_data_layers_to_js, Boundary, GerberData};
 use crate::util::format_bytes;
@@ -68,6 +74,40 @@ fn parse_layer_data(
     }
 
     Ok(non_empty_layers)
+}
+
+fn parse_layer_payload_data(
+    content: &str,
+    offset_x: f32,
+    offset_y: f32,
+    preserve_arc_regions: bool,
+    arc_tessellation_quality: u32,
+) -> Result<ParsedGerberLayer, JsValue> {
+    if !offset_x.is_finite() || !offset_y.is_finite() {
+        return Err(JsValue::from_str("Layer offset must be finite"));
+    }
+
+    let mut payload =
+        parse_gerber_payload_with_options(content, preserve_arc_regions, arc_tessellation_quality)?;
+
+    if offset_x != 0.0 || offset_y != 0.0 {
+        for layer in &mut payload.render_layers {
+            layer.translate(offset_x, offset_y);
+        }
+        if let Some(interaction_layer) = &mut payload.interaction_layer {
+            interaction_layer.translate(offset_x, offset_y);
+        }
+    }
+
+    payload.render_layers.retain(|layer| layer.has_geometry());
+
+    if payload.render_layers.is_empty() {
+        return Err(JsValue::from_str(
+            "File does not contain valid Gerber data (no geometry found)",
+        ));
+    }
+
+    Ok(payload)
 }
 
 #[wasm_bindgen]
@@ -137,6 +177,8 @@ pub struct GerberProcessor {
     minimum_feature_pixels: f32,
     drill_outline_pixels: f32,
     drill_outline_layer_ids: Vec<u32>,
+    interaction_enabled: bool,
+    interaction_layers: Vec<Option<InteractionLayer>>,
 }
 
 impl Default for GerberProcessor {
@@ -148,6 +190,8 @@ impl Default for GerberProcessor {
             minimum_feature_pixels: 0.0,
             drill_outline_pixels: 0.0,
             drill_outline_layer_ids: Vec::new(),
+            interaction_enabled: false,
+            interaction_layers: Vec::new(),
         }
     }
 }
@@ -180,29 +224,49 @@ impl GerberProcessor {
         }
     }
 
+    fn add_parsed_layer_payload(&mut self, payload: ParsedGerberLayer) -> Result<u32, JsValue> {
+        let interaction_layer = payload.interaction_layer;
+        let layer_id = self.add_parsed_layers(payload.render_layers)?;
+        self.set_interaction_layer(layer_id as usize, interaction_layer);
+        Ok(layer_id)
+    }
+
     fn add_drill_parse_result(&mut self, drill: DrillParseResult) -> Result<JsValue, JsValue> {
-        if !drill.fill_layer.has_geometry() {
+        let DrillParseResult {
+            outline_layer,
+            fill_layer,
+            metadata,
+            interaction_layer,
+        } = drill;
+
+        if !fill_layer.has_geometry() {
             return Err(JsValue::from_str(
                 "File does not contain valid drill data (no holes found)",
             ));
         }
 
-        let Some(renderer) = &mut self.renderer else {
-            return Err(JsValue::from_str(
-                "Renderer not initialized. Call init() first.",
-            ));
+        let (outline_layer_id, fill_layer_id) = {
+            let Some(renderer) = &mut self.renderer else {
+                return Err(JsValue::from_str(
+                    "Renderer not initialized. Call init() first.",
+                ));
+            };
+
+            let outline_layer_id = renderer.add_layer(vec![outline_layer])?;
+            renderer.set_layer_inner_outline(outline_layer_id, self.drill_outline_pixels, 0.0)?;
+            let fill_layer_id = match renderer.add_layer(vec![fill_layer]) {
+                Ok(layer_id) => layer_id,
+                Err(error) => {
+                    let _ = renderer.remove_layer(outline_layer_id);
+                    return Err(error);
+                }
+            };
+            (outline_layer_id, fill_layer_id)
         };
 
-        let outline_layer_id = renderer.add_layer(vec![drill.outline_layer])?;
-        renderer.set_layer_inner_outline(outline_layer_id, self.drill_outline_pixels, 0.0)?;
-        let fill_layer_id = match renderer.add_layer(vec![drill.fill_layer]) {
-            Ok(layer_id) => layer_id,
-            Err(error) => {
-                let _ = renderer.remove_layer(outline_layer_id);
-                return Err(error);
-            }
-        };
         self.drill_outline_layer_ids.push(outline_layer_id as u32);
+        self.set_interaction_layer(outline_layer_id, interaction_layer);
+        self.set_interaction_layer(fill_layer_id, None);
 
         let object = Object::new();
         Reflect::set(
@@ -215,13 +279,30 @@ impl GerberProcessor {
             &JsValue::from_str("fillLayerId"),
             &JsValue::from_f64(fill_layer_id as f64),
         )?;
-        Reflect::set(
-            &object,
-            &JsValue::from_str("metadata"),
-            &drill.metadata.to_js()?,
-        )?;
+        Reflect::set(&object, &JsValue::from_str("metadata"), &metadata.to_js()?)?;
 
         Ok(object.into())
+    }
+
+    fn set_interaction_layer(
+        &mut self,
+        layer_id: usize,
+        interaction_layer: Option<InteractionLayer>,
+    ) {
+        if !self.interaction_enabled {
+            return;
+        }
+
+        if self.interaction_layers.len() <= layer_id {
+            self.interaction_layers.resize_with(layer_id + 1, || None);
+        }
+        self.interaction_layers[layer_id] = interaction_layer;
+    }
+
+    fn remove_interaction_layer(&mut self, layer_id: usize) {
+        if let Some(slot) = self.interaction_layers.get_mut(layer_id) {
+            *slot = None;
+        }
     }
 }
 
@@ -310,6 +391,13 @@ impl GerberProcessor {
         }
     }
 
+    pub fn set_interactions_enabled(&mut self, enabled: bool) {
+        self.interaction_enabled = enabled;
+        if !enabled {
+            self.interaction_layers.clear();
+        }
+    }
+
     pub fn set_layer_inner_outline(
         &mut self,
         layer_id: u32,
@@ -378,6 +466,17 @@ impl GerberProcessor {
     /// # Returns
     /// * Layer ID (u32) for tracking this layer
     pub fn add_layer(&mut self, content: String) -> Result<u32, JsValue> {
+        if self.interaction_enabled {
+            let payload = parse_layer_payload_data(
+                &content,
+                0.0,
+                0.0,
+                self.preserve_arc_regions,
+                self.arc_tessellation_quality,
+            )?;
+            return self.add_parsed_layer_payload(payload);
+        }
+
         let gerber_data_layers = parse_layer_data(
             &content,
             0.0,
@@ -403,6 +502,17 @@ impl GerberProcessor {
         offset_x: f32,
         offset_y: f32,
     ) -> Result<u32, JsValue> {
+        if self.interaction_enabled {
+            let payload = parse_layer_payload_data(
+                &content,
+                offset_x,
+                offset_y,
+                self.preserve_arc_regions,
+                self.arc_tessellation_quality,
+            )?;
+            return self.add_parsed_layer_payload(payload);
+        }
+
         let gerber_data_layers = parse_layer_data(
             &content,
             offset_x,
@@ -415,7 +525,11 @@ impl GerberProcessor {
 
     /// Add an Excellon / NC Drill file as a drill overlay.
     pub fn add_drill_layer(&mut self, content: String) -> Result<JsValue, JsValue> {
-        let drill = parse_drill_with_offset(&content, DRILL_OUTLINE_WIDTH_MM, 0.0, 0.0)?;
+        let drill = if self.interaction_enabled {
+            parse_drill_with_offset_and_interactions(&content, DRILL_OUTLINE_WIDTH_MM, 0.0, 0.0)?
+        } else {
+            parse_drill_with_offset(&content, DRILL_OUTLINE_WIDTH_MM, 0.0, 0.0)?
+        };
         self.add_drill_parse_result(drill)
     }
 
@@ -425,7 +539,16 @@ impl GerberProcessor {
         offset_x: f32,
         offset_y: f32,
     ) -> Result<JsValue, JsValue> {
-        let drill = parse_drill_with_offset(&content, DRILL_OUTLINE_WIDTH_MM, offset_x, offset_y)?;
+        let drill = if self.interaction_enabled {
+            parse_drill_with_offset_and_interactions(
+                &content,
+                DRILL_OUTLINE_WIDTH_MM,
+                offset_x,
+                offset_y,
+            )?
+        } else {
+            parse_drill_with_offset(&content, DRILL_OUTLINE_WIDTH_MM, offset_x, offset_y)?
+        };
         self.add_drill_parse_result(drill)
     }
 
@@ -438,7 +561,8 @@ impl GerberProcessor {
     /// Add a worker-produced render payload directly to WebGL buffers.
     pub fn add_render_payload(&mut self, render_payload: JsValue) -> Result<u32, JsValue> {
         if let Some(renderer) = &mut self.renderer {
-            Ok(renderer.add_layer_from_render_payload(&render_payload)? as u32)
+            let layer_id = renderer.add_layer_from_render_payload(&render_payload)?;
+            Ok(layer_id as u32)
         } else {
             Err(JsValue::from_str(
                 "Renderer not initialized. Call init() first.",
@@ -458,6 +582,7 @@ impl GerberProcessor {
             renderer.remove_layer(layer_id as usize)?;
             self.drill_outline_layer_ids
                 .retain(|&outline_layer_id| outline_layer_id != layer_id);
+            self.remove_interaction_layer(layer_id as usize);
             Ok("remove_done".to_string())
         } else {
             Err(JsValue::from_str(
@@ -474,6 +599,7 @@ impl GerberProcessor {
         if let Some(renderer) = &mut self.renderer {
             renderer.clear_all();
             self.drill_outline_layer_ids.clear();
+            self.interaction_layers.clear();
             Ok("clear_done".to_string())
         } else {
             Err(JsValue::from_str(
@@ -596,6 +722,65 @@ impl GerberProcessor {
                 clear_canvas,
             )?;
             Ok("render_done".to_string())
+        } else {
+            Err(JsValue::from_str(
+                "Renderer not initialized. Call init() first.",
+            ))
+        }
+    }
+
+    pub fn pick_interaction_feature(
+        &self,
+        layer_ids: &[u32],
+        x: f32,
+        y: f32,
+        tolerance: f32,
+    ) -> Result<JsValue, JsValue> {
+        if !self.interaction_enabled {
+            return Ok(JsValue::NULL);
+        }
+        if !x.is_finite() || !y.is_finite() || !tolerance.is_finite() {
+            return Err(JsValue::from_str("Pick coordinates must be finite"));
+        }
+
+        for &layer_id in layer_ids.iter().rev() {
+            let Some(Some(interaction_layer)) = self.interaction_layers.get(layer_id as usize)
+            else {
+                continue;
+            };
+            if let Some((feature_id, feature)) = interaction_layer.pick(x, y, tolerance) {
+                return feature.info_to_js(layer_id, feature_id);
+            }
+        }
+
+        Ok(JsValue::NULL)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_interaction_highlight(
+        &mut self,
+        layer_id: u32,
+        feature_id: u32,
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+    ) -> Result<String, JsValue> {
+        if !self.interaction_enabled {
+            return Ok("highlight_skipped".to_string());
+        }
+
+        let feature = self
+            .interaction_layers
+            .get(layer_id as usize)
+            .and_then(Option::as_ref)
+            .and_then(|layer| layer.features.get(feature_id as usize))
+            .cloned()
+            .ok_or_else(|| JsValue::from_str("Interaction feature not found"))?;
+
+        if let Some(renderer) = &mut self.renderer {
+            renderer.render_interaction_highlight(&feature, zoom_x, zoom_y, offset_x, offset_y)?;
+            Ok("highlight_done".to_string())
         } else {
             Err(JsValue::from_str(
                 "Renderer not initialized. Call init() first.",

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -15,6 +15,7 @@ use state::{
 };
 
 use self::geometry::{arc_curve_bounds, parse_graphic_command, Primitive, RegionContour};
+use crate::interaction::InteractionLayer;
 use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
     Triangles,
@@ -30,6 +31,11 @@ pub struct PolarityLayer {
     pub(crate) polarity: Polarity,
     pub(crate) primitives: Vec<Primitive>,
     pub(crate) path_regions: PathRegions,
+}
+
+pub struct ParsedGerberLayer {
+    pub render_layers: Vec<GerberData>,
+    pub interaction_layer: Option<InteractionLayer>,
 }
 
 fn collect_lines(data: &str) -> Result<Vec<&str>, JsValue> {
@@ -820,10 +826,19 @@ pub struct GerberParser {
     pub current_primitives: Vec<Primitive>, // Accumulating primitives for current polarity
     pub current_path_regions: PathRegions,
     pub region_contours: Vec<RegionContour>, // Contours collected in Region mode
+    pub interaction_layer: Option<InteractionLayer>,
 }
 
 impl GerberParser {
     pub fn with_options(preserve_arc_regions: bool, arc_tessellation_quality: u32) -> Self {
+        Self::with_options_and_interactions(preserve_arc_regions, arc_tessellation_quality, false)
+    }
+
+    pub fn with_options_and_interactions(
+        preserve_arc_regions: bool,
+        arc_tessellation_quality: u32,
+        collect_interactions: bool,
+    ) -> Self {
         GerberParser {
             apertures: HashMap::new(),
             macros: HashMap::new(),
@@ -834,6 +849,7 @@ impl GerberParser {
             current_primitives: Vec::new(),
             current_path_regions: PathRegions::empty(),
             region_contours: Vec::new(),
+            interaction_layer: collect_interactions.then(InteractionLayer::new),
         }
     }
 
@@ -867,6 +883,7 @@ impl GerberParser {
                     &mut self.polarity_layers,
                     self.preserve_arc_regions,
                     self.arc_tessellation_quality,
+                    self.interaction_layer.is_some(),
                 )?;
             } else if line_ref.starts_with("G04") {
                 // Comment line, skip
@@ -877,6 +894,7 @@ impl GerberParser {
                 || line_ref.starts_with('I')
                 || line_ref.starts_with('J')
             {
+                let collect_interactions = self.interaction_layer.is_some();
                 parse_graphic_command(
                     line_ref,
                     &mut self.current_state,
@@ -885,8 +903,10 @@ impl GerberParser {
                     &mut self.region_contours,
                     &mut self.current_path_regions,
                     &mut self.polarity_layers,
+                    self.interaction_layer.as_mut(),
                     self.preserve_arc_regions,
                     self.arc_tessellation_quality,
+                    collect_interactions,
                 )
                 .map_err(|message| JsValue::from_str(&message))?;
             }
@@ -926,6 +946,14 @@ impl GerberParser {
         }
 
         Ok(gerber_data_layers)
+    }
+
+    pub fn parse_payload(&mut self, data: &str) -> Result<ParsedGerberLayer, JsValue> {
+        let render_layers = self.parse(data)?;
+        Ok(ParsedGerberLayer {
+            render_layers,
+            interaction_layer: take(&mut self.interaction_layer),
+        })
     }
 
     /// Convert a vector of primitives to GerberData
@@ -980,6 +1008,7 @@ fn parse_command(
     polarity_layers: &mut Vec<PolarityLayer>,
     preserve_arc_regions: bool,
     arc_tessellation_quality: u32,
+    collect_interactions: bool,
 ) -> Result<(), JsValue> {
     let line = if !line_ref.ends_with('%') {
         let mut buffer = String::new();
@@ -1006,7 +1035,13 @@ fn parse_command(
     if line.starts_with("%AM") {
         parse_macro(&line, macros);
     } else if line.starts_with("%ADD") {
-        parse_aperture(&line, apertures, macros, state.unit_multiplier);
+        parse_aperture(
+            &line,
+            apertures,
+            macros,
+            state.unit_multiplier,
+            collect_interactions,
+        );
     } else if line.starts_with("%MO") {
         // Unit mode: %MOMM* or %MOIN*
         parse_mo(&line, state);
@@ -1044,6 +1079,7 @@ fn parse_command(
             polarity_layers,
             preserve_arc_regions,
             arc_tessellation_quality,
+            collect_interactions,
         )?;
     } else if line.starts_with("%LM") {
         // Layer mirroring: %LMN*, %LMX*, %LMY*, %LMXY*
@@ -1123,6 +1159,7 @@ fn parse_aperture_block(
     polarity_layers: &mut Vec<PolarityLayer>,
     preserve_arc_regions: bool,
     arc_tessellation_quality: u32,
+    collect_interactions: bool,
 ) -> Result<(), JsValue> {
     let Some(block_code) = parse_aperture_block_code(line) else {
         return Ok(());
@@ -1167,6 +1204,7 @@ fn parse_aperture_block(
                 &mut block_layers,
                 preserve_arc_regions,
                 arc_tessellation_quality,
+                collect_interactions,
             )?;
             if let Some(enclosing_state) = nested_block_state {
                 *state = enclosing_state;
@@ -1186,8 +1224,10 @@ fn parse_aperture_block(
                 &mut block_region_contours,
                 &mut block_path_regions,
                 &mut block_layers,
+                None,
                 preserve_arc_regions,
                 arc_tessellation_quality,
+                collect_interactions,
             )
             .map_err(|message| JsValue::from_str(&message))?;
         }
@@ -1221,6 +1261,19 @@ pub fn parse_gerber_with_options(
 ) -> Result<Vec<GerberData>, JsValue> {
     let mut parser = GerberParser::with_options(preserve_arc_regions, arc_tessellation_quality);
     parser.parse(data)
+}
+
+pub fn parse_gerber_payload_with_options(
+    data: &str,
+    preserve_arc_regions: bool,
+    arc_tessellation_quality: u32,
+) -> Result<ParsedGerberLayer, JsValue> {
+    let mut parser = GerberParser::with_options_and_interactions(
+        preserve_arc_regions,
+        arc_tessellation_quality,
+        true,
+    );
+    parser.parse_payload(data)
 }
 
 #[cfg(test)]

--- a/wasm/src/parser/aperture.rs
+++ b/wasm/src/parser/aperture.rs
@@ -14,6 +14,32 @@ struct TriangleTemplateTransformKey {
     layer_rotation: u32,
 }
 
+/// Aperture shape metadata used by optional interaction indexing.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ApertureKind {
+    Circle,
+    Rectangle,
+    Obround,
+    Polygon,
+    Macro,
+    Block,
+    Unknown,
+}
+
+impl ApertureKind {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            ApertureKind::Circle => "circle",
+            ApertureKind::Rectangle => "rectangle",
+            ApertureKind::Obround => "obround",
+            ApertureKind::Polygon => "polygon",
+            ApertureKind::Macro => "macro",
+            ApertureKind::Block => "block",
+            ApertureKind::Unknown => "unknown",
+        }
+    }
+}
+
 /// Aperture definition (Circle, Rectangle, Obround, Polygon, or Macro reference)
 #[derive(Clone, Debug)]
 pub struct Aperture {
@@ -24,6 +50,13 @@ pub struct Aperture {
     pub triangle_template: Option<Rc<Vec<f32>>>,
     triangle_template_cache: RefCell<HashMap<TriangleTemplateTransformKey, Rc<Vec<f32>>>>,
     pub is_solid_circle: bool,
+    pub kind: ApertureKind,
+    pub macro_name: Option<String>,
+    pub width: f32,
+    pub height: f32,
+    pub hole_diameter: f32,
+    pub vertices: u32,
+    pub rotation: f32,
 }
 
 impl Aperture {
@@ -36,6 +69,13 @@ impl Aperture {
             triangle_template: None,
             triangle_template_cache: RefCell::new(HashMap::new()),
             is_solid_circle: false,
+            kind: ApertureKind::Unknown,
+            macro_name: None,
+            width: 0.0,
+            height: 0.0,
+            hole_diameter: 0.0,
+            vertices: 0,
+            rotation: 0.0,
         }
     }
 
@@ -52,6 +92,13 @@ impl Aperture {
             triangle_template: None,
             triangle_template_cache: RefCell::new(HashMap::new()),
             is_solid_circle: false,
+            kind: ApertureKind::Block,
+            macro_name: None,
+            width: 0.0,
+            height: 0.0,
+            hole_diameter: 0.0,
+            vertices: 0,
+            rotation: 0.0,
         }
     }
 
@@ -160,6 +207,83 @@ fn build_triangle_template(primitives: &[Primitive]) -> Option<Rc<Vec<f32>>> {
     Some(Rc::new(vertices))
 }
 
+fn primitive_bounds(primitives: &[Primitive]) -> Option<(f32, f32, f32, f32)> {
+    let mut min_x = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+
+    for primitive in primitives {
+        match primitive {
+            Primitive::Triangle { vertices, .. } => {
+                for vertex in vertices {
+                    min_x = min_x.min(vertex[0]);
+                    max_x = max_x.max(vertex[0]);
+                    min_y = min_y.min(vertex[1]);
+                    max_y = max_y.max(vertex[1]);
+                }
+            }
+            Primitive::Circle { x, y, radius, .. } => {
+                min_x = min_x.min(*x - *radius);
+                max_x = max_x.max(*x + *radius);
+                min_y = min_y.min(*y - *radius);
+                max_y = max_y.max(*y + *radius);
+            }
+            Primitive::Arc {
+                x,
+                y,
+                radius,
+                thickness,
+                ..
+            } => {
+                let outer = *radius + *thickness * 0.5;
+                min_x = min_x.min(*x - outer);
+                max_x = max_x.max(*x + outer);
+                min_y = min_y.min(*y - outer);
+                max_y = max_y.max(*y + outer);
+            }
+            Primitive::Thermal {
+                x,
+                y,
+                outer_diameter,
+                ..
+            } => {
+                let radius = *outer_diameter * 0.5;
+                min_x = min_x.min(*x - radius);
+                max_x = max_x.max(*x + radius);
+                min_y = min_y.min(*y - radius);
+                max_y = max_y.max(*y + radius);
+            }
+            Primitive::Line {
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+                width,
+                ..
+            } => {
+                let radius = *width * 0.5;
+                min_x = min_x.min(start_x.min(*end_x) - radius);
+                max_x = max_x.max(start_x.max(*end_x) + radius);
+                min_y = min_y.min(start_y.min(*end_y) - radius);
+                max_y = max_y.max(start_y.max(*end_y) + radius);
+            }
+            Primitive::TriangleTemplateFlash { template, x, y } => {
+                for point in template.chunks_exact(2) {
+                    let px = point[0] + *x;
+                    let py = point[1] + *y;
+                    min_x = min_x.min(px);
+                    max_x = max_x.max(px);
+                    min_y = min_y.min(py);
+                    max_y = max_y.max(py);
+                }
+            }
+        }
+    }
+
+    min_x.is_finite().then_some((min_x, max_x, min_y, max_y))
+}
+
 /// Parse Aperture definition - %ADD{code}{shape}{params}*%
 /// Example: %ADD10C,0.20*% (circle), %ADD20R,0.5X0.3*% (rectangle), %ADD30TESTMACRO*1.5*%
 pub fn parse_aperture(
@@ -167,6 +291,7 @@ pub fn parse_aperture(
     apertures: &mut HashMap<String, Aperture>,
     macros: &HashMap<String, ApertureMacro>,
     unit_multiplier: f32,
+    collect_metadata: bool,
 ) {
     // Format: %ADD{code}{shape},{params}*%
     // Remove %ADD and %
@@ -219,6 +344,12 @@ pub fn parse_aperture(
 
                     aperture.radius = diameter_mm / 2.0;
                     aperture.is_solid_circle = hole_diameter_mm == 0.0;
+                    if collect_metadata {
+                        aperture.kind = ApertureKind::Circle;
+                        aperture.width = diameter_mm;
+                        aperture.height = diameter_mm;
+                        aperture.hole_diameter = hole_diameter_mm;
+                    }
                     aperture.primitives.push(Primitive::Circle {
                         x: 0.0,
                         y: 0.0,
@@ -249,6 +380,12 @@ pub fn parse_aperture(
                         };
 
                         aperture.radius = width_mm.max(height_mm) / 2.0;
+                        if collect_metadata {
+                            aperture.kind = ApertureKind::Rectangle;
+                            aperture.width = width_mm;
+                            aperture.height = height_mm;
+                            aperture.hole_diameter = hole_diameter_mm;
+                        }
                         // Split Rectangle into two triangles
                         let half_width = width_mm / 2.0;
                         let half_height = height_mm / 2.0;
@@ -298,6 +435,12 @@ pub fn parse_aperture(
                         let radius = short_side / 2.0;
 
                         aperture.radius = radius;
+                        if collect_metadata {
+                            aperture.kind = ApertureKind::Obround;
+                            aperture.width = width_mm;
+                            aperture.height = height_mm;
+                            aperture.hole_diameter = hole_diameter_mm;
+                        }
 
                         if width_mm > height_mm {
                             // If width is greater - circles on the left and right, rectangle in the middle
@@ -430,6 +573,14 @@ pub fn parse_aperture(
                         };
 
                         aperture.radius = diameter_mm / 2.0;
+                        if collect_metadata {
+                            aperture.kind = ApertureKind::Polygon;
+                            aperture.width = diameter_mm;
+                            aperture.height = diameter_mm;
+                            aperture.hole_diameter = hole_diameter_mm;
+                            aperture.vertices = num_vertices.max(0.0) as u32;
+                            aperture.rotation = rotation_radians;
+                        }
                         let radius = diameter_mm / 2.0;
                         let num_vertices = num_vertices as u32;
                         let angle_step = 2.0 * std::f32::consts::PI / num_vertices as f32;
@@ -487,6 +638,17 @@ pub fn parse_aperture(
                     scale_primitive(primitive, unit_multiplier);
                 }
                 aperture.radius = 0.0; // For macros, the radius depends on the parameters
+                if collect_metadata {
+                    aperture.kind = ApertureKind::Macro;
+                    aperture.macro_name = Some(shape.clone());
+                    if let Some((min_x, max_x, min_y, max_y)) =
+                        primitive_bounds(&aperture.primitives)
+                    {
+                        aperture.width = max_x - min_x;
+                        aperture.height = max_y - min_y;
+                        aperture.radius = aperture.width.max(aperture.height) / 2.0;
+                    }
+                }
             }
         }
     }

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1232,6 +1232,8 @@ fn record_block_flash_interaction(
     let properties = InteractionFeature::gerber_properties_with_transform(
         aperture,
         state.layer_scale,
+        state.mirror_x,
+        state.mirror_y,
         state.layer_rotation,
     );
     for sy in 0..state.sr_y {
@@ -1367,184 +1369,181 @@ pub fn execute_interpolation(
     let start_y = state.y;
 
     if let Some(aperture) = apertures.get(&state.current_aperture) {
-        match state.interpolation_mode.as_str() {
-            "linear" | "linear_x10" | "linear_x01" | "linear_x001" => {
-                // Draw line with Step and Repeat
-                for sy in 0..state.sr_y {
-                    for sx in 0..state.sr_x {
-                        let offset_x = sx as f32 * state.sr_i;
-                        let offset_y = sy as f32 * state.sr_j;
-                        let sr_start_x = start_x + offset_x;
-                        let sr_start_y = start_y + offset_y;
-                        let sr_end_x = end_x + offset_x;
-                        let sr_end_y = end_y + offset_y;
-
-                        if points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y) {
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_start_x,
-                                sr_start_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            )?;
-                            continue;
-                        }
-
-                        // RS-274X draw objects can only be created with a solid standard circle
-                        // aperture. Non-zero-length draws with other apertures are non-image.
-                        if !aperture.is_solid_circle {
-                            continue;
-                        }
-
-                        // Flash aperture at start point (no SR since we're already in SR loop)
-                        flash_aperture_no_sr(
-                            aperture,
-                            primitives,
-                            sr_start_x,
-                            sr_start_y,
-                            state.layer_scale,
-                            state.mirror_x,
-                            state.mirror_y,
-                            state.layer_rotation,
-                        )?;
-
-                        // Store line body separately from the two round cap flashes so
-                        // the renderer can keep it instanced and clamp screen thickness.
-                        let diameter = aperture.radius * 2.0 * state.layer_scale;
-                        if let Some(line) =
-                            line_to_body(sr_start_x, sr_start_y, sr_end_x, sr_end_y, diameter, 1.0)
-                        {
-                            try_reserve_primitives(primitives, 1, "linear interpolation")?;
-                            primitives.push(line);
-                        }
-
-                        // Flash aperture at end point (no SR since we're already in SR loop)
-                        flash_aperture_no_sr(
-                            aperture,
-                            primitives,
-                            sr_end_x,
-                            sr_end_y,
-                            state.layer_scale,
-                            state.mirror_x,
-                            state.mirror_y,
-                            state.layer_rotation,
-                        )?;
-                    }
-                }
+        for sy in 0..state.sr_y {
+            for sx in 0..state.sr_x {
+                let offset_x = sx as f32 * state.sr_i;
+                let offset_y = sy as f32 * state.sr_j;
+                append_interpolation_no_sr(
+                    state,
+                    aperture,
+                    primitives,
+                    start_x + offset_x,
+                    start_y + offset_y,
+                    end_x + offset_x,
+                    end_y + offset_y,
+                    i,
+                    j,
+                )?;
             }
-            "clockwise" | "counterclockwise" => {
-                // Draw arc with Step and Repeat
-                for sy in 0..state.sr_y {
-                    for sx in 0..state.sr_x {
-                        let offset_x = sx as f32 * state.sr_i;
-                        let offset_y = sy as f32 * state.sr_j;
-                        let sr_start_x = start_x + offset_x;
-                        let sr_start_y = start_y + offset_y;
-                        let sr_end_x = end_x + offset_x;
-                        let sr_end_y = end_y + offset_y;
-
-                        if points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y)
-                            && !arc_center_offset_present(i, j)
-                        {
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_start_x,
-                                sr_start_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            )?;
-                            continue;
-                        }
-
-                        // RS-274X arc objects can only be created with a solid standard circle
-                        // aperture. Non-zero-length arcs with other apertures are non-image.
-                        if !aperture.is_solid_circle {
-                            continue;
-                        }
-
-                        if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
-                            calculate_arc_parameters(
-                                state, sr_start_x, sr_start_y, sr_end_x, sr_end_y, i, j,
-                            )
-                        {
-                            let thickness = aperture.radius * 2.0 * state.layer_scale;
-                            let end_angle = start_angle + sweep_angle;
-
-                            let cap_start_x = center_x + radius * start_angle.cos();
-                            let cap_start_y = center_y + radius * start_angle.sin();
-                            let cap_end_x = center_x + radius * end_angle.cos();
-                            let cap_end_y = center_y + radius * end_angle.sin();
-
-                            // Flash aperture at rendered arc start point.
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                cap_start_x,
-                                cap_start_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            )?;
-
-                            // Add Arc primitive
-                            try_reserve_primitives(primitives, 1, "arc interpolation")?;
-                            primitives.push(Primitive::Arc {
-                                x: center_x,
-                                y: center_y,
-                                radius,
-                                start_angle,
-                                end_angle: start_angle + sweep_angle,
-                                thickness,
-                                exposure: 1.0,
-                            });
-
-                            // Flash aperture at rendered arc end point.
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                cap_end_x,
-                                cap_end_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            )?;
-                        } else {
-                            flash_aperture_no_sr(
-                                aperture,
-                                primitives,
-                                sr_start_x,
-                                sr_start_y,
-                                state.layer_scale,
-                                state.mirror_x,
-                                state.mirror_y,
-                                state.layer_rotation,
-                            )?;
-                            if !points_coincide(sr_start_x, sr_start_y, sr_end_x, sr_end_y) {
-                                flash_aperture_no_sr(
-                                    aperture,
-                                    primitives,
-                                    sr_end_x,
-                                    sr_end_y,
-                                    state.layer_scale,
-                                    state.mirror_x,
-                                    state.mirror_y,
-                                    state.layer_rotation,
-                                )?;
-                            }
-                        }
-                    }
-                }
-            }
-            _ => {}
         }
+    }
+
+    Ok(())
+}
+
+fn append_interpolation_no_sr(
+    state: &ParserState,
+    aperture: &Aperture,
+    primitives: &mut Vec<Primitive>,
+    start_x: f32,
+    start_y: f32,
+    end_x: f32,
+    end_y: f32,
+    i: f32,
+    j: f32,
+) -> Result<(), String> {
+    match state.interpolation_mode.as_str() {
+        "linear" | "linear_x10" | "linear_x01" | "linear_x001" => {
+            if points_coincide(start_x, start_y, end_x, end_y) {
+                flash_aperture_no_sr(
+                    aperture,
+                    primitives,
+                    start_x,
+                    start_y,
+                    state.layer_scale,
+                    state.mirror_x,
+                    state.mirror_y,
+                    state.layer_rotation,
+                )?;
+                return Ok(());
+            }
+
+            // RS-274X draw objects can only be created with a solid standard circle
+            // aperture. Non-zero-length draws with other apertures are non-image.
+            if !aperture.is_solid_circle {
+                return Ok(());
+            }
+
+            flash_aperture_no_sr(
+                aperture,
+                primitives,
+                start_x,
+                start_y,
+                state.layer_scale,
+                state.mirror_x,
+                state.mirror_y,
+                state.layer_rotation,
+            )?;
+
+            // Store line body separately from the two round cap flashes so
+            // the renderer can keep it instanced and clamp screen thickness.
+            let diameter = aperture.radius * 2.0 * state.layer_scale;
+            if let Some(line) = line_to_body(start_x, start_y, end_x, end_y, diameter, 1.0) {
+                try_reserve_primitives(primitives, 1, "linear interpolation")?;
+                primitives.push(line);
+            }
+
+            flash_aperture_no_sr(
+                aperture,
+                primitives,
+                end_x,
+                end_y,
+                state.layer_scale,
+                state.mirror_x,
+                state.mirror_y,
+                state.layer_rotation,
+            )?;
+        }
+        "clockwise" | "counterclockwise" => {
+            if points_coincide(start_x, start_y, end_x, end_y) && !arc_center_offset_present(i, j) {
+                flash_aperture_no_sr(
+                    aperture,
+                    primitives,
+                    start_x,
+                    start_y,
+                    state.layer_scale,
+                    state.mirror_x,
+                    state.mirror_y,
+                    state.layer_rotation,
+                )?;
+                return Ok(());
+            }
+
+            // RS-274X arc objects can only be created with a solid standard circle
+            // aperture. Non-zero-length arcs with other apertures are non-image.
+            if !aperture.is_solid_circle {
+                return Ok(());
+            }
+
+            if let Some((center_x, center_y, radius, start_angle, sweep_angle)) =
+                calculate_arc_parameters(state, start_x, start_y, end_x, end_y, i, j)
+            {
+                let thickness = aperture.radius * 2.0 * state.layer_scale;
+                let end_angle = start_angle + sweep_angle;
+
+                let cap_start_x = center_x + radius * start_angle.cos();
+                let cap_start_y = center_y + radius * start_angle.sin();
+                let cap_end_x = center_x + radius * end_angle.cos();
+                let cap_end_y = center_y + radius * end_angle.sin();
+
+                flash_aperture_no_sr(
+                    aperture,
+                    primitives,
+                    cap_start_x,
+                    cap_start_y,
+                    state.layer_scale,
+                    state.mirror_x,
+                    state.mirror_y,
+                    state.layer_rotation,
+                )?;
+
+                try_reserve_primitives(primitives, 1, "arc interpolation")?;
+                primitives.push(Primitive::Arc {
+                    x: center_x,
+                    y: center_y,
+                    radius,
+                    start_angle,
+                    end_angle: start_angle + sweep_angle,
+                    thickness,
+                    exposure: 1.0,
+                });
+
+                flash_aperture_no_sr(
+                    aperture,
+                    primitives,
+                    cap_end_x,
+                    cap_end_y,
+                    state.layer_scale,
+                    state.mirror_x,
+                    state.mirror_y,
+                    state.layer_rotation,
+                )?;
+            } else {
+                flash_aperture_no_sr(
+                    aperture,
+                    primitives,
+                    start_x,
+                    start_y,
+                    state.layer_scale,
+                    state.mirror_x,
+                    state.mirror_y,
+                    state.layer_rotation,
+                )?;
+                if !points_coincide(start_x, start_y, end_x, end_y) {
+                    flash_aperture_no_sr(
+                        aperture,
+                        primitives,
+                        end_x,
+                        end_y,
+                        state.layer_scale,
+                        state.mirror_x,
+                        state.mirror_y,
+                        state.layer_rotation,
+                    )?;
+                }
+            }
+        }
+        _ => {}
     }
 
     Ok(())
@@ -2241,6 +2240,8 @@ fn record_primitive_delta(
     primitives: &[Primitive],
     start_index: usize,
     layer_scale: f32,
+    mirror_x: bool,
+    mirror_y: bool,
     layer_rotation: f32,
     arc_command: Option<&str>,
 ) {
@@ -2256,6 +2257,8 @@ fn record_primitive_delta(
         let mut properties = InteractionFeature::gerber_properties_with_transform(
             aperture,
             layer_scale,
+            mirror_x,
+            mirror_y,
             layer_rotation,
         );
         properties.arc_command = arc_command.map(str::to_string);
@@ -2296,6 +2299,8 @@ fn record_flash_interactions(
     let properties = InteractionFeature::gerber_properties_with_transform(
         aperture,
         state.layer_scale,
+        state.mirror_x,
+        state.mirror_y,
         state.layer_rotation,
     );
     for sy in 0..state.sr_y {
@@ -2320,6 +2325,87 @@ fn record_flash_interactions(
                 aperture,
                 state.polarity,
                 &primitives,
+                properties.clone(),
+            ) {
+                interaction_layer.push(feature);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn record_interpolation_interactions(
+    interaction_layer: Option<&mut InteractionLayer>,
+    kind: FeatureKind,
+    aperture_code: &str,
+    aperture: Option<&Aperture>,
+    state: &ParserState,
+    primitives: &[Primitive],
+    start_index: usize,
+    end_x: f32,
+    end_y: f32,
+    i: f32,
+    j: f32,
+    arc_command: Option<&str>,
+) -> Result<(), String> {
+    if state.sr_x <= 1 && state.sr_y <= 1 {
+        record_primitive_delta(
+            interaction_layer,
+            kind,
+            aperture_code,
+            aperture,
+            state.polarity,
+            primitives,
+            start_index,
+            state.layer_scale,
+            state.mirror_x,
+            state.mirror_y,
+            state.layer_rotation,
+            arc_command,
+        );
+        return Ok(());
+    }
+
+    let Some(interaction_layer) = interaction_layer else {
+        return Ok(());
+    };
+    let Some(aperture) = aperture else {
+        return Ok(());
+    };
+
+    let mut properties = InteractionFeature::gerber_properties_with_transform(
+        aperture,
+        state.layer_scale,
+        state.mirror_x,
+        state.mirror_y,
+        state.layer_rotation,
+    );
+    properties.arc_command = arc_command.map(str::to_string);
+
+    for sy in 0..state.sr_y {
+        for sx in 0..state.sr_x {
+            let offset_x = sx as f32 * state.sr_i;
+            let offset_y = sy as f32 * state.sr_j;
+            let mut copy_primitives = Vec::new();
+            append_interpolation_no_sr(
+                state,
+                aperture,
+                &mut copy_primitives,
+                state.x + offset_x,
+                state.y + offset_y,
+                end_x + offset_x,
+                end_y + offset_y,
+                i,
+                j,
+            )?;
+
+            if let Some(feature) = feature_from_primitive_delta(
+                kind.clone(),
+                aperture_code,
+                aperture,
+                state.polarity,
+                &copy_primitives,
                 properties.clone(),
             ) {
                 interaction_layer.push(feature);
@@ -2508,6 +2594,8 @@ pub fn parse_graphic_command(
                             primitives,
                             primitive_start,
                             state.layer_scale,
+                            state.mirror_x,
+                            state.mirror_y,
                             state.layer_rotation,
                             None,
                         );
@@ -2621,18 +2709,20 @@ pub fn parse_graphic_command(
                         execute_interpolation(state, apertures, primitives, x, y, i, j)?;
                         let aperture = apertures.get(&state.current_aperture);
                         let (kind, arc_command) = interpolation_feature_kind(state, x, y, i, j);
-                        record_primitive_delta(
+                        record_interpolation_interactions(
                             interaction_layer.as_deref_mut(),
                             kind,
                             &state.current_aperture,
                             aperture,
-                            state.polarity,
+                            state,
                             primitives,
                             primitive_start,
-                            state.layer_scale,
-                            state.layer_rotation,
+                            x,
+                            y,
+                            i,
+                            j,
                             arc_command,
-                        );
+                        )?;
                     }
                 }
                 2 => {
@@ -2701,18 +2791,20 @@ pub fn parse_graphic_command(
             execute_interpolation(state, apertures, primitives, x, y, i, j)?;
             let aperture = apertures.get(&state.current_aperture);
             let (kind, arc_command) = interpolation_feature_kind(state, x, y, i, j);
-            record_primitive_delta(
+            record_interpolation_interactions(
                 interaction_layer,
                 kind,
                 &state.current_aperture,
                 aperture,
-                state.polarity,
+                state,
                 primitives,
                 primitive_start,
-                state.layer_scale,
-                state.layer_rotation,
+                x,
+                y,
+                i,
+                j,
                 arc_command,
-            );
+            )?;
         }
     } else {
         // No drawing operation

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1272,7 +1272,7 @@ fn record_block_flash_interaction(
                 if let Some(feature) = InteractionFeature::from_geometry(
                     FeatureKind::Flash,
                     aperture_name(aperture_code),
-                    aperture_type(aperture),
+                    Some(aperture_type(aperture)),
                     aperture.macro_name.clone(),
                     toggled_block_polarity(block_layer.polarity, state.polarity),
                     transformed,
@@ -2251,9 +2251,7 @@ fn record_primitive_delta(
         InteractionFeature::from_primitives(
             kind,
             aperture_name(aperture_code),
-            aperture
-                .map(aperture_type)
-                .unwrap_or_else(|| "region".to_string()),
+            aperture.map(aperture_type),
             None,
             polarity,
             delta.to_vec(),
@@ -2338,7 +2336,7 @@ pub fn parse_graphic_command(
                             if let Some(feature) = InteractionFeature::from_geometry(
                                 FeatureKind::Region,
                                 None,
-                                "region".to_string(),
+                                None,
                                 None,
                                 state.polarity,
                                 Vec::new(),

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1229,7 +1229,11 @@ fn record_block_flash_interaction(
         return Ok(());
     };
 
-    let properties = InteractionFeature::gerber_properties(aperture);
+    let properties = InteractionFeature::gerber_properties_with_transform(
+        aperture,
+        state.layer_scale,
+        state.layer_rotation,
+    );
     for sy in 0..state.sr_y {
         for sx in 0..state.sr_x {
             let flash_x = x + sx as f32 * state.sr_i;
@@ -2236,6 +2240,9 @@ fn record_primitive_delta(
     polarity: Polarity,
     primitives: &[Primitive],
     start_index: usize,
+    layer_scale: f32,
+    layer_rotation: f32,
+    arc_command: Option<&str>,
 ) {
     let Some(interaction_layer) = interaction_layer else {
         return;
@@ -2246,8 +2253,18 @@ fn record_primitive_delta(
 
     let delta = &primitives[start_index..];
     let feature = if let Some(aperture) = aperture {
-        feature_from_primitive_delta(kind, aperture_code, aperture, polarity, delta)
+        let mut properties = InteractionFeature::gerber_properties_with_transform(
+            aperture,
+            layer_scale,
+            layer_rotation,
+        );
+        properties.arc_command = arc_command.map(str::to_string);
+        feature_from_primitive_delta(kind, aperture_code, aperture, polarity, delta, properties)
     } else {
+        let properties = FeatureProperties {
+            arc_command: arc_command.map(str::to_string),
+            ..FeatureProperties::default()
+        };
         InteractionFeature::from_primitives(
             kind,
             aperture_name(aperture_code),
@@ -2255,12 +2272,20 @@ fn record_primitive_delta(
             None,
             polarity,
             delta.to_vec(),
-            FeatureProperties::default(),
+            properties,
         )
     };
 
     if let Some(feature) = feature {
         interaction_layer.push(feature);
+    }
+}
+
+fn arc_command_for_interpolation(interpolation_mode: &str) -> Option<&'static str> {
+    match interpolation_mode {
+        "clockwise" => Some("G02"),
+        "counterclockwise" => Some("G03"),
+        _ => None,
     }
 }
 
@@ -2408,6 +2433,9 @@ pub fn parse_graphic_command(
                             state.polarity,
                             primitives,
                             primitive_start,
+                            state.layer_scale,
+                            state.layer_rotation,
+                            None,
                         );
                     }
 
@@ -2533,6 +2561,9 @@ pub fn parse_graphic_command(
                             state.polarity,
                             primitives,
                             primitive_start,
+                            state.layer_scale,
+                            state.layer_rotation,
+                            arc_command_for_interpolation(&state.interpolation_mode),
                         );
                     }
                 }
@@ -2581,6 +2612,9 @@ pub fn parse_graphic_command(
                                 state.polarity,
                                 primitives,
                                 primitive_start,
+                                state.layer_scale,
+                                state.layer_rotation,
+                                None,
                             );
                         }
                     }
@@ -2618,6 +2652,9 @@ pub fn parse_graphic_command(
                 state.polarity,
                 primitives,
                 primitive_start,
+                state.layer_scale,
+                state.layer_rotation,
+                arc_command_for_interpolation(&state.interpolation_mode),
             );
         }
     } else {

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -1,3 +1,7 @@
+use crate::interaction::{
+    aperture_name, aperture_type, feature_from_primitive_delta, FeatureKind, FeatureProperties,
+    InteractionFeature, InteractionLayer,
+};
 use crate::parse_common::{parse_coordinate_number, parse_g_code, read_word_value};
 use crate::parser::{Aperture, FormatSpec, ParserState, Polarity, PolarityLayer};
 use crate::shape::PathRegions;
@@ -965,7 +969,11 @@ pub fn convert_coordinate(
     )
     .unwrap_or(0.0);
 
-    result.is_finite().then_some(result).unwrap_or(0.0)
+    if result.is_finite() {
+        result
+    } else {
+        0.0
+    }
 }
 
 /// Flash aperture at given position without Step and Repeat
@@ -1200,6 +1208,78 @@ fn flash_block_aperture(
                         primitives: transformed,
                         path_regions: transformed_path_regions,
                     });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn record_block_flash_interaction(
+    interaction_layer: Option<&mut InteractionLayer>,
+    block_layers: &[PolarityLayer],
+    aperture_code: &str,
+    aperture: &Aperture,
+    state: &ParserState,
+    x: f32,
+    y: f32,
+) -> Result<(), String> {
+    let Some(interaction_layer) = interaction_layer else {
+        return Ok(());
+    };
+
+    let properties = InteractionFeature::gerber_properties(aperture);
+    for sy in 0..state.sr_y {
+        for sx in 0..state.sr_x {
+            let flash_x = x + sx as f32 * state.sr_i;
+            let flash_y = y + sy as f32 * state.sr_j;
+
+            for block_layer in block_layers {
+                let mut transformed = Vec::new();
+                try_reserve_primitives(
+                    &mut transformed,
+                    block_layer.primitives.len(),
+                    "aperture block interaction",
+                )?;
+
+                for primitive in &block_layer.primitives {
+                    transformed.push(transform_primitive_for_flash(
+                        primitive,
+                        flash_x,
+                        flash_y,
+                        state.layer_scale,
+                        state.mirror_x,
+                        state.mirror_y,
+                        state.layer_rotation,
+                    ));
+                }
+
+                let mut transformed_path_regions = block_layer.path_regions.clone();
+                transformed_path_regions.transform_for_flash(
+                    state.layer_scale,
+                    state.mirror_x,
+                    state.mirror_y,
+                    state.layer_rotation,
+                    flash_x,
+                    flash_y,
+                );
+
+                if transformed.is_empty() && !transformed_path_regions.has_geometry() {
+                    continue;
+                }
+
+                if let Some(feature) = InteractionFeature::from_geometry(
+                    FeatureKind::Flash,
+                    aperture_name(aperture_code),
+                    aperture_type(aperture),
+                    aperture.macro_name.clone(),
+                    toggled_block_polarity(block_layer.polarity, state.polarity),
+                    transformed,
+                    transformed_path_regions,
+                    properties.clone(),
+                ) {
+                    interaction_layer.push(feature);
                 }
             }
         }
@@ -1667,6 +1747,8 @@ fn region_arc_tessellation_max_angle_step(quality: u32) -> f32 {
 pub fn build_path_regions(
     region_contours: &[RegionContour],
     state: &ParserState,
+    arc_tessellation_quality: u32,
+    collect_pick_contours: bool,
 ) -> Result<PathRegions, String> {
     let mut path_regions = PathRegions::empty();
 
@@ -1674,7 +1756,14 @@ pub fn build_path_regions(
         for sx in 0..state.sr_x {
             let offset_x = sx as f32 * state.sr_i;
             let offset_y = sy as f32 * state.sr_j;
-            append_path_region(&mut path_regions, region_contours, offset_x, offset_y)?;
+            append_path_region(
+                &mut path_regions,
+                region_contours,
+                offset_x,
+                offset_y,
+                arc_tessellation_quality,
+                collect_pick_contours,
+            )?;
         }
     }
 
@@ -1686,6 +1775,8 @@ fn append_path_region(
     region_contours: &[RegionContour],
     offset_x: f32,
     offset_y: f32,
+    arc_tessellation_quality: u32,
+    collect_pick_contours: bool,
 ) -> Result<(), String> {
     let Some((min_x, max_x, min_y, max_y)) =
         path_region_bounds(region_contours, offset_x, offset_y)
@@ -1712,6 +1803,15 @@ fn append_path_region(
         append_contour_segments(path_regions, contour, reference, offset_x, offset_y)?;
     }
 
+    if collect_pick_contours {
+        path_regions.pick_contours.push(path_region_pick_contours(
+            region_contours,
+            offset_x,
+            offset_y,
+            arc_tessellation_quality,
+        )?);
+    }
+
     path_regions
         .wedge_vertex_offsets
         .push((path_regions.wedge_vertices.len() / 2) as u32);
@@ -1720,6 +1820,49 @@ fn append_path_region(
         .push((path_regions.sector_vertices.len() / 7) as u32);
 
     Ok(())
+}
+
+fn path_region_pick_contours(
+    region_contours: &[RegionContour],
+    offset_x: f32,
+    offset_y: f32,
+    arc_tessellation_quality: u32,
+) -> Result<Vec<Vec<[f32; 2]>>, String> {
+    let flattened_contours;
+    let contour_iter: Box<dyn Iterator<Item = &[[f32; 2]]> + '_> =
+        if region_contours_have_arcs(region_contours) {
+            flattened_contours =
+                flatten_region_contours(region_contours, arc_tessellation_quality)?;
+            Box::new(flattened_contours.iter().map(Vec::as_slice))
+        } else {
+            Box::new(region_contours_to_point_slices(region_contours))
+        };
+
+    let mut contours = Vec::new();
+    try_reserve_values(
+        &mut contours,
+        region_contours.len(),
+        "path region pick contours",
+    )?;
+    for contour in contour_iter {
+        if contour.len() < 3 {
+            continue;
+        }
+        let mut transformed = Vec::new();
+        try_reserve_values(
+            &mut transformed,
+            contour.len(),
+            "path region pick contour points",
+        )?;
+        transformed.extend(
+            contour
+                .iter()
+                .map(|point| [point[0] + offset_x, point[1] + offset_y]),
+        );
+        contours.push(transformed);
+    }
+
+    Ok(contours)
 }
 
 fn append_contour_segments(
@@ -2085,6 +2228,44 @@ fn append_region_segment(
     Ok(())
 }
 
+fn record_primitive_delta(
+    interaction_layer: Option<&mut InteractionLayer>,
+    kind: FeatureKind,
+    aperture_code: &str,
+    aperture: Option<&Aperture>,
+    polarity: Polarity,
+    primitives: &[Primitive],
+    start_index: usize,
+) {
+    let Some(interaction_layer) = interaction_layer else {
+        return;
+    };
+    if start_index >= primitives.len() {
+        return;
+    }
+
+    let delta = &primitives[start_index..];
+    let feature = if let Some(aperture) = aperture {
+        feature_from_primitive_delta(kind, aperture_code, aperture, polarity, delta)
+    } else {
+        InteractionFeature::from_primitives(
+            kind,
+            aperture_name(aperture_code),
+            aperture
+                .map(aperture_type)
+                .unwrap_or_else(|| "region".to_string()),
+            None,
+            polarity,
+            delta.to_vec(),
+            FeatureProperties::default(),
+        )
+    };
+
+    if let Some(feature) = feature {
+        interaction_layer.push(feature);
+    }
+}
+
 /// Parse graphic commands - process G/D/XY codes
 /// Example: G01X1000Y2000D01* (draw line), X1000Y2000D03* (flash), etc.
 pub fn parse_graphic_command(
@@ -2095,8 +2276,10 @@ pub fn parse_graphic_command(
     region_contours: &mut Vec<RegionContour>,
     path_regions: &mut PathRegions,
     polarity_layers: &mut Vec<PolarityLayer>,
+    mut interaction_layer: Option<&mut InteractionLayer>,
     preserve_arc_regions: bool,
     arc_tessellation_quality: u32,
+    collect_interactions: bool,
 ) -> Result<(), String> {
     let clean_line = line.trim_end_matches('*');
 
@@ -2144,9 +2327,30 @@ pub fn parse_graphic_command(
 
                     if preserve_arc_regions && region_contours_have_arcs(region_contours) {
                         flush_primitives_to_layer(primitives, state.polarity, polarity_layers)?;
-                        path_regions.append(build_path_regions(region_contours, state)?);
+                        let region_path_regions = build_path_regions(
+                            region_contours,
+                            state,
+                            arc_tessellation_quality,
+                            collect_interactions,
+                        )?;
+                        path_regions.append(region_path_regions.clone());
+                        if let Some(interaction_layer) = interaction_layer.as_deref_mut() {
+                            if let Some(feature) = InteractionFeature::from_geometry(
+                                FeatureKind::Region,
+                                None,
+                                "region".to_string(),
+                                None,
+                                state.polarity,
+                                Vec::new(),
+                                region_path_regions,
+                                FeatureProperties::default(),
+                            ) {
+                                interaction_layer.push(feature);
+                            }
+                        }
                     } else {
                         flush_path_regions_to_layer(path_regions, state.polarity, polarity_layers)?;
+                        let primitive_start = primitives.len();
                         // Triangulate region and add to primitives with Step and Repeat
                         // Regions are always positive (add material)
                         let flattened_contours;
@@ -2198,6 +2402,15 @@ pub fn parse_graphic_command(
                                 }
                             }
                         }
+                        record_primitive_delta(
+                            interaction_layer.as_deref_mut(),
+                            FeatureKind::Region,
+                            "",
+                            None,
+                            state.polarity,
+                            primitives,
+                            primitive_start,
+                        );
                     }
 
                     region_contours.clear();
@@ -2304,7 +2517,25 @@ pub fn parse_graphic_command(
                         }
                     } else {
                         flush_path_regions_to_layer(path_regions, state.polarity, polarity_layers)?;
+                        let primitive_start = primitives.len();
                         execute_interpolation(state, apertures, primitives, x, y, i, j)?;
+                        let aperture = apertures.get(&state.current_aperture);
+                        let kind = if state.interpolation_mode == "clockwise"
+                            || state.interpolation_mode == "counterclockwise"
+                        {
+                            FeatureKind::ArcDraw
+                        } else {
+                            FeatureKind::Draw
+                        };
+                        record_primitive_delta(
+                            interaction_layer.as_deref_mut(),
+                            kind,
+                            &state.current_aperture,
+                            aperture,
+                            state.polarity,
+                            primitives,
+                            primitive_start,
+                        );
                     }
                 }
                 2 => {
@@ -2329,7 +2560,32 @@ pub fn parse_graphic_command(
                 3 if !state.region_mode => {
                     // D03: Flash aperture at current position
                     flush_path_regions_to_layer(path_regions, state.polarity, polarity_layers)?;
+                    let primitive_start = primitives.len();
                     flash_aperture(state, apertures, primitives, polarity_layers, x, y)?;
+                    let aperture = apertures.get(&state.current_aperture);
+                    if let Some(aperture) = aperture {
+                        if let Some(block_layers) = aperture.block_layers.as_ref() {
+                            record_block_flash_interaction(
+                                interaction_layer.as_deref_mut(),
+                                block_layers,
+                                &state.current_aperture,
+                                aperture,
+                                state,
+                                x,
+                                y,
+                            )?;
+                        } else {
+                            record_primitive_delta(
+                                interaction_layer.as_deref_mut(),
+                                FeatureKind::Flash,
+                                &state.current_aperture,
+                                Some(aperture),
+                                state.polarity,
+                                primitives,
+                                primitive_start,
+                            );
+                        }
+                    }
                 }
                 _ if d_code >= 10 => {
                     // D10+: Aperture selection
@@ -2346,7 +2602,25 @@ pub fn parse_graphic_command(
             }
         } else {
             flush_path_regions_to_layer(path_regions, state.polarity, polarity_layers)?;
+            let primitive_start = primitives.len();
             execute_interpolation(state, apertures, primitives, x, y, i, j)?;
+            let aperture = apertures.get(&state.current_aperture);
+            let kind = if state.interpolation_mode == "clockwise"
+                || state.interpolation_mode == "counterclockwise"
+            {
+                FeatureKind::ArcDraw
+            } else {
+                FeatureKind::Draw
+            };
+            record_primitive_delta(
+                interaction_layer,
+                kind,
+                &state.current_aperture,
+                aperture,
+                state.polarity,
+                primitives,
+                primitive_start,
+            );
         }
     } else {
         // No drawing operation

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -2281,6 +2281,80 @@ fn record_primitive_delta(
     }
 }
 
+fn record_flash_interactions(
+    interaction_layer: Option<&mut InteractionLayer>,
+    aperture_code: &str,
+    aperture: &Aperture,
+    state: &ParserState,
+    x: f32,
+    y: f32,
+) -> Result<(), String> {
+    let Some(interaction_layer) = interaction_layer else {
+        return Ok(());
+    };
+
+    let properties = InteractionFeature::gerber_properties_with_transform(
+        aperture,
+        state.layer_scale,
+        state.layer_rotation,
+    );
+    for sy in 0..state.sr_y {
+        for sx in 0..state.sr_x {
+            let flash_x = x + sx as f32 * state.sr_i;
+            let flash_y = y + sy as f32 * state.sr_j;
+            let mut primitives = Vec::new();
+            flash_aperture_no_sr(
+                aperture,
+                &mut primitives,
+                flash_x,
+                flash_y,
+                state.layer_scale,
+                state.mirror_x,
+                state.mirror_y,
+                state.layer_rotation,
+            )?;
+
+            if let Some(feature) = feature_from_primitive_delta(
+                FeatureKind::Flash,
+                aperture_code,
+                aperture,
+                state.polarity,
+                &primitives,
+                properties.clone(),
+            ) {
+                interaction_layer.push(feature);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn interpolation_feature_kind(
+    state: &ParserState,
+    end_x: f32,
+    end_y: f32,
+    i: f32,
+    j: f32,
+) -> (FeatureKind, Option<&'static str>) {
+    let is_arc =
+        state.interpolation_mode == "clockwise" || state.interpolation_mode == "counterclockwise";
+    if points_coincide(state.x, state.y, end_x, end_y)
+        && (!is_arc || !arc_center_offset_present(i, j))
+    {
+        return (FeatureKind::Flash, None);
+    }
+
+    if is_arc {
+        (
+            FeatureKind::ArcDraw,
+            arc_command_for_interpolation(&state.interpolation_mode),
+        )
+    } else {
+        (FeatureKind::Draw, None)
+    }
+}
+
 fn arc_command_for_interpolation(interpolation_mode: &str) -> Option<&'static str> {
     match interpolation_mode {
         "clockwise" => Some("G02"),
@@ -2546,13 +2620,7 @@ pub fn parse_graphic_command(
                         let primitive_start = primitives.len();
                         execute_interpolation(state, apertures, primitives, x, y, i, j)?;
                         let aperture = apertures.get(&state.current_aperture);
-                        let kind = if state.interpolation_mode == "clockwise"
-                            || state.interpolation_mode == "counterclockwise"
-                        {
-                            FeatureKind::ArcDraw
-                        } else {
-                            FeatureKind::Draw
-                        };
+                        let (kind, arc_command) = interpolation_feature_kind(state, x, y, i, j);
                         record_primitive_delta(
                             interaction_layer.as_deref_mut(),
                             kind,
@@ -2563,7 +2631,7 @@ pub fn parse_graphic_command(
                             primitive_start,
                             state.layer_scale,
                             state.layer_rotation,
-                            arc_command_for_interpolation(&state.interpolation_mode),
+                            arc_command,
                         );
                     }
                 }
@@ -2589,7 +2657,6 @@ pub fn parse_graphic_command(
                 3 if !state.region_mode => {
                     // D03: Flash aperture at current position
                     flush_path_regions_to_layer(path_regions, state.polarity, polarity_layers)?;
-                    let primitive_start = primitives.len();
                     flash_aperture(state, apertures, primitives, polarity_layers, x, y)?;
                     let aperture = apertures.get(&state.current_aperture);
                     if let Some(aperture) = aperture {
@@ -2604,18 +2671,14 @@ pub fn parse_graphic_command(
                                 y,
                             )?;
                         } else {
-                            record_primitive_delta(
+                            record_flash_interactions(
                                 interaction_layer.as_deref_mut(),
-                                FeatureKind::Flash,
                                 &state.current_aperture,
-                                Some(aperture),
-                                state.polarity,
-                                primitives,
-                                primitive_start,
-                                state.layer_scale,
-                                state.layer_rotation,
-                                None,
-                            );
+                                aperture,
+                                state,
+                                x,
+                                y,
+                            )?;
                         }
                     }
                 }
@@ -2637,13 +2700,7 @@ pub fn parse_graphic_command(
             let primitive_start = primitives.len();
             execute_interpolation(state, apertures, primitives, x, y, i, j)?;
             let aperture = apertures.get(&state.current_aperture);
-            let kind = if state.interpolation_mode == "clockwise"
-                || state.interpolation_mode == "counterclockwise"
-            {
-                FeatureKind::ArcDraw
-            } else {
-                FeatureKind::Draw
-            };
+            let (kind, arc_command) = interpolation_feature_kind(state, x, y, i, j);
             record_primitive_delta(
                 interaction_layer,
                 kind,
@@ -2654,7 +2711,7 @@ pub fn parse_graphic_command(
                 primitive_start,
                 state.layer_scale,
                 state.layer_rotation,
-                arc_command_for_interpolation(&state.interpolation_mode),
+                arc_command,
             );
         }
     } else {

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1,5 +1,6 @@
 use super::aperture_macro::{evaluate_expression, parse_macro};
 use super::{format_count, parse_gerber, parse_gerber_with_options, GerberParser};
+use crate::interaction::FeatureKind;
 use crate::shape::GerberData;
 use std::collections::HashMap;
 
@@ -553,6 +554,56 @@ M02*",
             .as_deref(),
         Some("G03")
     );
+}
+
+#[test]
+fn zero_length_d01_interaction_reports_flash() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10R,1.0X0.5*%
+D10*
+X000000Y000000D02*
+X000000Y000000D01*
+M02*",
+        )
+        .expect("zero-length D01 interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    assert_eq!(interaction_layer.features.len(), 1);
+    assert_eq!(interaction_layer.features[0].kind, FeatureKind::Flash);
+}
+
+#[test]
+fn step_repeat_d03_interactions_are_split_per_copy() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10C,0.5*%
+%SRX2Y1I2.0J0.0*%
+D10*
+X000000Y000000D03*
+%SR*%
+M02*",
+        )
+        .expect("step-repeat flash interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    assert_eq!(interaction_layer.features.len(), 2);
+    let first = &interaction_layer.features[0].bounds;
+    let second = &interaction_layer.features[1].bounds;
+    assert_approx_eq((first.min_x() + first.max_x()) * 0.5, 0.0);
+    assert_approx_eq((second.min_x() + second.max_x()) * 0.5, 2.0);
 }
 
 #[test]

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -607,6 +607,36 @@ M02*",
 }
 
 #[test]
+fn step_repeat_d01_interactions_are_split_per_copy() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10C,0.5*%
+%SRX2Y1I2.0J0.0*%
+D10*
+X000000Y000000D02*
+X010000Y000000D01*
+%SR*%
+M02*",
+        )
+        .expect("step-repeat draw interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    assert_eq!(interaction_layer.features.len(), 2);
+    assert_eq!(interaction_layer.features[0].kind, FeatureKind::Draw);
+    assert_eq!(interaction_layer.features[1].kind, FeatureKind::Draw);
+    let first = &interaction_layer.features[0].bounds;
+    let second = &interaction_layer.features[1].bounds;
+    assert_approx_eq((first.min_x() + first.max_x()) * 0.5, 0.5);
+    assert_approx_eq((second.min_x() + second.max_x()) * 0.5, 2.5);
+}
+
+#[test]
 fn interaction_aperture_properties_use_effective_scale_and_rotation() {
     let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
     let payload = parser
@@ -634,6 +664,33 @@ M02*",
         properties.rotation.expect("rotation should be reported"),
         std::f32::consts::FRAC_PI_2,
     );
+}
+
+#[test]
+fn interaction_aperture_rotation_reflects_mirroring_before_layer_rotation() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10P,1.0X5X45*%
+%LMX*%
+%LR90*%
+D10*
+X000000Y000000D03*
+M02*",
+        )
+        .expect("mirrored rotated polygon interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    let rotation = interaction_layer.features[0]
+        .properties
+        .rotation
+        .expect("polygon rotation should be reported");
+    assert_approx_eq(rotation, -std::f32::consts::FRAC_PI_4 * 3.0);
 }
 
 #[test]

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -516,6 +516,122 @@ M02*",
 }
 
 #[test]
+fn arc_draw_interactions_report_g02_and_g03_commands() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10C,1.0*%
+D10*
+G75*
+X010000Y000000D02*
+G02*
+X-010000Y000000I-010000J000000D01*
+G03*
+X010000Y000000I010000J000000D01*
+M02*",
+        )
+        .expect("arc draw interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    assert_eq!(interaction_layer.features.len(), 2);
+    assert_eq!(
+        interaction_layer.features[0]
+            .properties
+            .arc_command
+            .as_deref(),
+        Some("G02")
+    );
+    assert_eq!(
+        interaction_layer.features[1]
+            .properties
+            .arc_command
+            .as_deref(),
+        Some("G03")
+    );
+}
+
+#[test]
+fn interaction_aperture_properties_use_effective_scale_and_rotation() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD24R,1.0X0.5*%
+%LS2.0*%
+%LR90*%
+D24*
+X000000Y000000D03*
+M02*",
+        )
+        .expect("scaled rotated aperture interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    let properties = &interaction_layer.features[0].properties;
+    assert_eq!(properties.diameter, None);
+    assert_approx_eq(properties.width.expect("width should be reported"), 2.0);
+    assert_approx_eq(properties.height.expect("height should be reported"), 1.0);
+    assert_approx_eq(
+        properties.rotation.expect("rotation should be reported"),
+        std::f32::consts::FRAC_PI_2,
+    );
+}
+
+#[test]
+fn non_circle_apertures_do_not_report_diameter_properties() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let polygon_payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10P,1.0X5X45*%
+D10*
+X000000Y000000D03*
+M02*",
+        )
+        .expect("polygon aperture interaction payload should parse");
+    let polygon_layer = polygon_payload
+        .interaction_layer
+        .expect("polygon interaction layer should be collected");
+    let polygon_properties = &polygon_layer.features[0].properties;
+    assert_eq!(polygon_properties.diameter, None);
+    assert_eq!(polygon_properties.vertices, Some(5));
+    assert_approx_eq(
+        polygon_properties
+            .rotation
+            .expect("polygon rotation should be reported"),
+        std::f32::consts::FRAC_PI_4,
+    );
+
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let macro_payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%AMROUND*1,1,1.0,0,0,0*%
+%ADD10ROUND*%
+D10*
+X000000Y000000D03*
+M02*",
+        )
+        .expect("macro aperture interaction payload should parse");
+    let macro_layer = macro_payload
+        .interaction_layer
+        .expect("macro interaction layer should be collected");
+    assert_eq!(macro_layer.features[0].properties.diameter, None);
+}
+
+#[test]
 fn region_arc_can_be_flattened_for_legacy_triangles() {
     let layers = parse_gerber_with_options(
         "\

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1,5 +1,5 @@
 use super::aperture_macro::{evaluate_expression, parse_macro};
-use super::{format_count, parse_gerber, parse_gerber_with_options};
+use super::{format_count, parse_gerber, parse_gerber_with_options, GerberParser};
 use crate::shape::GerberData;
 use std::collections::HashMap;
 
@@ -480,10 +480,39 @@ M02*",
     assert_eq!(layer.path_regions.sector_vertex_offsets, vec![0, 6]);
     assert_eq!(layer.path_regions.cover_vertices.len(), 12);
     assert_eq!(layer.path_regions.clear_vertices.len(), 12);
+    assert!(layer.path_regions.pick_contours.is_empty());
     assert_approx_eq(layer.boundary.min_x, -1.0);
     assert_approx_eq(layer.boundary.max_x, 1.0);
     assert_approx_eq(layer.boundary.min_y, 0.0);
     assert_approx_eq(layer.boundary.max_y, 1.0);
+}
+
+#[test]
+fn preserved_region_arc_interaction_uses_path_regions() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+G75*
+G36*
+X010000Y000000D02*
+G03*
+X-010000Y000000I-010000J000000D01*
+G37*
+M02*",
+        )
+        .expect("region arc interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    assert_eq!(interaction_layer.features.len(), 1);
+    let feature = &interaction_layer.features[0];
+    assert!(feature.primitives.is_empty());
+    assert_eq!(feature.path_regions.region_count(), 1);
+    assert_eq!(feature.path_regions.pick_contours.len(), 1);
 }
 
 #[test]
@@ -555,6 +584,39 @@ M02*",
     assert_eq!(layers.len(), 1);
     assert!(layers[0].triangles.vertices.is_empty());
     assert_eq!(layers[0].path_regions.region_count(), 1);
+    assert!(layers[0].path_regions.pick_contours.is_empty());
+}
+
+#[test]
+fn aperture_block_path_region_flash_is_interactive() {
+    let mut parser = GerberParser::with_options_and_interactions(true, 1, true);
+    let payload = parser
+        .parse_payload(
+            "\
+%FSLAX24Y24*%
+%MOMM*%
+%ABD10*%
+G75*
+G36*
+X010000Y000000D02*
+G03*
+X-010000Y000000I-010000J000000D01*
+G37*
+%AB*%
+D10*
+X000000Y000000D03*
+M02*",
+        )
+        .expect("aperture block arc region interaction payload should parse");
+
+    let interaction_layer = payload
+        .interaction_layer
+        .expect("interaction layer should be collected");
+    assert_eq!(interaction_layer.features.len(), 1);
+    let feature = &interaction_layer.features[0];
+    assert!(feature.primitives.is_empty());
+    assert_eq!(feature.path_regions.region_count(), 1);
+    assert_eq!(feature.path_regions.pick_contours.len(), 1);
 }
 
 #[test]

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -6,18 +6,22 @@ mod shader;
 use buffer::{BufferCache, Fbo, TriangleTemplateBufferCache};
 use camera::Camera;
 use shader::{
-    ShaderProgram, ShaderPrograms, ALWAYS, ARRAY_BUFFER, BLEND, COLOR_BUFFER_BIT, FLOAT, FUNC_ADD,
-    INVERT, KEEP, NOTEQUAL, ONE, ONE_MINUS_SRC_ALPHA, STATIC_DRAW, STENCIL_BUFFER_BIT,
-    STENCIL_TEST, TRIANGLES, ZERO,
+    compile_program, ShaderProgram, ShaderPrograms, ALWAYS, ARRAY_BUFFER, BLEND, COLOR_BUFFER_BIT,
+    EQUAL, FLOAT, FUNC_ADD, HIGHLIGHT_FRAGMENT_SHADER, HIGHLIGHT_STENCIL_FRAGMENT_SHADER,
+    HIGHLIGHT_VERTEX_SHADER, INVERT, KEEP, NOTEQUAL, ONE, ONE_MINUS_SRC_ALPHA, REPLACE, SRC_ALPHA,
+    STATIC_DRAW, STENCIL_BUFFER_BIT, STENCIL_TEST, STREAM_DRAW, TRIANGLES, ZERO,
 };
 
+use crate::interaction::InteractionFeature;
 use crate::shape::{
     Arcs, Boundary, Circles, GerberData, Lines, PathRegions, Thermals, TriangleTemplateInstances,
     Triangles,
 };
 use js_sys::{Array, Float32Array, Reflect, Uint32Array};
 use wasm_bindgen::{prelude::*, JsCast};
-use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlTexture};
+use web_sys::{
+    WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlTexture, WebGlVertexArrayObject,
+};
 
 /// Metadata for a single user layer (may contain multiple polarity sublayers)
 pub struct LayerMetadata {
@@ -43,6 +47,10 @@ pub struct Renderer {
     camera: Camera,
     quad_buffer: WebGlBuffer, // Shared quad buffer for all layers
     minimum_feature_pixels: f32,
+    highlight_program: Option<ShaderProgram>,
+    highlight_stencil_program: Option<ShaderProgram>,
+    highlight_buffer: Option<WebGlBuffer>,
+    highlight_vertex_array: Option<WebGlVertexArrayObject>,
 }
 
 struct BufferCacheBuildGuard {
@@ -112,6 +120,10 @@ impl Renderer {
             camera: Camera::new(),
             quad_buffer,
             minimum_feature_pixels: 0.0,
+            highlight_program: None,
+            highlight_stencil_program: None,
+            highlight_buffer: None,
+            highlight_vertex_array: None,
         })
     }
 
@@ -2190,6 +2202,17 @@ impl Renderer {
         gl.buffer_sub_data_with_i32_and_array_buffer_view(ARRAY_BUFFER, 0, data);
     }
 
+    fn upload_f32_slice_to_bound_buffer_with_usage(
+        gl: &WebGl2RenderingContext,
+        data: &[f32],
+        usage: u32,
+    ) {
+        unsafe {
+            let array = Float32Array::view(data);
+            gl.buffer_data_with_array_buffer_view(ARRAY_BUFFER, &array, usage);
+        }
+    }
+
     fn upload_f32_slice_to_bound_buffer(gl: &WebGl2RenderingContext, data: &[f32]) {
         // Avoid JS memory copy.
         unsafe {
@@ -2354,6 +2377,372 @@ impl Renderer {
         self.gl.draw_arrays(TRIANGLES, 0, 6);
 
         Ok(())
+    }
+
+    fn ensure_highlight_resources(&mut self) -> Result<(), JsValue> {
+        if self.highlight_program.is_some()
+            && self.highlight_stencil_program.is_some()
+            && self.highlight_buffer.is_some()
+            && self.highlight_vertex_array.is_some()
+        {
+            return Ok(());
+        }
+
+        self.delete_highlight_resources();
+
+        let highlight_program = compile_program(
+            &self.gl,
+            HIGHLIGHT_VERTEX_SHADER,
+            HIGHLIGHT_FRAGMENT_SHADER,
+            &["position"],
+            &["transform"],
+        )?;
+        let stencil_program = match compile_program(
+            &self.gl,
+            HIGHLIGHT_VERTEX_SHADER,
+            HIGHLIGHT_STENCIL_FRAGMENT_SHADER,
+            &["position"],
+            &["transform"],
+        ) {
+            Ok(program) => program,
+            Err(error) => {
+                self.gl.delete_program(Some(&highlight_program.program));
+                return Err(error);
+            }
+        };
+        let buffer = match self.gl.create_buffer() {
+            Some(buffer) => buffer,
+            None => {
+                self.gl.delete_program(Some(&highlight_program.program));
+                self.gl.delete_program(Some(&stencil_program.program));
+                return Err(JsValue::from_str("Failed to create highlight buffer"));
+            }
+        };
+        let vertex_array = match self.gl.create_vertex_array() {
+            Some(vertex_array) => vertex_array,
+            None => {
+                self.gl.delete_buffer(Some(&buffer));
+                self.gl.delete_program(Some(&highlight_program.program));
+                self.gl.delete_program(Some(&stencil_program.program));
+                return Err(JsValue::from_str("Failed to create highlight VAO"));
+            }
+        };
+
+        self.highlight_program = Some(highlight_program);
+        self.highlight_stencil_program = Some(stencil_program);
+        self.highlight_buffer = Some(buffer);
+        self.highlight_vertex_array = Some(vertex_array);
+        Ok(())
+    }
+
+    fn delete_highlight_resources(&mut self) {
+        Self::delete_highlight_resources_from(
+            &self.gl,
+            &mut self.highlight_program,
+            &mut self.highlight_stencil_program,
+            &mut self.highlight_buffer,
+            &mut self.highlight_vertex_array,
+        );
+    }
+
+    fn delete_highlight_resources_from(
+        gl: &WebGl2RenderingContext,
+        highlight_program: &mut Option<ShaderProgram>,
+        highlight_stencil_program: &mut Option<ShaderProgram>,
+        highlight_buffer: &mut Option<WebGlBuffer>,
+        highlight_vertex_array: &mut Option<WebGlVertexArrayObject>,
+    ) {
+        if let Some(program) = highlight_program.take() {
+            gl.delete_program(Some(&program.program));
+        }
+        if let Some(program) = highlight_stencil_program.take() {
+            gl.delete_program(Some(&program.program));
+        }
+        if let Some(buffer) = highlight_buffer.take() {
+            gl.delete_buffer(Some(&buffer));
+        }
+        if let Some(vertex_array) = highlight_vertex_array.take() {
+            gl.delete_vertex_array(Some(&vertex_array));
+        }
+    }
+
+    fn draw_highlight_vertices(
+        &self,
+        program: &ShaderProgram,
+        vertices: &[f32],
+        transform: &[f32; 9],
+    ) -> Result<(), JsValue> {
+        if vertices.len() < 6 {
+            return Ok(());
+        }
+        if !vertices.len().is_multiple_of(2) {
+            return Err(JsValue::from_str(
+                "Highlight vertex buffer has an odd coordinate count",
+            ));
+        }
+        let vertex_count = vertices.len() / 2;
+        if !vertex_count.is_multiple_of(3) {
+            return Err(JsValue::from_str(
+                "Highlight vertex count is not divisible by 3",
+            ));
+        }
+        let vertex_count = Self::checked_usize_to_i32("highlight vertex count", vertex_count)?;
+
+        self.gl.use_program(Some(&program.program));
+        self.gl.uniform_matrix3fv_with_f32_array(
+            program.uniforms.get("transform"),
+            false,
+            transform,
+        );
+        self.gl
+            .bind_vertex_array(self.highlight_vertex_array.as_ref());
+        self.gl
+            .bind_buffer(ARRAY_BUFFER, self.highlight_buffer.as_ref());
+        Self::upload_f32_slice_to_bound_buffer_with_usage(&self.gl, vertices, STREAM_DRAW);
+        let position = Self::shader_attribute(program, "position")?;
+        self.gl.enable_vertex_attrib_array(position);
+        self.gl
+            .vertex_attrib_pointer_with_i32(position, 2, FLOAT, false, 0, 0);
+        self.gl.vertex_attrib_divisor(position, 0);
+        self.gl.draw_arrays(TRIANGLES, 0, vertex_count);
+        Ok(())
+    }
+
+    fn draw_highlight_path_regions(
+        &self,
+        path_regions: &PathRegions,
+        transform: &[f32; 9],
+        highlight_program: &ShaderProgram,
+        stencil_program: &ShaderProgram,
+    ) -> Result<(), JsValue> {
+        let region_count = path_regions.region_count();
+        if region_count == 0 {
+            return Ok(());
+        }
+
+        Self::validate_path_region_data(path_regions, 0)?;
+        let mut guard = BufferCacheBuildGuard::new(&self.gl);
+        Self::create_path_region_gpu_cache(
+            &self.gl,
+            &self.programs,
+            &mut guard.cache,
+            path_regions,
+        )?;
+        let buffer_cache = guard.commit();
+        let solid_color = [1.0, 1.0, 1.0, 1.0];
+
+        let result = (|| -> Result<(), JsValue> {
+            for region_idx in 0..region_count {
+                self.gl.color_mask(false, false, false, false);
+                self.gl.stencil_func(ALWAYS, 0, 0xff);
+                self.gl.stencil_op(KEEP, KEEP, INVERT);
+
+                let wedge_start = Self::checked_u32_to_i32(
+                    "highlight path wedge vertex start",
+                    path_regions.wedge_vertex_offsets[region_idx],
+                )?;
+                let wedge_end = Self::checked_u32_to_i32(
+                    "highlight path wedge vertex end",
+                    path_regions.wedge_vertex_offsets[region_idx + 1],
+                )?;
+                if wedge_end > wedge_start {
+                    self.draw_path_solid_range(
+                        transform,
+                        &solid_color,
+                        buffer_cache.path_wedge_vao.as_ref(),
+                        wedge_start,
+                        wedge_end - wedge_start,
+                    )?;
+                }
+
+                let sector_start = Self::checked_u32_to_i32(
+                    "highlight path sector vertex start",
+                    path_regions.sector_vertex_offsets[region_idx],
+                )?;
+                let sector_end = Self::checked_u32_to_i32(
+                    "highlight path sector vertex end",
+                    path_regions.sector_vertex_offsets[region_idx + 1],
+                )?;
+                if sector_end > sector_start {
+                    self.draw_path_sector_range(
+                        transform,
+                        &buffer_cache,
+                        sector_start,
+                        sector_end - sector_start,
+                    )?;
+                }
+
+                self.gl.color_mask(true, true, true, true);
+                self.gl.stencil_func(NOTEQUAL, 0, 0xff);
+                self.gl.stencil_op(KEEP, KEEP, KEEP);
+                let clear_start = region_idx.checked_mul(12).ok_or_else(|| {
+                    JsValue::from_str("highlight path clear vertex start overflows")
+                })?;
+                let clear_end = clear_start + 12;
+                self.draw_highlight_vertices(
+                    highlight_program,
+                    &path_regions.clear_vertices[clear_start..clear_end],
+                    transform,
+                )?;
+
+                self.gl.color_mask(false, false, false, false);
+                self.gl.stencil_func(ALWAYS, 0, 0xff);
+                self.gl.stencil_op(ZERO, ZERO, ZERO);
+                let cover_start = region_idx.checked_mul(12).ok_or_else(|| {
+                    JsValue::from_str("highlight path cover vertex start overflows")
+                })?;
+                let cover_end = cover_start + 12;
+                self.draw_highlight_vertices(
+                    stencil_program,
+                    &path_regions.cover_vertices[cover_start..cover_end],
+                    transform,
+                )?;
+            }
+
+            Ok(())
+        })();
+
+        Self::delete_buffer_cache(&self.gl, buffer_cache);
+        result
+    }
+
+    fn bounds_rect_triangles(bounds: &Boundary) -> [f32; 12] {
+        [
+            bounds.min_x(),
+            bounds.min_y(),
+            bounds.max_x(),
+            bounds.min_y(),
+            bounds.min_x(),
+            bounds.max_y(),
+            bounds.min_x(),
+            bounds.max_y(),
+            bounds.max_x(),
+            bounds.min_y(),
+            bounds.max_x(),
+            bounds.max_y(),
+        ]
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_interaction_highlight(
+        &mut self,
+        feature: &InteractionFeature,
+        zoom_x: f32,
+        zoom_y: f32,
+        offset_x: f32,
+        offset_y: f32,
+    ) -> Result<(), JsValue> {
+        Self::validate_finite_value("highlight zoom_x", zoom_x)?;
+        Self::validate_finite_value("highlight zoom_y", zoom_y)?;
+        Self::validate_finite_value("highlight offset_x", offset_x)?;
+        Self::validate_finite_value("highlight offset_y", offset_y)?;
+        Self::validate_finite_value("highlight bounds.min_x", feature.bounds.min_x())?;
+        Self::validate_finite_value("highlight bounds.max_x", feature.bounds.max_x())?;
+        Self::validate_finite_value("highlight bounds.min_y", feature.bounds.min_y())?;
+        Self::validate_finite_value("highlight bounds.max_y", feature.bounds.max_y())?;
+
+        let batches = feature.highlight_batches();
+        let has_primitive_batches = batches.iter().any(|batch| batch.vertices.len() >= 6);
+        let has_path_regions = feature.path_regions.has_geometry();
+        if !has_primitive_batches && !has_path_regions {
+            return Ok(());
+        }
+
+        self.update_camera(zoom_x, zoom_y, offset_x, offset_y);
+        let (width, height) = self.get_canvas_size()?;
+        if width == 0 || height == 0 {
+            return Err(JsValue::from_str(
+                "Cannot render highlight to a zero-sized canvas",
+            ));
+        }
+        let width_i32 = Self::checked_u32_to_i32("canvas width", width)?;
+        let height_i32 = Self::checked_u32_to_i32("canvas height", height)?;
+        let transform = self.camera.get_transform_matrix(width, height);
+        let bounds_vertices = Self::bounds_rect_triangles(&feature.bounds);
+        self.ensure_highlight_resources()?;
+
+        let stencil_bits = self
+            .gl
+            .get_parameter(WebGl2RenderingContext::STENCIL_BITS)?
+            .as_f64()
+            .unwrap_or(0.0) as i32;
+
+        self.gl
+            .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+        self.gl.viewport(0, 0, width_i32, height_i32);
+        self.gl.disable(WebGl2RenderingContext::DEPTH_TEST);
+        self.gl.disable(WebGl2RenderingContext::CULL_FACE);
+        self.gl.color_mask(true, true, true, true);
+
+        let render_result = (|| -> Result<(), JsValue> {
+            if stencil_bits <= 0 {
+                // Accurate dark/clear clipping needs stencil. Without it, skip the
+                // highlight instead of drawing cleared holes as selected.
+                return Ok(());
+            }
+
+            let stencil_program = self
+                .highlight_stencil_program
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("Highlight stencil program unavailable"))?;
+            let highlight_program = self
+                .highlight_program
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("Highlight program unavailable"))?;
+
+            if has_primitive_batches {
+                self.gl.clear_stencil(0);
+                self.gl.stencil_mask(0xff);
+                self.gl.clear(STENCIL_BUFFER_BIT);
+                self.gl.enable(STENCIL_TEST);
+                self.gl.disable(BLEND);
+                self.gl.color_mask(false, false, false, false);
+                self.gl.stencil_op(KEEP, KEEP, REPLACE);
+
+                for batch in &batches {
+                    let stencil_value = if batch.clear { 0 } else { 1 };
+                    self.gl.stencil_func(ALWAYS, stencil_value, 0xff);
+                    self.draw_highlight_vertices(stencil_program, &batch.vertices, &transform)?;
+                }
+
+                self.gl.color_mask(true, true, true, true);
+                self.gl.enable(BLEND);
+                self.gl.blend_equation(FUNC_ADD);
+                self.gl.blend_func(SRC_ALPHA, ONE_MINUS_SRC_ALPHA);
+                self.gl.stencil_func(EQUAL, 1, 0xff);
+                self.gl.stencil_mask(0x00);
+                self.gl.stencil_op(KEEP, KEEP, KEEP);
+                self.draw_highlight_vertices(highlight_program, &bounds_vertices, &transform)?;
+            }
+
+            if has_path_regions {
+                self.gl.clear_stencil(0);
+                self.gl.stencil_mask(0xff);
+                self.gl.clear(STENCIL_BUFFER_BIT);
+                self.gl.enable(STENCIL_TEST);
+                self.gl.enable(BLEND);
+                self.gl.blend_equation(FUNC_ADD);
+                self.gl.blend_func(SRC_ALPHA, ONE_MINUS_SRC_ALPHA);
+                self.draw_highlight_path_regions(
+                    &feature.path_regions,
+                    &transform,
+                    highlight_program,
+                    stencil_program,
+                )?;
+            }
+            Ok(())
+        })();
+
+        self.gl.disable(STENCIL_TEST);
+        self.gl.disable(BLEND);
+        self.gl.stencil_mask(0xff);
+        self.gl.color_mask(true, true, true, true);
+        self.gl.bind_buffer(ARRAY_BUFFER, None);
+        self.gl.bind_vertex_array(None);
+        self.gl.blend_equation(FUNC_ADD);
+        self.gl.blend_func(SRC_ALPHA, ONE_MINUS_SRC_ALPHA);
+
+        render_result
     }
 
     /// Draw instanced triangles
@@ -4346,6 +4735,13 @@ impl Renderer {
 
         old_gl.delete_buffer(Some(&old_quad_buffer));
         Self::delete_shader_programs(&old_gl, &old_programs);
+        Self::delete_highlight_resources_from(
+            &old_gl,
+            &mut self.highlight_program,
+            &mut self.highlight_stencil_program,
+            &mut self.highlight_buffer,
+            &mut self.highlight_vertex_array,
+        );
         self.gl = gl;
 
         Ok(())
@@ -4355,6 +4751,7 @@ impl Renderer {
 impl Drop for Renderer {
     fn drop(&mut self) {
         self.clear_all();
+        self.delete_highlight_resources();
         self.gl.delete_buffer(Some(&self.quad_buffer));
         Self::delete_shader_programs(&self.gl, &self.programs);
     }

--- a/wasm/src/renderer/shader.rs
+++ b/wasm/src/renderer/shader.rs
@@ -9,17 +9,21 @@ pub const TRIANGLES: u32 = WebGl2RenderingContext::TRIANGLES;
 pub const FLOAT: u32 = WebGl2RenderingContext::FLOAT;
 pub const ARRAY_BUFFER: u32 = WebGl2RenderingContext::ARRAY_BUFFER;
 pub const STATIC_DRAW: u32 = WebGl2RenderingContext::STATIC_DRAW;
+pub const STREAM_DRAW: u32 = WebGl2RenderingContext::STREAM_DRAW;
 pub const VERTEX_SHADER: u32 = WebGl2RenderingContext::VERTEX_SHADER;
 pub const FRAGMENT_SHADER: u32 = WebGl2RenderingContext::FRAGMENT_SHADER;
 pub const BLEND: u32 = WebGl2RenderingContext::BLEND;
 pub const ONE_MINUS_SRC_ALPHA: u32 = WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA;
 pub const ONE: u32 = WebGl2RenderingContext::ONE;
+pub const SRC_ALPHA: u32 = WebGl2RenderingContext::SRC_ALPHA;
 pub const FUNC_ADD: u32 = WebGl2RenderingContext::FUNC_ADD;
 pub const ZERO: u32 = WebGl2RenderingContext::ZERO;
 pub const STENCIL_TEST: u32 = WebGl2RenderingContext::STENCIL_TEST;
 pub const ALWAYS: u32 = WebGl2RenderingContext::ALWAYS;
+pub const EQUAL: u32 = WebGl2RenderingContext::EQUAL;
 pub const NOTEQUAL: u32 = WebGl2RenderingContext::NOTEQUAL;
 pub const KEEP: u32 = WebGl2RenderingContext::KEEP;
+pub const REPLACE: u32 = WebGl2RenderingContext::REPLACE;
 pub const INVERT: u32 = WebGl2RenderingContext::INVERT;
 
 // Shader sources
@@ -64,6 +68,13 @@ pub const PATH_SOLID_FRAGMENT_SHADER: &str = include_str!("shaders/path_solid.fr
 pub const PATH_SECTOR_VERTEX_SHADER: &str = include_str!("shaders/path_sector.vert.glsl");
 
 pub const PATH_SECTOR_FRAGMENT_SHADER: &str = include_str!("shaders/path_sector.frag.glsl");
+
+pub const HIGHLIGHT_VERTEX_SHADER: &str = include_str!("shaders/highlight.vert.glsl");
+
+pub const HIGHLIGHT_FRAGMENT_SHADER: &str = include_str!("shaders/highlight.frag.glsl");
+
+pub const HIGHLIGHT_STENCIL_FRAGMENT_SHADER: &str =
+    include_str!("shaders/highlight_stencil.frag.glsl");
 
 /// Shader program with uniform locations
 pub struct ShaderProgram {
@@ -246,7 +257,7 @@ impl ShaderPrograms {
 }
 
 /// Compile a shader program
-fn compile_program(
+pub(crate) fn compile_program(
     gl: &WebGl2RenderingContext,
     vertex_src: &str,
     fragment_src: &str,

--- a/wasm/src/renderer/shaders/highlight.frag.glsl
+++ b/wasm/src/renderer/shaders/highlight.frag.glsl
@@ -1,0 +1,20 @@
+#version 300 es
+precision highp float;
+
+out vec4 fragColor;
+
+void main() {
+    ivec2 pixel = ivec2(gl_FragCoord.xy);
+    ivec2 local = pixel & 3;
+    ivec2 tile = pixel >> 2;
+
+    if (local.x >= 2 || local.y >= 2) {
+        discard;
+    }
+
+    if (((tile.x ^ tile.y) & 1) == 0) {
+        fragColor = vec4(1.0, 1.0, 1.0, 0.86);
+    } else {
+        fragColor = vec4(0.0, 0.0, 0.0, 0.72);
+    }
+}

--- a/wasm/src/renderer/shaders/highlight.vert.glsl
+++ b/wasm/src/renderer/shaders/highlight.vert.glsl
@@ -1,0 +1,10 @@
+#version 300 es
+precision highp float;
+
+in vec2 position;
+uniform mat3 transform;
+
+void main() {
+    vec3 transformed = transform * vec3(position, 1.0);
+    gl_Position = vec4(transformed.xy, 0.0, 1.0);
+}

--- a/wasm/src/renderer/shaders/highlight_stencil.frag.glsl
+++ b/wasm/src/renderer/shaders/highlight_stencil.frag.glsl
@@ -1,0 +1,8 @@
+#version 300 es
+precision highp float;
+
+out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(1.0);
+}

--- a/wasm/src/shape.rs
+++ b/wasm/src/shape.rs
@@ -447,6 +447,7 @@ pub struct PathRegions {
     pub(crate) sector_vertex_offsets: Vec<u32>,
     pub(crate) cover_vertices: Vec<f32>,
     pub(crate) clear_vertices: Vec<f32>,
+    pub(crate) pick_contours: Vec<Vec<Vec<[f32; 2]>>>,
 }
 
 impl PathRegions {
@@ -465,6 +466,7 @@ impl PathRegions {
             sector_vertex_offsets: normalize_offsets(sector_vertex_offsets),
             cover_vertices,
             clear_vertices,
+            pick_contours: Vec::new(),
         }
     }
 
@@ -476,6 +478,7 @@ impl PathRegions {
             sector_vertex_offsets: vec![0],
             cover_vertices: Vec::new(),
             clear_vertices: Vec::new(),
+            pick_contours: Vec::new(),
         }
     }
 
@@ -498,6 +501,7 @@ impl PathRegions {
         self.sector_vertices.extend(other.sector_vertices);
         self.cover_vertices.extend(other.cover_vertices);
         self.clear_vertices.extend(other.clear_vertices);
+        self.pick_contours.extend(other.pick_contours);
 
         for offset in other.wedge_vertex_offsets.iter().skip(1) {
             self.wedge_vertex_offsets.push(wedge_base + offset);
@@ -512,6 +516,7 @@ impl PathRegions {
         self.sector_vertices = Vec::new();
         self.cover_vertices = Vec::new();
         self.clear_vertices = Vec::new();
+        self.pick_contours = Vec::new();
     }
 
     pub(crate) fn translate(&mut self, dx: f32, dy: f32) {
@@ -526,6 +531,14 @@ impl PathRegions {
 
         translate_point_pairs(&mut self.cover_vertices, dx, dy);
         translate_point_pairs(&mut self.clear_vertices, dx, dy);
+        for region in &mut self.pick_contours {
+            for contour in region {
+                for point in contour {
+                    point[0] += dx;
+                    point[1] += dy;
+                }
+            }
+        }
     }
 
     pub(crate) fn transform_for_flash(
@@ -579,6 +592,18 @@ impl PathRegions {
             );
             point[0] = x;
             point[1] = y;
+        }
+
+        for region in &mut self.pick_contours {
+            for contour in region {
+                for point in contour {
+                    let (x, y) = transformed_point_for_flash(
+                        point[0], point[1], scale, mirror_x, mirror_y, rotation, dx, dy,
+                    );
+                    point[0] = x;
+                    point[1] = y;
+                }
+            }
         }
     }
 
@@ -701,6 +726,7 @@ fn transform_arc_angles(
 
 /// Boundary information for the entire Gerber layer
 #[wasm_bindgen]
+#[derive(Clone, Debug)]
 pub struct Boundary {
     pub(crate) min_x: f32,
     pub(crate) max_x: f32,
@@ -745,6 +771,13 @@ impl Boundary {
         self.max_x += dx;
         self.min_y += dy;
         self.max_y += dy;
+    }
+
+    pub(crate) fn include_boundary(&mut self, other: &Boundary) {
+        self.min_x = self.min_x.min(other.min_x);
+        self.max_x = self.max_x.max(other.max_x);
+        self.min_y = self.min_y.min(other.min_y);
+        self.max_y = self.max_y.max(other.max_y);
     }
 
     pub(crate) fn to_js(&self) -> Result<JsValue, JsValue> {

--- a/wasm/src/util.rs
+++ b/wasm/src/util.rs
@@ -4,7 +4,7 @@ pub(crate) fn format_count(value: usize) -> String {
     let first_group_len = digits.len() % 3;
 
     for (index, ch) in digits.chars().enumerate() {
-        if index > 0 && index >= first_group_len && (index - first_group_len) % 3 == 0 {
+        if index > 0 && index >= first_group_len && (index - first_group_len).is_multiple_of(3) {
             formatted.push(',');
         }
         formatted.push(ch);


### PR DESCRIPTION
## Summary
- Add interaction-aware feature parsing and WebGL highlight rendering for Gerber and drill geometry.
- Add CPU picking with drill priority, same-location selection cycling, and viewport-relative mouse/touch hit tolerances.
- Return structured feature metadata and properties while keeping region/drill distinct from aperture metadata.
- Keep screenshot export render-only so selected-feature highlights are not included.

## Validation
- node --check js/main.js
- cargo clippy --manifest-path wasm/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path wasm/Cargo.toml
- wasm-pack build wasm --target web --out-dir pkg --release
- npm --prefix packages/wasm-gerber-renderer run check
- git diff --check
- Subagent review completed with no blockers after latest metadata and cycling changes.
