### PR TITLE
Add composite rendering mode and touch layer reorder

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -147,6 +147,7 @@ wasm-gerber-viewer/
 ├── wasm/
 │   ├── Cargo.toml                     # Rust crate manifest
 │   ├── Cargo.lock                     # Rust dependency lockfile
+│   ├── rust-pipeline.md               # Rust/WASM 파이프라인 설명
 │   ├── pkg/                           # 생성된 wasm-pack 출력
 │   └── src/
 │       ├── lib.rs                     # WASM API 진입점

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ wasm-gerber-viewer/
 │   └── wasm-gerber-renderer/          # npm package and Node CLI
 ├── wasm/
 │   ├── Cargo.toml                     # Rust crate manifest
+│   ├── rust-pipeline.md               # Rust/WASM pipeline notes
 │   ├── pkg/                           # Generated wasm-pack output
 │   └── src/
 │       ├── lib.rs                     # WASM API entry point

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -147,6 +147,7 @@ wasm-gerber-viewer/
 ├── wasm/
 │   ├── Cargo.toml                     # Rust crate manifest
 │   ├── Cargo.lock                     # Rust dependency lockfile
+│   ├── rust-pipeline.md               # Rust/WASM 管线说明
 │   ├── pkg/                           # 生成的 wasm-pack 输出
 │   └── src/
 │       ├── lib.rs                     # WASM API 入口

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -147,6 +147,7 @@ wasm-gerber-viewer/
 ├── wasm/
 │   ├── Cargo.toml                     # Rust crate manifest
 │   ├── Cargo.lock                     # Rust dependency lockfile
+│   ├── rust-pipeline.md               # Rust/WASM 管線說明
 │   ├── pkg/                           # 產生的 wasm-pack 輸出
 │   └── src/
 │       ├── lib.rs                     # WASM API 入口

--- a/css/style.css
+++ b/css/style.css
@@ -721,6 +721,11 @@ button {
   background: var(--surface-2);
 }
 
+.alpha-control[hidden],
+.side-panel.collapsed .alpha-control[hidden] {
+  display: none;
+}
+
 .layer-list-scroll {
   flex: 1 1 auto;
   min-height: 0;
@@ -771,10 +776,17 @@ button {
 
 .layer-item[draggable="true"] {
   cursor: grab;
+  -webkit-touch-callout: none;
+  user-select: none;
 }
 
 .layer-item.dragging {
   opacity: 0.45;
+}
+
+.layer-item.touch-dragging {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(94, 234, 212, 0.55);
 }
 
 .layer-item.drop-before::before,

--- a/index.html
+++ b/index.html
@@ -273,6 +273,31 @@
                   </div>
                   <div class="option-outline">
                     <div class="option-row">
+                      <span>Layer Rendering</span>
+                      <div class="segmented-control" role="radiogroup" aria-label="Layer rendering mode">
+                        <label>
+                          <input
+                            type="radio"
+                            id="composite-mode-blend"
+                            name="composite-mode"
+                            value="blend"
+                          />
+                          <span>Blend</span>
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            id="composite-mode-stack"
+                            name="composite-mode"
+                            value="stack"
+                          />
+                          <span>Stack</span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="option-outline">
+                    <div class="option-row">
                       <span>Region Arcs</span>
                       <div class="segmented-control" role="radiogroup" aria-label="Region arc rendering mode">
                         <label>

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -95,6 +95,14 @@ export function getViewerElements(documentRef = document) {
       documentRef,
       "rendering-mode-realtime",
     ),
+    compositeModeBlendInput: requireElement(
+      documentRef,
+      "composite-mode-blend",
+    ),
+    compositeModeStackInput: requireElement(
+      documentRef,
+      "composite-mode-stack",
+    ),
     regionArcExactInput: requireElement(documentRef, "region-arc-exact"),
     regionArcApproximateInput: requireElement(
       documentRef,

--- a/js/main.js
+++ b/js/main.js
@@ -64,7 +64,18 @@ const RENDERING_MODE_VALUES = new Set([
   RENDERING_MODE_LAZY,
   RENDERING_MODE_REALTIME,
 ]);
+const COMPOSITE_MODE_BLEND = "blend";
+const COMPOSITE_MODE_STACK = "stack";
+const COMPOSITE_MODE_VALUES = new Set([
+  COMPOSITE_MODE_BLEND,
+  COMPOSITE_MODE_STACK,
+]);
 const LAZY_WHEEL_RENDER_DELAY_MS = 140;
+const LAYER_TOUCH_DRAG_DELAY_MS = 500;
+const LAYER_TOUCH_DRAG_CANCEL_PX = 8;
+const LAYER_TOUCH_AUTOSCROLL_EDGE_PX = 56;
+const LAYER_TOUCH_AUTOSCROLL_MAX_PX = 14;
+const LAYER_REORDER_ANIMATION_MS = 180;
 const DRILL_LAYER_KIND = "drill";
 const GERBER_LAYER_KIND = "gerber";
 const PTH_DRILL_TYPE = "pth";
@@ -647,6 +658,11 @@ export class GerberViewer {
     this.nextLayerDomId = 0;
     this.draggedLayerId = null;
     this.layerDropIndex = null;
+    this.layerTouchDrag = null;
+    this.layerTouchDragTimer = null;
+    this.layerTouchScrollFrame = null;
+    this.layerTouchScrollVelocity = 0;
+    this.layerTouchSuppressClickUntil = 0;
     this.pendingLayerRecordsForRecovery = null;
     this.pendingLazyRenderTimer = null;
     this.lazyViewportRenderState = null;
@@ -716,7 +732,7 @@ export class GerberViewer {
     this.arcTessellationQuality =
       this.viewerOptionsStore.get("arcTessellationQuality") ?? "normal";
     this.minimumFeaturePixels = Number(
-      this.viewerOptionsStore.get("minimumFeaturePixels") ?? 0,
+      this.viewerOptionsStore.get("minimumFeaturePixels") ?? 1,
     );
     this.drillOutlinePixels = Number(
       this.viewerOptionsStore.get("drillOutlinePixels") ?? 0,
@@ -728,6 +744,10 @@ export class GerberViewer {
     this.renderingMode = RENDERING_MODE_VALUES.has(storedRenderingMode)
       ? storedRenderingMode
       : RENDERING_MODE_LAZY;
+    const storedCompositeMode = this.viewerOptionsStore.get("compositeMode");
+    this.compositeMode = COMPOSITE_MODE_VALUES.has(storedCompositeMode)
+      ? storedCompositeMode
+      : COMPOSITE_MODE_BLEND;
     this.drawerController = new DrawerController({
       drawer: this.drawer,
       resizeHandle: this.resizeHandle,
@@ -775,7 +795,8 @@ export class GerberViewer {
         canvasHeight: this.canvas.height,
         rectWidth: rect.width,
         rectHeight: rect.height,
-        globalAlpha: this.globalAlpha,
+        globalAlpha: this.getCompositeAlpha(),
+        compositeMode: this.compositeMode,
         backgroundColor: this.isCanvasLight ? "#f8fafc" : "#020617",
       }),
       isWebGlUnavailable: () =>
@@ -1100,6 +1121,14 @@ export class GerberViewer {
       });
     }
 
+    for (const input of this.getCompositeModeInputs()) {
+      input.addEventListener("change", () => {
+        if (input.checked) {
+          this.setCompositeMode(input.value);
+        }
+      });
+    }
+
     // Alpha slider
     this.alphaSlider.addEventListener("input", (e) => {
       const alpha = parseInt(e.target.value) / 100;
@@ -1217,6 +1246,31 @@ export class GerberViewer {
         this.clearLayerDropIndicator();
       }
     });
+    this.layerList.addEventListener(
+      "touchstart",
+      (e) => this.handleLayerTouchStart(e),
+      { passive: false },
+    );
+    this.layerList.addEventListener(
+      "touchmove",
+      (e) => this.handleLayerTouchMove(e),
+      { passive: false },
+    );
+    this.layerList.addEventListener(
+      "touchend",
+      (e) => this.handleLayerTouchEnd(e),
+      { passive: false },
+    );
+    this.layerList.addEventListener(
+      "touchcancel",
+      (e) => this.handleLayerTouchCancel(e),
+      { passive: false },
+    );
+    this.layerList.addEventListener(
+      "click",
+      (e) => this.suppressLayerClickAfterTouchDrag(e),
+      true,
+    );
 
     // File drop events
     this.dropZone.addEventListener("dragover", (e) => this.handleDragOver(e));
@@ -1323,6 +1377,7 @@ export class GerberViewer {
       minimumFeaturePixels: this.minimumFeaturePixels,
       drillOutlinePixels: this.drillOutlinePixels,
       pthPlatingMicrometers: this.pthPlatingMicrometers,
+      compositeMode: this.compositeMode,
     };
   }
 
@@ -1369,6 +1424,10 @@ export class GerberViewer {
     return [this.renderingModeLazyInput, this.renderingModeRealtimeInput];
   }
 
+  getCompositeModeInputs() {
+    return [this.compositeModeBlendInput, this.compositeModeStackInput];
+  }
+
   syncRenderingModeControls() {
     const renderingModeDisabled =
       this.isRendererBusy() || this.isViewportGestureActive();
@@ -1380,6 +1439,11 @@ export class GerberViewer {
 
   syncOptionControls() {
     this.syncRenderingModeControls();
+
+    for (const input of this.getCompositeModeInputs()) {
+      input.checked = input.value === this.compositeMode;
+      input.disabled = this.isRendererBusy();
+    }
 
     this.regionArcExactInput.checked = this.preserveArcRegions;
     this.regionArcApproximateInput.checked = !this.preserveArcRegions;
@@ -1440,6 +1504,39 @@ export class GerberViewer {
 
   shouldRenderViewportRealtime() {
     return this.isRealtimeRendering();
+  }
+
+  setCompositeMode(mode) {
+    if (!COMPOSITE_MODE_VALUES.has(mode)) {
+      this.syncOptionControls();
+      return;
+    }
+    if (mode === this.compositeMode) {
+      return;
+    }
+    if (this.isRendererBusy()) {
+      this.syncOptionControls();
+      return;
+    }
+
+    this.compositeMode = mode;
+    this.viewerOptionsStore.set("compositeMode", this.compositeMode);
+    this.syncOptionControls();
+    this.requestRender();
+    this.updateUiState();
+  }
+
+  isStackCompositeMode() {
+    return this.compositeMode === COMPOSITE_MODE_STACK;
+  }
+
+  updateAlphaControlState(rendererBusy = this.isRendererBusy()) {
+    const shouldHide = this.isStackCompositeMode();
+    const alphaControl = this.alphaSlider.closest(".alpha-control");
+    if (alphaControl) {
+      alphaControl.hidden = shouldHide;
+    }
+    this.alphaSlider.disabled = rendererBusy || shouldHide;
   }
 
   isViewportGestureActive() {
@@ -1897,10 +1994,14 @@ export class GerberViewer {
     this.fileInput.disabled = rendererBusy;
     this.selectFilesBtn.disabled = rendererBusy;
     this.emptyUploadBtn.disabled = rendererBusy;
+    this.updateAlphaControlState(rendererBusy);
     this.clearAllBtn.disabled = rendererBusy || totalLayers === 0;
     this.toolbarClearAllBtn.disabled = rendererBusy || totalLayers === 0;
     this.updateEmptyLayerListActionState(rendererBusy);
     this.syncRenderingModeControls();
+    for (const input of this.getCompositeModeInputs()) {
+      input.disabled = rendererBusy;
+    }
     this.regionArcExactInput.disabled = rendererBusy;
     this.regionArcApproximateInput.disabled = rendererBusy;
     for (const input of this.getArcQualityInputs()) {
@@ -3605,7 +3706,8 @@ export class GerberViewer {
     }
 
     try {
-      const { activeLayerIds, colorData, blendModes } = this.getRenderLayerPayload();
+      const { activeLayerIds, colorData, blendModes, alpha } =
+        this.getRenderLayerPayload();
 
       // Render with active layers
       if (blendModes.some((mode) => mode !== 0)) {
@@ -3620,7 +3722,7 @@ export class GerberViewer {
           this.getViewScaleY(),
           this.camera.offsetX,
           this.camera.offsetY,
-          this.globalAlpha,
+          alpha,
           true,
         );
       } else {
@@ -3631,7 +3733,7 @@ export class GerberViewer {
           this.getViewScaleY(),
           this.camera.offsetX,
           this.camera.offsetY,
-          this.globalAlpha,
+          alpha,
         );
       }
       this.renderSelectedFeatureHighlight();
@@ -3678,17 +3780,23 @@ export class GerberViewer {
     const activeLayerIds = [];
     const colorData = [];
     const blendModes = [];
+    const alpha = this.getCompositeAlpha();
+    const isStack = this.isStackCompositeMode();
     const backgroundColor = this.isCanvasLight
       ? [248 / 255, 250 / 255, 252 / 255]
       : [2 / 255, 6 / 255, 23 / 255];
-    const drillAlpha = this.globalAlpha > 0 ? 1 / this.globalAlpha : 0;
+    const drillAlpha = alpha > 0 ? 1 / alpha : 0;
 
-    this.layers.forEach((layer) => {
-      if (!isDrillLayer(layer) && selectedLayerIds.has(layer.id)) {
-        activeLayerIds.push(layer.layerId);
-        colorData.push(layer.color[0], layer.color[1], layer.color[2], 1);
-        blendModes.push(0);
-      }
+    const gerberLayers = this.layers.filter(
+      (layer) => !isDrillLayer(layer) && selectedLayerIds.has(layer.id),
+    );
+    const orderedGerberLayers = isStack
+      ? [...gerberLayers].reverse()
+      : gerberLayers;
+    orderedGerberLayers.forEach((layer) => {
+      activeLayerIds.push(layer.layerId);
+      colorData.push(layer.color[0], layer.color[1], layer.color[2], 1);
+      blendModes.push(isStack ? 1 : 0);
     });
 
     this.layers.forEach((layer) => {
@@ -3721,7 +3829,12 @@ export class GerberViewer {
       activeLayerIds: new Uint32Array(activeLayerIds),
       colorData: new Float32Array(colorData),
       blendModes: new Uint8Array(blendModes),
+      alpha,
     };
+  }
+
+  getCompositeAlpha() {
+    return this.isStackCompositeMode() ? 1 : this.globalAlpha;
   }
 
   renderMeasurements() {
@@ -4298,10 +4411,11 @@ export class GerberViewer {
 
   getVisibleInteractionLayerIds() {
     const layerIds = [];
-    for (const layer of this.layers) {
-      if (layer.visible && !isDrillLayer(layer)) {
-        layerIds.push(layer.layerId);
-      }
+    const gerberLayers = this.layers
+      .filter((layer) => layer.visible && !isDrillLayer(layer))
+      .reverse();
+    for (const layer of gerberLayers) {
+      layerIds.push(layer.layerId);
     }
     for (const layer of this.layers) {
       if (layer.visible && isDrillLayer(layer)) {
@@ -4960,30 +5074,75 @@ export class GerberViewer {
 
     event.preventDefault();
     event.stopPropagation();
+    this.reorderGerberLayer(this.draggedLayerId, this.layerDropIndex);
+    this.draggedLayerId = null;
+    this.layerDropIndex = null;
+    this.clearLayerDropIndicator();
+  }
+
+  reorderGerberLayer(layerId, dropIndex) {
     const gerberLayers = this.layers.filter((layer) => !isDrillLayer(layer));
     const drillLayers = this.layers.filter(isDrillLayer);
     const fromIndex = gerberLayers.findIndex(
-      (layer) => layer.id === this.draggedLayerId,
+      (layer) => layer.id === layerId,
     );
-    if (fromIndex === -1) return;
+    if (fromIndex === -1) return false;
 
-    let toIndex = this.layerDropIndex;
+    let toIndex = dropIndex;
     if (fromIndex < toIndex) {
       toIndex -= 1;
     }
 
     if (fromIndex !== toIndex) {
+      const previousRects = this.captureLayerItemRects();
       const [layer] = gerberLayers.splice(fromIndex, 1);
       gerberLayers.splice(toIndex, 0, layer);
       this.layers = [...gerberLayers, ...drillLayers];
       this.renderLayerList();
+      this.animateLayerReorder(previousRects);
       this.requestRender();
       this.updateUiState();
     }
 
-    this.draggedLayerId = null;
-    this.layerDropIndex = null;
-    this.clearLayerDropIndicator();
+    return fromIndex !== toIndex;
+  }
+
+  captureLayerItemRects() {
+    const rects = new Map();
+    for (const item of this.layerList.querySelectorAll(".layer-item[data-layer-id]")) {
+      rects.set(item.dataset.layerId, item.getBoundingClientRect());
+    }
+    return rects;
+  }
+
+  animateLayerReorder(previousRects) {
+    if (
+      !previousRects?.size ||
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+
+    for (const item of this.layerList.querySelectorAll(".layer-item[data-layer-id]")) {
+      const previousRect = previousRects.get(item.dataset.layerId);
+      if (!previousRect) continue;
+
+      const currentRect = item.getBoundingClientRect();
+      const deltaX = previousRect.left - currentRect.left;
+      const deltaY = previousRect.top - currentRect.top;
+      if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) continue;
+
+      item.animate(
+        [
+          { transform: `translate(${deltaX}px, ${deltaY}px)` },
+          { transform: "translate(0, 0)" },
+        ],
+        {
+          duration: LAYER_REORDER_ANIMATION_MS,
+          easing: "cubic-bezier(0.2, 0, 0, 1)",
+        },
+      );
+    }
   }
 
   getLayerDropPlacement(clientY) {
@@ -5015,6 +5174,224 @@ export class GerberViewer {
     this.layerList
       .querySelectorAll(".drop-before, .drop-after")
       .forEach((item) => item.classList.remove("drop-before", "drop-after"));
+  }
+
+  handleLayerTouchStart(event) {
+    if (event.touches.length !== 1 || this.layerTouchDrag) {
+      this.cancelLayerTouchDrag();
+      return;
+    }
+    if (
+      event.target instanceof Element &&
+      event.target.closest("input, button")
+    ) {
+      return;
+    }
+
+    const item = event.target instanceof Element
+      ? event.target.closest('.layer-item[draggable="true"][data-layer-id]')
+      : null;
+    if (!item) {
+      return;
+    }
+
+    const touch = event.touches[0];
+    const layerId = item.dataset.layerId;
+    const scrollElement = this.getLayerListScrollElement();
+    this.layerTouchDrag = {
+      active: false,
+      identifier: touch.identifier,
+      layerId,
+      item,
+      startX: touch.clientX,
+      startY: touch.clientY,
+      lastClientY: touch.clientY,
+      scrollElement,
+    };
+    this.layerTouchDragTimer = window.setTimeout(() => {
+      this.activateLayerTouchDrag();
+    }, LAYER_TOUCH_DRAG_DELAY_MS);
+  }
+
+  handleLayerTouchMove(event) {
+    if (!this.layerTouchDrag) return;
+
+    if (event.touches.length !== 1) {
+      if (this.layerTouchDrag.active) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.layerTouchSuppressClickUntil = Date.now() + 500;
+      }
+      this.cancelLayerTouchDrag();
+      return;
+    }
+
+    const touch = this.findLayerTouch(event.touches);
+    if (!touch) {
+      this.cancelLayerTouchDrag();
+      return;
+    }
+
+    const drag = this.layerTouchDrag;
+    const distance = Math.hypot(
+      touch.clientX - drag.startX,
+      touch.clientY - drag.startY,
+    );
+
+    if (!drag.active) {
+      if (distance > LAYER_TOUCH_DRAG_CANCEL_PX) {
+        this.cancelLayerTouchDrag();
+      }
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    drag.lastClientY = touch.clientY;
+    this.updateLayerTouchDropPlacement(touch.clientY);
+    this.updateLayerTouchAutoScroll(touch.clientY);
+  }
+
+  handleLayerTouchEnd(event) {
+    if (!this.layerTouchDrag) return;
+
+    const drag = this.layerTouchDrag;
+    if (!this.findLayerTouch(event.changedTouches)) {
+      return;
+    }
+
+    const wasActive = drag.active;
+    if (wasActive) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (this.draggedLayerId && this.layerDropIndex !== null) {
+        this.reorderGerberLayer(this.draggedLayerId, this.layerDropIndex);
+      }
+      this.layerTouchSuppressClickUntil = Date.now() + 500;
+    }
+    this.cancelLayerTouchDrag();
+  }
+
+  handleLayerTouchCancel(event) {
+    if (!this.layerTouchDrag) return;
+    if (this.layerTouchDrag.active) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.layerTouchSuppressClickUntil = Date.now() + 500;
+    }
+    this.cancelLayerTouchDrag();
+  }
+
+  activateLayerTouchDrag() {
+    const drag = this.layerTouchDrag;
+    if (!drag || drag.active) return;
+
+    drag.active = true;
+    this.draggedLayerId = drag.layerId;
+    this.layerDropIndex = null;
+    this.dropZone.classList.remove("drag-active");
+    drag.item.classList.add("dragging", "touch-dragging");
+    this.updateLayerTouchDropPlacement(drag.lastClientY);
+  }
+
+  cancelLayerTouchDrag() {
+    if (this.layerTouchDragTimer !== null) {
+      clearTimeout(this.layerTouchDragTimer);
+      this.layerTouchDragTimer = null;
+    }
+    this.stopLayerTouchAutoScroll();
+    if (this.layerTouchDrag?.item) {
+      this.layerTouchDrag.item.classList.remove("dragging", "touch-dragging");
+    }
+    this.layerTouchDrag = null;
+    this.draggedLayerId = null;
+    this.layerDropIndex = null;
+    this.layerTouchScrollVelocity = 0;
+    this.clearLayerDropIndicator();
+  }
+
+  findLayerTouch(touchList) {
+    const drag = this.layerTouchDrag;
+    if (!drag) return null;
+    return Array.from(touchList).find(
+      (touch) => touch.identifier === drag.identifier,
+    ) ?? null;
+  }
+
+  getLayerListScrollElement() {
+    return this.layerList.closest(".layer-list-scroll") ?? this.layerList;
+  }
+
+  updateLayerTouchDropPlacement(clientY) {
+    const placement = this.getLayerDropPlacement(clientY);
+    if (!placement) return;
+
+    this.layerDropIndex = placement.dropIndex;
+    this.clearLayerDropIndicator();
+    placement.item.classList.add(
+      placement.position === "after" ? "drop-after" : "drop-before",
+    );
+  }
+
+  updateLayerTouchAutoScroll(clientY) {
+    const drag = this.layerTouchDrag;
+    const scrollElement = drag?.scrollElement;
+    if (!drag?.active || !scrollElement) return;
+
+    const rect = scrollElement.getBoundingClientRect();
+    let velocity = 0;
+    if (clientY < rect.top + LAYER_TOUCH_AUTOSCROLL_EDGE_PX) {
+      const ratio =
+        (rect.top + LAYER_TOUCH_AUTOSCROLL_EDGE_PX - clientY) /
+        LAYER_TOUCH_AUTOSCROLL_EDGE_PX;
+      velocity = -Math.ceil(ratio * LAYER_TOUCH_AUTOSCROLL_MAX_PX);
+    } else if (clientY > rect.bottom - LAYER_TOUCH_AUTOSCROLL_EDGE_PX) {
+      const ratio =
+        (clientY - (rect.bottom - LAYER_TOUCH_AUTOSCROLL_EDGE_PX)) /
+        LAYER_TOUCH_AUTOSCROLL_EDGE_PX;
+      velocity = Math.ceil(ratio * LAYER_TOUCH_AUTOSCROLL_MAX_PX);
+    }
+
+    this.layerTouchScrollVelocity = velocity;
+    if (velocity === 0) {
+      this.stopLayerTouchAutoScroll();
+      return;
+    }
+
+    if (this.layerTouchScrollFrame === null) {
+      this.layerTouchScrollFrame = requestAnimationFrame(() =>
+        this.stepLayerTouchAutoScroll(),
+      );
+    }
+  }
+
+  stepLayerTouchAutoScroll() {
+    this.layerTouchScrollFrame = null;
+    const drag = this.layerTouchDrag;
+    const scrollElement = drag?.scrollElement;
+    if (!drag?.active || !scrollElement || this.layerTouchScrollVelocity === 0) {
+      return;
+    }
+
+    scrollElement.scrollTop += this.layerTouchScrollVelocity;
+    this.updateLayerTouchDropPlacement(drag.lastClientY);
+    this.layerTouchScrollFrame = requestAnimationFrame(() =>
+      this.stepLayerTouchAutoScroll(),
+    );
+  }
+
+  stopLayerTouchAutoScroll() {
+    if (this.layerTouchScrollFrame !== null) {
+      cancelAnimationFrame(this.layerTouchScrollFrame);
+      this.layerTouchScrollFrame = null;
+    }
+  }
+
+  suppressLayerClickAfterTouchDrag(event) {
+    if (Date.now() > this.layerTouchSuppressClickUntil) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
   }
 
   renderLayerList() {

--- a/js/screenshot-exporter.js
+++ b/js/screenshot-exporter.js
@@ -384,15 +384,17 @@ export class ScreenshotExporter {
       throw new Error("Arc tessellation quality requires an updated WASM module.");
     }
     const renderOptions = this.getRenderOptions?.() ?? {};
+    const isStackCompositeMode = renderOptions.compositeMode === "stack";
     if (typeof processor.set_minimum_feature_pixels === "function") {
       processor.set_minimum_feature_pixels(
-        Number(renderOptions.minimumFeaturePixels ?? 0),
+        Number(renderOptions.minimumFeaturePixels ?? 1),
       );
     }
 
     const activeLayerIds = [];
     const colorData = [];
     const blendModes = [];
+    const gerberRenderLayers = [];
     const drillLayers = [];
     let wasmLayerCount = 0;
     const drillFillColor = includeBackground
@@ -459,10 +461,20 @@ export class ScreenshotExporter {
         : processor.add_layer(layer.sourceContent);
       wasmLayerCount += 1;
       if (layer.visible) {
-        activeLayerIds.push(layerId);
-        colorData.push(layer.color[0], layer.color[1], layer.color[2], 1);
-        blendModes.push(0);
+        gerberRenderLayers.push({
+          layerId,
+          color: layer.color,
+        });
       }
+    }
+
+    const orderedGerberRenderLayers = isStackCompositeMode
+      ? [...gerberRenderLayers].reverse()
+      : gerberRenderLayers;
+    for (const layer of orderedGerberRenderLayers) {
+      activeLayerIds.push(layer.layerId);
+      colorData.push(layer.color[0], layer.color[1], layer.color[2], 1);
+      blendModes.push(isStackCompositeMode ? 1 : 0);
     }
 
     for (const layer of drillLayers) {

--- a/js/viewer-options.js
+++ b/js/viewer-options.js
@@ -1,10 +1,11 @@
 const DEFAULT_VIEWER_OPTIONS = {
   preserveArcRegions: true,
   arcTessellationQuality: "normal",
-  minimumFeaturePixels: 0,
+  minimumFeaturePixels: 1,
   drillOutlinePixels: 0,
   pthPlatingMicrometers: 20,
   renderingMode: "lazy",
+  compositeMode: "blend",
 };
 
 const ARC_TESSELLATION_QUALITIES = new Set(["low", "normal", "high"]);
@@ -12,6 +13,7 @@ const MINIMUM_FEATURE_PIXELS = new Set([0, 1, 2]);
 const DRILL_OUTLINE_PIXELS = new Set([0, 1, 2, 3]);
 const PTH_PLATING_MICROMETERS = new Set([10, 20, 30, 40, 50]);
 const RENDERING_MODES = new Set(["lazy", "realtime"]);
+const COMPOSITE_MODES = new Set(["blend", "stack"]);
 
 function createMemoryStorage() {
   const values = new Map();
@@ -37,7 +39,7 @@ function getDefaultStorage() {
 export class ViewerOptionsStore {
   constructor(
     storage = getDefaultStorage(),
-    storageKey = "wasm-gerber-viewer.options",
+    storageKey = "wasm-gerber-viewer.options.v2",
   ) {
     this.storage = storage ?? createMemoryStorage();
     this.storageKey = storageKey;
@@ -78,6 +80,9 @@ export class ViewerOptionsStore {
         renderingMode: RENDERING_MODES.has(stored.renderingMode)
           ? stored.renderingMode
           : DEFAULT_VIEWER_OPTIONS.renderingMode,
+        compositeMode: COMPOSITE_MODES.has(stored.compositeMode)
+          ? stored.compositeMode
+          : DEFAULT_VIEWER_OPTIONS.compositeMode,
       };
     } catch {
       return this.getDefaults();

--- a/wasm/rust-pipeline.md
+++ b/wasm/rust-pipeline.md
@@ -1,0 +1,359 @@
+# Rust/WASM Pipeline
+
+This document describes the Rust pipeline under `wasm/src`. The JavaScript UI
+and workers provide input, options, layer order, and camera state. Rust/WASM
+handles parsing, geometry storage, WebGL rendering, CPU picking, and highlight
+rendering.
+
+## Overall Rust/WASM Pipeline
+
+```mermaid
+flowchart TD
+  JS["JavaScript UI / workers"] --> API["wasm/src/lib.rs public API"]
+  API --> InputKind{"Input path"}
+
+  InputKind -->|Gerber source| GerberParse["parse_gerber_layer*"]
+  GerberParse --> Parser["GerberParser"]
+  Parser --> GerberData["GerberData vector<br/>polarity sublayers"]
+  Parser --> MaybeInteraction["Optional InteractionLayer"]
+
+  InputKind -->|Drill source| DrillParse["parse_drill_layer"]
+  DrillParse --> DrillResult["DrillParseResult"]
+  DrillResult --> DrillLayers["outline_layer + fill_layer"]
+  DrillResult --> DrillMeta["Drill metadata"]
+  DrillResult --> DrillInteraction["Optional InteractionLayer"]
+
+  InputKind -->|Worker payload| Payload["Render payload / restored GerberData"]
+
+  GerberData --> AddParsed["GerberProcessor::add_parsed_layers"]
+  Payload --> AddPayload["Renderer::add_layer_from_render_payload"]
+  DrillLayers --> AddDrill["GerberProcessor::add_drill_parse_result"]
+
+  AddParsed --> Renderer["Renderer layer state + GPU resources"]
+  AddPayload --> Renderer
+  AddDrill --> Renderer
+
+  MaybeInteraction --> InteractionStore["interaction_layers by renderer layer id"]
+  DrillInteraction --> InteractionStore
+
+  Renderer --> RenderEntry["render / render_tile / render_pixels"]
+  InteractionStore --> Picking["pick_interaction_feature*"]
+  Picking --> Highlight["render_interaction_highlight"]
+```
+
+### 1. WASM Entry Points
+
+The public boundary is mostly defined in `wasm/src/lib.rs`.
+
+Key APIs:
+
+- `init_panic_hook()`: installs browser-console panic reporting.
+- `reserve_input_capacity(byte_count)`: preflights large JS-to-WASM input
+  copies with catchable allocation errors.
+- `parse_gerber_layer*()`: parses Gerber input and returns JS geometry payloads.
+- `parse_drill_layer()`: parses Excellon/NC drill input into outline/fill
+  payloads.
+- `GerberProcessor`: owns the stateful WebGL renderer, parser options, drill
+  options, and optional interaction indexes.
+
+### 2. Gerber Parsing
+
+Gerber parsing starts in `wasm/src/parser.rs`.
+
+Important functions:
+
+- `parse_gerber_with_options(content, preserve_arc_regions, arc_tessellation_quality)`
+- `parse_gerber_payload_with_options(...)`
+- `GerberParser`
+
+The parser processes the file in object-stream order and emits polarity
+sublayers. The render output is `Vec<GerberData>`, where each `GerberData`
+represents one polarity batch within a user layer.
+
+High-level flow:
+
+1. Build aperture, aperture macro, and parser state.
+2. Convert graphic commands into primitives.
+3. Build region contours and path-region data.
+4. Split output when polarity or block-aperture boundaries require it.
+5. Drop empty geometry batches.
+6. If interaction is enabled, build an `InteractionLayer` alongside render
+   geometry.
+
+### 3. Drill Parsing
+
+Drill parsing lives in `wasm/src/drill.rs`.
+
+Important functions:
+
+- `parse_drill_with_offset(...)`
+- `parse_drill_with_offset_and_interactions(...)`
+
+Drill input is split into two render layers:
+
+- `outline_layer`: plated ring or outline geometry.
+- `fill_layer`: hole clear/fill geometry.
+
+`DrillParseResult` contains both render layers, metadata, and an optional
+interaction layer. `GerberProcessor::add_drill_parse_result()` adds outline and
+fill as separate renderer layers, stores the outline id for later option
+updates, and returns `outlineLayerId`, `fillLayerId`, and metadata to JS.
+
+### 4. Geometry Model
+
+The shared geometry model is in `wasm/src/shape.rs`.
+
+Important types:
+
+- `GerberData`: one renderable polarity sublayer.
+- `Boundary`: min/max bounds.
+- `Lines`, `Circles`, `Arcs`, `Thermals`, `TriangleTemplateInstances`.
+- `PathRegions`: region/path based geometry.
+
+`GerberData` also supports JS payload conversion. This lets a worker parse
+geometry in one WASM instance and pass a compact payload back to the main
+renderer instance.
+
+### 5. Processor State
+
+`GerberProcessor` keeps the top-level state:
+
+- `renderer: Option<Renderer>`: WebGL renderer.
+- `preserve_arc_regions`, `arc_tessellation_quality`: parser options.
+- `minimum_feature_pixels`: display-size adjustment for tiny features.
+- `drill_outline_pixels`: drill outline expansion in screen pixels.
+- `drill_outline_layer_ids`: drill outline layers that need option updates.
+- `interaction_enabled`, `interaction_layers`: CPU picking data.
+
+Layer-add flow:
+
+1. JS calls `add_layer`, `add_layer_with_offset`, `add_render_payload`, or
+   `add_drill_layer`.
+2. Rust parses source text directly or restores `GerberData` from JS payloads.
+3. `Renderer::add_layer()` or `Renderer::add_layer_from_render_payload()`
+   creates renderer layer metadata and GPU resources.
+4. If interaction is enabled, the matching `InteractionLayer` is stored by
+   renderer layer id.
+
+### 6. Interaction Pipeline
+
+Interaction data is implemented in `wasm/src/interaction.rs`.
+
+Important types:
+
+- `InteractionLayer`
+- `InteractionFeature`
+- `FeatureKind`
+
+CPU picking flow:
+
+1. JS converts click/touch coordinates into world coordinates.
+2. JS passes visible interaction layer ids and a world-space tolerance to
+   `pick_interaction_feature()`.
+3. Rust scans layer ids in reverse order so visually higher layers are tested
+   first.
+4. Repeated picking at nearly the same location uses
+   `pick_interaction_feature_after()` to cycle to the next candidate.
+5. Rust returns structured feature metadata, not display strings.
+
+Highlight flow:
+
+1. JS stores the selected `layerId` and `featureId`.
+2. After normal rendering, JS calls `render_interaction_highlight()`.
+3. Rust looks up the stored `InteractionFeature`.
+4. WebGL highlight passes render the selected area.
+
+## Rendering Pipeline
+
+Rendering is implemented by `Renderer` in `wasm/src/renderer.rs`.
+
+```mermaid
+flowchart TD
+  RenderCall["render* API"] --> Validate["Validate layer ids, colors, size, and camera input"]
+  Validate --> Camera["Update camera state and compute transform"]
+  Camera --> RenderWithTransform["render_with_transform"]
+  RenderWithTransform --> LayerFbos["render_layer_fbos"]
+
+  LayerFbos --> PerLayer{"For each active layer"}
+  PerLayer --> DirtyCheck{"FBO dirty or transform changed?"}
+  DirtyCheck -->|No| Reuse["Reuse cached layer FBO"]
+  DirtyCheck -->|Yes| BindFbo["Bind layer FBO and clear to transparent"]
+  BindFbo --> Geometry["render_layer_geometry"]
+  Geometry --> Positive["Positive polarity writes alpha"]
+  Geometry --> Negative["Negative polarity erases alpha"]
+  Positive --> Cache["Mark FBO clean and cache transform"]
+  Negative --> Cache
+
+  Reuse --> Composite["composite_layers_to_target"]
+  Cache --> Composite
+  Composite --> TextureShader["Texture shader applies layer color and alpha"]
+  TextureShader --> BlendMode{"Blend mode"}
+  BlendMode -->|0| Additive["Additive blend"]
+  BlendMode -->|1| SourceOver["Premultiplied source-over"]
+  BlendMode -->|2| ClearReduce["Destination clear / reduce"]
+  Additive --> Target["Canvas or offscreen framebuffer"]
+  SourceOver --> Target
+  ClearReduce --> Target
+  Target --> OptionalHighlight["Optional interaction highlight pass"]
+```
+
+The key design point is that final color alpha is not applied while drawing
+individual geometry primitives. Instead, each user layer is first rendered into
+its own FBO as a layer mask, and final color/alpha is applied only when those
+layer FBOs are composited to the target canvas.
+
+This avoids intra-layer alpha accumulation. If flashes, lines, regions, or arcs
+inside the same file overlap, the overlap should not become a different color
+just because the same layer was drawn multiple times.
+
+### 1. Renderer Initialization
+
+Initialization paths:
+
+- `GerberProcessor::init(gl)` -> `Renderer::new(gl)`
+- `GerberProcessor::init_with_size(gl, width, height)` ->
+  `Renderer::new_headless(...)`
+
+The renderer owns shader programs, shared buffers, layer FBOs, geometry buffer
+caches, and highlight resources.
+
+### 2. Layer Registration
+
+`Renderer::add_layer(gerber_data: Vec<GerberData>)` registers one user layer.
+The `Vec<GerberData>` is the list of polarity sublayers for that user layer.
+
+Registration creates or prepares:
+
+- layer metadata.
+- one FBO for the user layer.
+- sublayer buffer caches.
+- bounds.
+- uploaded geometry or render payload backed buffers.
+
+`add_layer_from_render_payload()` is the worker-to-main-renderer path. It avoids
+reparsing source text in the main renderer when a worker has already produced a
+render payload.
+
+### 3. Render Call Stack
+
+JS usually calls one of these APIs:
+
+- `render(active_layer_ids, color_data, zoom_x, zoom_y, offset_x, offset_y, alpha)`
+- `render_with_clear(...)`
+- `render_with_clear_and_blend_modes(..., blend_modes, ..., clear_canvas)`
+- screenshot/headless variants such as `render_tile*()` and `render_pixels*()`
+
+Most paths converge to:
+
+1. Validate render input.
+2. Update camera state.
+3. Compute the transform matrix.
+4. Call `render_with_transform(...)`.
+5. Call `render_layer_fbos(...)`.
+6. Call `composite_layers(...)`.
+
+### 4. Layer FBO Rendering
+
+`render_layer_fbos(active_layer_ids, transform, width, height)` prepares each
+active layer's FBO.
+
+A layer FBO is redrawn only when:
+
+- the layer is dirty, or
+- the cached FBO transform differs from the current transform.
+
+When redrawing:
+
+1. Bind the layer FBO.
+2. Clear it to transparent black.
+3. Call `render_layer_geometry(layer_idx, transform, width, height)`.
+4. Mark the layer clean and cache the transform.
+
+### 5. Geometry Rendering Inside One Layer
+
+`render_layer_geometry()` draws all polarity sublayers inside one user layer.
+
+Rules:
+
+- Positive polarity fills alpha in the layer FBO.
+- Negative polarity erases alpha in the layer FBO.
+- Final layer color and final layer alpha are not applied here.
+
+Geometry types drawn in this pass:
+
+- triangles.
+- triangle templates.
+- lines.
+- circles.
+- arcs.
+- thermals.
+- path regions.
+
+This pass is what prevents same-layer overlaps from changing color. The FBO is
+treated as the material mask for that user layer, not as the final colored
+image.
+
+### 6. Final Canvas Composition
+
+`composite_layers_to_target(...)` composites layer FBO textures into the final
+target, which can be the visible canvas or an offscreen framebuffer.
+
+Inputs:
+
+- `active_layer_ids`: layer order chosen by JS.
+- `color_data`: RGB or RGBA per active layer.
+- `alpha`: global alpha.
+- `blend_modes`: optional per-layer composite mode.
+- `clear_canvas`: whether to clear the target first.
+
+For each layer:
+
+- if `color_data` is RGBA, `layer_alpha = color_data.a * alpha`.
+- if `color_data` is RGB, `layer_alpha = alpha`.
+- the texture shader multiplies FBO alpha by the layer color alpha and emits
+  premultiplied color.
+
+Current blend mode meanings:
+
+- `0`: additive composition, `blend_func(ONE, ONE)`.
+- `1`: premultiplied source-over style composition,
+  `blend_func_separate(ONE, ONE_MINUS_SRC_ALPHA, ONE, ONE_MINUS_SRC_ALPHA)`.
+- `2`: clear/reduce destination using source alpha,
+  `blend_func_separate(ZERO, ONE_MINUS_SRC_ALPHA, ZERO, ONE_MINUS_SRC_ALPHA)`.
+
+Drill outline and fill/clear behavior relies on these modes.
+
+### 7. Screenshot and Headless Rendering
+
+Screenshot export uses the same renderer pipeline.
+
+- Single-image export renders one tile into an offscreen WebGL canvas.
+- Large export renders multiple tiles with `render_tile*()`.
+- Each tile still follows the layer FBO pass and final composite pass.
+- Measurement overlay is drawn later on a 2D canvas.
+
+### 8. Highlight Rendering
+
+Selected-feature highlight is an extra pass after normal layer composition.
+
+Flow:
+
+1. Normal layer rendering finishes.
+2. JS calls `render_interaction_highlight(layer_id, feature_id, camera...)`.
+3. Rust retrieves the stored `InteractionFeature`.
+4. Highlight shaders render the selected area, using stencil/blend state as
+   needed.
+
+The visible app render includes highlight after normal layer composition.
+Screenshot export intentionally omits selected-feature highlight and only draws
+measurements after the WebGL render.
+
+### 9. Performance Invariants
+
+- Geometry upload and layer FBO redraws happen only when needed.
+- Camera transform changes invalidate the layer FBO result.
+- Color, alpha, and layer order changes should only require the final composite
+  pass when possible.
+- Final alpha must not be applied during the per-geometry layer pass.
+- Layer display policy should be implemented at the FBO composite stage, not in
+  primitive drawing.


### PR DESCRIPTION
## Summary
- Add Blend / Stack layer rendering mode with Stack source-over compositing and hidden alpha control.
- Keep live rendering, picking order, drill clear/fill behavior, and screenshot export composition aligned.
- Add mobile long-press layer reorder with autoscroll/reorder animation and document the Rust/WASM pipeline.

## Validation
- node --check js/main.js js/screenshot-exporter.js js/dom-elements.js js/viewer-options.js js/layer-list.js
- git diff --check
- npm --prefix packages/wasm-gerber-renderer run check
- 3 parallel Codex subagent reviews on the final diff; no blockers found.