### PR TITLE
[codex] Add renderer options and interaction toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,34 @@
                   </div>
                   <div class="option-outline">
                     <div class="option-row">
+                      <span>Interaction</span>
+                      <div class="segmented-control" role="radiogroup" aria-label="Interaction data mode">
+                        <label>
+                          <input
+                            type="radio"
+                            id="interaction-mode-on"
+                            name="interaction-mode"
+                            value="on"
+                          />
+                          <span>On</span>
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            id="interaction-mode-off"
+                            name="interaction-mode"
+                            value="off"
+                          />
+                          <span>Off</span>
+                        </label>
+                      </div>
+                    </div>
+                    <div class="option-note">
+                      <span>Applied after refresh.</span>
+                    </div>
+                  </div>
+                  <div class="option-outline">
+                    <div class="option-row">
                       <span>Region Arcs</span>
                       <div class="segmented-control" role="radiogroup" aria-label="Region arc rendering mode">
                         <label>

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -103,6 +103,8 @@ export function getViewerElements(documentRef = document) {
       documentRef,
       "composite-mode-stack",
     ),
+    interactionModeOnInput: requireElement(documentRef, "interaction-mode-on"),
+    interactionModeOffInput: requireElement(documentRef, "interaction-mode-off"),
     regionArcExactInput: requireElement(documentRef, "region-arc-exact"),
     regionArcApproximateInput: requireElement(
       documentRef,

--- a/js/main.js
+++ b/js/main.js
@@ -70,6 +70,12 @@ const COMPOSITE_MODE_VALUES = new Set([
   COMPOSITE_MODE_BLEND,
   COMPOSITE_MODE_STACK,
 ]);
+const INTERACTION_MODE_ON = "on";
+const INTERACTION_MODE_OFF = "off";
+const INTERACTION_MODE_VALUES = new Set([
+  INTERACTION_MODE_ON,
+  INTERACTION_MODE_OFF,
+]);
 const LAZY_WHEEL_RENDER_DELAY_MS = 140;
 const LAYER_TOUCH_DRAG_DELAY_MS = 500;
 const LAYER_TOUCH_DRAG_CANCEL_PX = 8;
@@ -748,6 +754,9 @@ export class GerberViewer {
     this.compositeMode = COMPOSITE_MODE_VALUES.has(storedCompositeMode)
       ? storedCompositeMode
       : COMPOSITE_MODE_BLEND;
+    this.interactionsOptionEnabled =
+      this.viewerOptionsStore.get("interactionsEnabled") !== false;
+    this.interactionsEnabled = this.interactionsOptionEnabled;
     this.drawerController = new DrawerController({
       drawer: this.drawer,
       resizeHandle: this.resizeHandle,
@@ -1129,6 +1138,14 @@ export class GerberViewer {
       });
     }
 
+    for (const input of this.getInteractionModeInputs()) {
+      input.addEventListener("change", () => {
+        if (input.checked) {
+          this.setInteractionMode(input.value);
+        }
+      });
+    }
+
     // Alpha slider
     this.alphaSlider.addEventListener("input", (e) => {
       const alpha = parseInt(e.target.value) / 100;
@@ -1428,6 +1445,10 @@ export class GerberViewer {
     return [this.compositeModeBlendInput, this.compositeModeStackInput];
   }
 
+  getInteractionModeInputs() {
+    return [this.interactionModeOnInput, this.interactionModeOffInput];
+  }
+
   syncRenderingModeControls() {
     const renderingModeDisabled =
       this.isRendererBusy() || this.isViewportGestureActive();
@@ -1444,6 +1465,8 @@ export class GerberViewer {
       input.checked = input.value === this.compositeMode;
       input.disabled = this.isRendererBusy();
     }
+
+    this.syncInteractionModeControls();
 
     this.regionArcExactInput.checked = this.preserveArcRegions;
     this.regionArcApproximateInput.checked = !this.preserveArcRegions;
@@ -1466,6 +1489,16 @@ export class GerberViewer {
     for (const input of this.getPthPlatingInputs()) {
       input.checked = Number(input.value) === this.pthPlatingMicrometers;
       input.disabled = this.isRendererBusy();
+    }
+  }
+
+  syncInteractionModeControls(rendererBusy = this.isRendererBusy()) {
+    const mode = this.interactionsOptionEnabled
+      ? INTERACTION_MODE_ON
+      : INTERACTION_MODE_OFF;
+    for (const input of this.getInteractionModeInputs()) {
+      input.checked = input.value === mode;
+      input.disabled = rendererBusy;
     }
   }
 
@@ -1523,6 +1556,38 @@ export class GerberViewer {
     this.viewerOptionsStore.set("compositeMode", this.compositeMode);
     this.syncOptionControls();
     this.requestRender();
+    this.updateUiState();
+  }
+
+  setInteractionMode(mode) {
+    if (!INTERACTION_MODE_VALUES.has(mode)) {
+      this.syncOptionControls();
+      return;
+    }
+    if (this.isRendererBusy()) {
+      this.syncOptionControls();
+      return;
+    }
+
+    const nextEnabled = mode === INTERACTION_MODE_ON;
+    if (nextEnabled === this.interactionsOptionEnabled) {
+      return;
+    }
+
+    this.interactionsOptionEnabled = nextEnabled;
+    this.viewerOptionsStore.set(
+      "interactionsEnabled",
+      this.interactionsOptionEnabled,
+    );
+    this.syncOptionControls();
+    this.showNotification(
+      "Refresh required",
+      "info",
+      NOTIFICATION_DURATION_MS,
+      (messageElement) => {
+        messageElement.textContent = "Interaction setting will apply after refresh.";
+      },
+    );
     this.updateUiState();
   }
 
@@ -2002,6 +2067,7 @@ export class GerberViewer {
     for (const input of this.getCompositeModeInputs()) {
       input.disabled = rendererBusy;
     }
+    this.syncInteractionModeControls(rendererBusy);
     this.regionArcExactInput.disabled = rendererBusy;
     this.regionArcApproximateInput.disabled = rendererBusy;
     for (const input of this.getArcQualityInputs()) {

--- a/js/viewer-options.js
+++ b/js/viewer-options.js
@@ -6,6 +6,7 @@ const DEFAULT_VIEWER_OPTIONS = {
   pthPlatingMicrometers: 20,
   renderingMode: "lazy",
   compositeMode: "blend",
+  interactionsEnabled: true,
 };
 
 const ARC_TESSELLATION_QUALITIES = new Set(["low", "normal", "high"]);
@@ -83,6 +84,10 @@ export class ViewerOptionsStore {
         compositeMode: COMPOSITE_MODES.has(stored.compositeMode)
           ? stored.compositeMode
           : DEFAULT_VIEWER_OPTIONS.compositeMode,
+        interactionsEnabled:
+          typeof stored.interactionsEnabled === "boolean"
+            ? stored.interactionsEnabled
+            : DEFAULT_VIEWER_OPTIONS.interactionsEnabled,
       };
     } catch {
       return this.getDefaults();

--- a/packages/wasm-gerber-renderer/README.kr.md
+++ b/packages/wasm-gerber-renderer/README.kr.md
@@ -271,7 +271,8 @@ Batch API(`renderGerberToCanvas`, `renderGerberToPng`, `renderGerberToPngStream`
 - `arcTessellationQuality`: arc 근사 품질입니다. `0` low, `1` normal, `2` high이며 기본값은 `1`입니다.
 - `minimumFeaturePixels`: line/arc의 최소 렌더링 폭(px)입니다. 기본값은 `1`입니다.
 - `renderDrills`: NC drill 파일(`.drl`, `.nc`, `.xnc`, `.xln`)을 drill overlay로 렌더링합니다. 기본값은 `true`입니다.
-- `globalAlpha`: 명시적인 layer `alpha`가 없는 layer에 적용되는 opacity입니다. 기본값은 `0.7`입니다.
+- `globalAlpha`: `blend` 모드에서 명시적인 layer `alpha`가 없는 Gerber layer에 적용되는 opacity입니다. 기본값은 `0.7`입니다.
+- `compositeMode`: layer 합성 모드입니다. `"blend"` 또는 `"stack"`을 받으며 기본값은 `"blend"`입니다. `blend`는 alpha additive blending을 사용하고, `stack`은 입력 순서대로 그려 뒤 layer가 앞 layer를 덮으며 Gerber layer 기본 opacity는 `1`입니다.
 - `layerErrorMode`: `"skip"`은 남은 유효한 layer를 계속 렌더링하고, `"throw"`는 첫 실패에서 Promise를 reject합니다. 기본값은 `"skip"`입니다.
 - `onLayerError`: `"skip"` mode에서 건너뛴 layer를 받는 callback입니다. 전달 값은 `{ layer, name, error }`입니다.
 - `rendererOptions`: 브라우저 one-shot helper 전용입니다. 렌더러 생성 시 그대로 전달됩니다.
@@ -322,6 +323,7 @@ gerber-renderer top.gbr bottom.gbr \
   --background '#05070c' \
   --padding 32 \
   --alpha 0.7 \
+  --composite-mode blend \
   --minimum-feature-pixels 1
 ```
 
@@ -343,6 +345,7 @@ CLI 옵션:
 - `--padding <px>`: fit-to-view padding입니다. 기본값은 `0`입니다.
 - `--background <color>`: hex 또는 `rgb()`/`rgba()` 배경입니다. 생략하면 투명 출력입니다.
 - `--alpha <0-1>`: global layer opacity입니다. 기본값은 `0.7`입니다.
+- `--composite-mode <blend|stack>`: layer 합성 모드입니다. 기본값은 `blend`입니다.
 - `--minimum-feature-pixels <px>`: line/arc의 최소 렌더링 폭입니다. 기본값은 `1`입니다.
 - `--max-render-target-bytes <size>`: render target별 memory cap입니다. byte 또는 `512m`, `2g` 같은 suffix를 받습니다.
 - `--approx-region-arcs`: 렌더링 전에 region arc를 line segment로 변환합니다.

--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -296,7 +296,8 @@ load. If every layer fails, the operation rejects with the first layer error.
 - `arcTessellationQuality`: arc approximation quality, `0` low, `1` normal, `2` high. Defaults to `1`.
 - `minimumFeaturePixels`: minimum rendered line/arc width in screen pixels. Defaults to `1`.
 - `renderDrills`: renders NC drill files (`.drl`, `.nc`, `.xnc`, `.xln`) as drill overlays. Defaults to `true`.
-- `globalAlpha`: opacity for Gerber layers without an explicit layer `alpha`. Defaults to `0.7`; drill layers render at full opacity unless their own `alpha` is set.
+- `globalAlpha`: opacity for Gerber layers without an explicit layer `alpha` in `blend` mode. Defaults to `0.7`; drill layers render at full opacity unless their own `alpha` is set.
+- `compositeMode`: layer compositing mode, `"blend"` or `"stack"`. Defaults to `"blend"`. `blend` uses additive alpha blending; `stack` draws layers in order so later layers cover earlier layers and defaults Gerber layer opacity to `1`.
 - `layerErrorMode`: `"skip"` renders remaining valid layers; `"throw"` rejects on first failure. Defaults to `"skip"`.
 - `onLayerError`: callback for skipped layers in `"skip"` mode: `{ layer, name, error }`.
 - `rendererOptions`: browser one-shot helpers only; passed through when creating the renderer.
@@ -347,6 +348,7 @@ gerber-renderer top.gbr bottom.gbr \
   --background '#05070c' \
   --padding 32 \
   --alpha 0.7 \
+  --composite-mode blend \
   --minimum-feature-pixels 1
 ```
 
@@ -368,6 +370,7 @@ CLI options:
 - `--padding <px>`: fit-to-view padding. Defaults to `0`.
 - `--background <color>`: hex or `rgb()`/`rgba()` background. Omit for transparent output.
 - `--alpha <0-1>`: global Gerber layer opacity. Defaults to `0.7`; drill overlays render at full opacity.
+- `--composite-mode <blend|stack>`: layer compositing mode. Defaults to `blend`.
 - `--minimum-feature-pixels <px>`: minimum rendered line/arc width. Defaults to `1`.
 - `--max-render-target-bytes <size>`: per-render target memory cap. Accepts bytes or suffixes like `512m` and `2g`.
 - `--approx-region-arcs`: converts region arcs to line segments before rendering.

--- a/packages/wasm-gerber-renderer/README.zh-Hans.md
+++ b/packages/wasm-gerber-renderer/README.zh-Hans.md
@@ -271,7 +271,8 @@ try {
 - `arcTessellationQuality`：圆弧近似质量，`0` 为低、`1` 为标准、`2` 为高。默认 `1`。
 - `minimumFeaturePixels`：线段/圆弧的最小渲染宽度，单位为屏幕像素。默认 `1`。
 - `renderDrills`：把 NC drill 文件（`.drl`、`.nc`、`.xnc`、`.xln`）渲染为钻孔叠加层。默认 `true`。
-- `globalAlpha`：没有显式图层 `alpha` 时使用的透明度。默认 `0.7`。
+- `globalAlpha`：`blend` 模式下没有显式图层 `alpha` 的 Gerber 图层透明度。默认 `0.7`。
+- `compositeMode`：图层合成模式，取 `"blend"` 或 `"stack"`。默认 `"blend"`。`blend` 使用 alpha additive blending；`stack` 按输入顺序绘制，后面的图层覆盖前面的图层，Gerber 图层默认透明度为 `1`。
 - `layerErrorMode`：`"skip"` 会继续渲染剩余有效图层；`"throw"` 会在第一次失败时中断。默认 `"skip"`。
 - `onLayerError`：`"skip"` 模式下接收被跳过图层的回调函数，参数为 `{ layer, name, error }`。
 - `rendererOptions`：仅用于浏览器一次性辅助函数；创建渲染器时会原样传入。
@@ -322,6 +323,7 @@ gerber-renderer top.gbr bottom.gbr \
   --background '#05070c' \
   --padding 32 \
   --alpha 0.7 \
+  --composite-mode blend \
   --minimum-feature-pixels 1
 ```
 
@@ -343,6 +345,7 @@ CLI 选项：
 - `--padding <px>`：自适应视图时使用的像素内边距。默认 `0`。
 - `--background <color>`：hex 或 `rgb()`/`rgba()` 背景。不指定则为透明输出。
 - `--alpha <0-1>`：全局图层透明度。默认 `0.7`。
+- `--composite-mode <blend|stack>`：图层合成模式。默认 `blend`。
 - `--minimum-feature-pixels <px>`：线段/圆弧的最小渲染宽度。默认 `1`。
 - `--max-render-target-bytes <size>`：每个渲染目标的内存上限。接受字节数或 `512m`、`2g` 这样的后缀。
 - `--approx-region-arcs`：渲染前把 region 圆弧转换为线段。

--- a/packages/wasm-gerber-renderer/README.zh-Hant.md
+++ b/packages/wasm-gerber-renderer/README.zh-Hant.md
@@ -271,7 +271,8 @@ try {
 - `arcTessellationQuality`：圓弧近似品質，`0` 為低、`1` 為標準、`2` 為高。預設 `1`。
 - `minimumFeaturePixels`：線段/圓弧的最小渲染寬度，單位為螢幕像素。預設 `1`。
 - `renderDrills`：把 NC drill 檔案（`.drl`、`.nc`、`.xnc`、`.xln`）渲染為鑽孔疊加層。預設 `true`。
-- `globalAlpha`：沒有明確圖層 `alpha` 時使用的透明度。預設 `0.7`。
+- `globalAlpha`：`blend` 模式下沒有明確圖層 `alpha` 的 Gerber 圖層透明度。預設 `0.7`。
+- `compositeMode`：圖層合成模式，取 `"blend"` 或 `"stack"`。預設 `"blend"`。`blend` 使用 alpha additive blending；`stack` 按輸入順序繪製，後面的圖層覆蓋前面的圖層，Gerber 圖層預設透明度為 `1`。
 - `layerErrorMode`：`"skip"` 會繼續渲染剩餘有效圖層；`"throw"` 會在第一次失敗時中斷。預設 `"skip"`。
 - `onLayerError`：`"skip"` 模式下接收被跳過圖層的回呼函式，參數為 `{ layer, name, error }`。
 - `rendererOptions`：僅用於瀏覽器一次性輔助函式；建立渲染器時會原樣傳入。
@@ -322,6 +323,7 @@ gerber-renderer top.gbr bottom.gbr \
   --background '#05070c' \
   --padding 32 \
   --alpha 0.7 \
+  --composite-mode blend \
   --minimum-feature-pixels 1
 ```
 
@@ -343,6 +345,7 @@ CLI 選項：
 - `--padding <px>`：自動適配視圖時使用的像素內邊距。預設 `0`。
 - `--background <color>`：hex 或 `rgb()`/`rgba()` 背景。不指定則為透明輸出。
 - `--alpha <0-1>`：全域圖層透明度。預設 `0.7`。
+- `--composite-mode <blend|stack>`：圖層合成模式。預設 `blend`。
 - `--minimum-feature-pixels <px>`：線段/圓弧的最小渲染寬度。預設 `1`。
 - `--max-render-target-bytes <size>`：每個渲染目標的記憶體上限。接受位元組數或 `512m`、`2g` 這類後綴。
 - `--approx-region-arcs`：渲染前把 region 圓弧轉換為線段。

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -49,7 +49,8 @@ gerber-renderer top.gbr bottom.gbr mask.gbr \
   --height 1000 \
   --background '#05070c' \
   --padding 32 \
-  --alpha 0.7
+  --alpha 0.7 \
+  --composite-mode blend
 ```
 
 Render an archive:
@@ -65,6 +66,7 @@ Useful CLI options:
 - `--background <color>` accepts hex or `rgb()`/`rgba()`; omit for transparent output.
 - `--padding <px>` adds fit-to-view padding.
 - `--alpha <0-1>` sets global Gerber layer opacity; drill overlays render at full opacity.
+- `--composite-mode <blend|stack>` sets additive blending or ordered stack compositing.
 - `--minimum-feature-pixels <px>` keeps thin lines/arcs visible.
 - `--max-render-target-bytes <size>` caps per-render target memory, e.g. `512m` or `2g`.
 - `--approx-region-arcs` uses faster approximate region arcs.
@@ -97,6 +99,7 @@ await renderGerberToPngFile(
     height: 1000,
     background: "#05070c",
     padding: 32,
+    compositeMode: "blend",
     minimumFeaturePixels: 1,
     onLayerError: ({ name, error }) => {
       console.warn(`Skipped ${name}: ${error instanceof Error ? error.message : error}`);
@@ -275,6 +278,7 @@ Use `onLayerError` to report skipped layers. Use `layerErrorMode: "throw"` when 
 - `flipX`, `flipY`: mirror the output around the frame center.
 - `view`: manual `{ zoomX, zoomY, offsetX, offsetY }`.
 - `globalAlpha`: opacity for Gerber layers without explicit layer `alpha`.
+- `compositeMode`: `"blend"` for additive alpha blending or `"stack"` for ordered source-over compositing.
 - `minimumFeaturePixels`: minimum visible line/arc width.
 - `renderDrills`: render NC drill files as drill overlays; set `false` to skip them.
 - `preserveArcRegions`: defaults to `true`; set `false` for approximate region arcs.

--- a/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
+++ b/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
@@ -14,6 +14,7 @@ Options:
   --padding <px>                   Fit padding in pixels (default: 0)
   --background <color>             Background color, e.g. #05070c (default: transparent)
   --alpha <0-1>                    Global layer alpha (default: 0.7)
+  --composite-mode <blend|stack>   Layer compositing mode (default: blend)
   --minimum-feature-pixels <px>    Minimum line/arc display width (default: 1)
   --max-render-target-bytes <size> Per-render target memory cap, e.g. 2g, 512m
   --approx-region-arcs             Approximate region arcs before rendering (default: false)
@@ -100,6 +101,8 @@ function parseArgs(args) {
       frameOptions.background = readOptionValue(args, ++index, arg);
     } else if (arg === "--alpha") {
       frameOptions.globalAlpha = readNumber(args, ++index, arg);
+    } else if (arg === "--composite-mode") {
+      frameOptions.compositeMode = readCompositeMode(args, ++index, arg);
     } else if (arg === "--minimum-feature-pixels") {
       frameOptions.minimumFeaturePixels = readNumber(args, ++index, arg);
     } else if (arg === "--max-render-target-bytes") {
@@ -124,6 +127,14 @@ function parseArgs(args) {
   }
 
   return { inputs, output, frameOptions, showSkill };
+}
+
+function readCompositeMode(args, index, flag) {
+  const value = readOptionValue(args, index, flag);
+  if (value === "blend" || value === "stack") {
+    return value;
+  }
+  throw new Error(`${flag} must be blend or stack.`);
 }
 
 function inferOutputPath(inputs) {

--- a/packages/wasm-gerber-renderer/index.d.ts
+++ b/packages/wasm-gerber-renderer/index.d.ts
@@ -20,6 +20,7 @@ export type GerberLayer =
 export type RGBColor = [number, number, number];
 export type RGBAColor = [number, number, number, number];
 export type LayerKind = "gerber" | "drill";
+export type CompositeMode = "blend" | "stack";
 
 export type RendererOptions = {
   wasmModule?: unknown;
@@ -49,6 +50,7 @@ export type FrameOptions = {
   minimumFeaturePixels?: number;
   renderDrills?: boolean;
   globalAlpha?: number;
+  compositeMode?: CompositeMode;
   rendererOptions?: RendererOptions;
   onLayerError?: (failure: LayerFailure) => void;
   layerErrorMode?: LayerErrorMode;

--- a/packages/wasm-gerber-renderer/index.js
+++ b/packages/wasm-gerber-renderer/index.js
@@ -1,5 +1,6 @@
 import {
   DEFAULT_BACKGROUND,
+  COMPOSITE_MODE_STACK,
   FrameState,
   PNG_SIGNATURE,
   addDrillLayerToProcessor,
@@ -376,6 +377,7 @@ export class GerberRenderer {
       frame.layers,
       globalAlpha,
       frame.options.background,
+      frame.options.compositeMode,
     );
     const activeLayerIds = new Uint32Array(renderEntries.map((entry) => entry.layerId));
     const blendModes = new Uint8Array(renderEntries.map((entry) => entry.blendMode));
@@ -391,7 +393,7 @@ export class GerberRenderer {
       );
       if (blendModes.some((mode) => mode !== 0)) {
         if (typeof frame.processor.render_with_clear_and_blend_modes !== "function") {
-          throw new Error("Drill rendering requires an updated WASM renderer.");
+          throw new Error("Stack compositing and drill rendering require an updated WASM renderer.");
         }
         frame.processor.render_with_clear_and_blend_modes(
           activeLayerIds,
@@ -422,9 +424,10 @@ export class GerberRenderer {
       }
       if (
         frame.layers.some((layer) => layer.alpha != null) ||
-        frame.layers.some((layer) => isDrillLayerKind(layer.kind))
+        frame.layers.some((layer) => isDrillLayerKind(layer.kind)) ||
+        frame.options.compositeMode === COMPOSITE_MODE_STACK
       ) {
-        throw new Error("Layer alpha requires an updated WASM renderer.");
+        throw new Error("Layer alpha, stack compositing, and drill rendering require an updated WASM renderer.");
       }
       const colorData = new Float32Array(
         renderEntries.flatMap((entry) => entry.color),
@@ -502,17 +505,20 @@ export class GerberRenderer {
   }
 }
 
-function createRenderEntries(layers, globalAlpha, background) {
+function createRenderEntries(layers, globalAlpha, background, compositeMode) {
   const entries = [];
   const drillColors = resolveDrillRenderColors(background);
+  const gerberBlendMode = compositeMode === COMPOSITE_MODE_STACK ? 1 : 0;
+  const gerberDefaultAlpha =
+    compositeMode === COMPOSITE_MODE_STACK ? 1 : globalAlpha;
 
   for (const layer of layers) {
     if (!isDrillLayerKind(layer.kind)) {
       entries.push({
         layerId: layer.layerId,
         color: layer.color,
-        alpha: resolveLayerAlpha(layer.alpha, globalAlpha),
-        blendMode: 0,
+        alpha: resolveLayerAlpha(layer.alpha, gerberDefaultAlpha),
+        blendMode: gerberBlendMode,
       });
     }
   }

--- a/packages/wasm-gerber-renderer/node.d.ts
+++ b/packages/wasm-gerber-renderer/node.d.ts
@@ -51,6 +51,7 @@ export type GerberNodePreparedLayer = {
 export type RGBColor = [number, number, number];
 export type RGBAColor = [number, number, number, number];
 export type LayerKind = "gerber" | "drill";
+export type CompositeMode = "blend" | "stack";
 export type PngRenderStrategy = "auto" | "full-frame" | "stream";
 
 export type NodeRendererOptions = {
@@ -85,6 +86,7 @@ export type NodeFrameOptions = {
   minimumFeaturePixels?: number;
   renderDrills?: boolean;
   globalAlpha?: number;
+  compositeMode?: CompositeMode;
   maxBandBytes?: number;
   maxFullFrameBytes?: number;
   maxRenderTargetBytes?: number;

--- a/packages/wasm-gerber-renderer/node.js
+++ b/packages/wasm-gerber-renderer/node.js
@@ -9,6 +9,7 @@ import { finished } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createDeflate } from "node:zlib";
 import {
+  COMPOSITE_MODE_STACK,
   DEFAULT_ARC_TESSELLATION_QUALITY,
   FrameState,
   PNG_SIGNATURE,
@@ -487,6 +488,7 @@ class NodeFrameState extends FrameState {
       preserveArcRegions: this.options.preserveArcRegions,
       arcTessellationQuality: this.options.arcTessellationQuality,
       minimumFeaturePixels: this.options.minimumFeaturePixels,
+      compositeMode: this.options.compositeMode,
       maxFullFrameBytes: this.options.maxFullFrameBytes,
       maxRenderTargetBytes: this.options.maxRenderTargetBytes,
       framebufferMemorySafetyFactor: this.options.framebufferMemorySafetyFactor,
@@ -1022,7 +1024,7 @@ function renderStreamBand(state, width, height, tileY, view, bandRowBytes) {
     const readX = tileX - renderTileX;
     if (hasBlendModes(state.renderContext.blendModes)) {
       if (typeof state.renderContext.processor.render_tile_with_blend_modes !== "function") {
-        throw new Error("Drill rendering requires an updated WASM renderer.");
+        throw new Error("Stack compositing and drill rendering require an updated WASM renderer.");
       }
       state.renderContext.processor.render_tile_with_blend_modes(
         state.renderContext.activeLayerIds,
@@ -1168,7 +1170,7 @@ function renderPlanPixels(renderContext, plan) {
       typeof renderContext.processor.render_pixels_with_clear_and_blend_modes !==
       "function"
     ) {
-      throw new Error("Drill rendering requires an updated WASM renderer.");
+      throw new Error("Stack compositing and drill rendering require an updated WASM renderer.");
     }
     return renderContext.processor.render_pixels_with_clear_and_blend_modes(
       renderContext.activeLayerIds,
@@ -1219,6 +1221,9 @@ function createPlanRenderEntries(processor, plan) {
   const drillOutlineEntries = [];
   const drillFillEntries = [];
   const drillColors = resolveDrillRenderColors(plan.background);
+  const gerberBlendMode = plan.compositeMode === COMPOSITE_MODE_STACK ? 1 : 0;
+  const gerberDefaultAlpha =
+    plan.compositeMode === COMPOSITE_MODE_STACK ? 1 : plan.globalAlpha;
 
   for (const layer of plan.layers) {
     if (isDrillLayerKind(layer.kind)) {
@@ -1244,8 +1249,8 @@ function createPlanRenderEntries(processor, plan) {
     gerberEntries.push({
       layerId: addPlanLayerToProcessor(processor, layer),
       color: layer.color,
-      alpha: resolveLayerAlpha(layer.alpha, plan.globalAlpha),
-      blendMode: 0,
+      alpha: resolveLayerAlpha(layer.alpha, gerberDefaultAlpha),
+      blendMode: gerberBlendMode,
     });
   }
 

--- a/packages/wasm-gerber-renderer/shared.js
+++ b/packages/wasm-gerber-renderer/shared.js
@@ -22,6 +22,9 @@ export const DEFAULT_BACKGROUND = null;
 export const DEFAULT_GLOBAL_ALPHA = 0.7;
 export const DEFAULT_MINIMUM_FEATURE_PIXELS = 1;
 export const DEFAULT_ARC_TESSELLATION_QUALITY = 1;
+export const DEFAULT_COMPOSITE_MODE = "blend";
+export const COMPOSITE_MODE_BLEND = "blend";
+export const COMPOSITE_MODE_STACK = "stack";
 export const LAYER_KIND_GERBER = "gerber";
 export const LAYER_KIND_DRILL = "drill";
 
@@ -206,6 +209,8 @@ export class FrameState {
 
   toResult(view) {
     const globalAlpha = clamp01(numberOrDefault(this.options.globalAlpha, 1));
+    const gerberDefaultAlpha =
+      this.options.compositeMode === COMPOSITE_MODE_STACK ? 1 : globalAlpha;
     return {
       width: this.options.width,
       height: this.options.height,
@@ -219,7 +224,7 @@ export class FrameState {
         color: layer.color,
         alpha: resolveLayerAlpha(
           layer.alpha,
-          isDrillLayerKind(layer.kind) ? 1 : globalAlpha,
+          isDrillLayerKind(layer.kind) ? 1 : gerberDefaultAlpha,
         ),
       })),
     };
@@ -246,8 +251,18 @@ export function createBaseFrameOptions(frameOptions = {}) {
     ),
     renderDrills: frameOptions.renderDrills !== false,
     globalAlpha: numberOrDefault(frameOptions.globalAlpha, DEFAULT_GLOBAL_ALPHA),
+    compositeMode: normalizeCompositeMode(frameOptions.compositeMode),
     colors: DEFAULT_COLORS.map((color) => [...color]),
   };
+}
+
+export function normalizeCompositeMode(value) {
+  if (value == null) return DEFAULT_COMPOSITE_MODE;
+  const mode = String(value);
+  if (mode === COMPOSITE_MODE_BLEND || mode === COMPOSITE_MODE_STACK) {
+    return mode;
+  }
+  throw new TypeError("compositeMode must be 'blend' or 'stack'.");
 }
 
 export async function loadWasmJsModule(rendererOptions, options = {}) {

--- a/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
+++ b/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
@@ -9,7 +9,11 @@ import {
 } from "../../../js/source-loader.js";
 import { GerberRenderer } from "../index.js";
 import { fileLayer, NodeGerberRenderer } from "../node.js";
-import { normalizeLayerKind } from "../shared.js";
+import {
+  createBaseFrameOptions,
+  normalizeCompositeMode,
+  normalizeLayerKind,
+} from "../shared.js";
 
 const DRILL_CONTENT = `M48
 METRIC,LZ
@@ -125,4 +129,15 @@ test("renderDrills false skips drill sources before reading", async () => {
     { renderDrills: false },
   );
   assert.equal(nodeRecord, null);
+});
+
+test("package composite mode defaults to blend and validates explicit values", () => {
+  assert.equal(createBaseFrameOptions().compositeMode, "blend");
+  assert.equal(createBaseFrameOptions({ compositeMode: "stack" }).compositeMode, "stack");
+  assert.equal(normalizeCompositeMode("blend"), "blend");
+  assert.equal(normalizeCompositeMode("stack"), "stack");
+  assert.throws(
+    () => normalizeCompositeMode("overlay"),
+    /compositeMode must be 'blend' or 'stack'/,
+  );
 });


### PR DESCRIPTION
## Summary

- Add `compositeMode: "blend" | "stack"` to the `wasm-gerber-renderer` package API, CLI, docs, and types.
- Add a viewer Interaction On/Off option that defaults to On and is persisted for application after refresh.
- Keep interaction mode changes refresh-only so the active WASM parser/processor is not reparsed immediately.

## Validation

- Ran 4 parallel read-only subagent reviews on the full `origin/main` diff.
- Treated one reported live-state concern as non-actionable because refresh-only application is the requested behavior.
- `node --check` on touched viewer and package JS files.
- `git diff --check origin/main`.
- `npm --prefix packages/wasm-gerber-renderer run check`.

## Notes

- Interaction Off is intended to reduce WASM memory use after the next page refresh by avoiding interaction parsing data collection.