### PR TITLE
Refine inverted layer and outline status UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -741,6 +741,18 @@ button {
   font-weight: 700;
 }
 
+.outline-source-status {
+  display: block;
+  padding: 0 14px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 500;
+}
+
 .outline-source-control select {
   width: 100%;
   min-width: 0;
@@ -765,7 +777,8 @@ button {
   color: #f8fafc;
 }
 
-.side-panel.collapsed .outline-source-control {
+.side-panel.collapsed .outline-source-control,
+.side-panel.collapsed .outline-source-status {
   display: none;
 }
 
@@ -896,8 +909,12 @@ button {
 .layer-checkbox {
   width: 18px;
   height: 18px;
-  accent-color: var(--accent);
+  accent-color: #3b82f6;
   cursor: pointer;
+}
+
+.layer-item-inverted .layer-checkbox {
+  accent-color: #ea580c;
 }
 
 .layer-label {

--- a/index.html
+++ b/index.html
@@ -239,11 +239,12 @@
                 <ul class="layer-list" id="layer-list"></ul>
                 <label class="outline-source-control" for="board-outline-select">
                   <span>Board Outline</span>
-                  <select id="board-outline-select">
+                  <select id="board-outline-select" aria-describedby="board-outline-status">
                     <option value="auto">Auto</option>
                     <option value="bounds">Bounds</option>
                   </select>
                 </label>
+                <span class="outline-source-status" id="board-outline-status" role="status" aria-live="polite">Auto fallback: Bounds</span>
               </div>
             </section>
 

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -76,6 +76,7 @@ export function getViewerElements(documentRef = document) {
     alphaSlider: requireElement(documentRef, "alpha-slider"),
     alphaValue: requireElement(documentRef, "alpha-value"),
     boardOutlineSelect: requireElement(documentRef, "board-outline-select"),
+    boardOutlineStatus: requireElement(documentRef, "board-outline-status"),
     layerList: requireElement(documentRef, "layer-list"),
     diagnosticList: requireElement(documentRef, "diagnostic-list"),
     notification,

--- a/js/layer-list.js
+++ b/js/layer-list.js
@@ -51,6 +51,9 @@ function createLayerItem({
 }) {
   const item = document.createElement("li");
   item.className = "layer-item";
+  if (layer.inverted) {
+    item.classList.add("layer-item-inverted");
+  }
   item.dataset.layerId = layer.id;
   item.dataset.layerIndex = String(index);
   item.draggable = true;
@@ -72,6 +75,10 @@ function createLayerItem({
   checkbox.type = "checkbox";
   checkbox.className = "layer-checkbox";
   checkbox.checked = layer.visible;
+  checkbox.setAttribute(
+    "aria-label",
+    `${layer.name} visibility${layer.inverted ? " (inverted)" : ""}`,
+  );
   checkbox.addEventListener("change", () => {
     onVisibilityChange(layer, checkbox.checked);
   });
@@ -138,6 +145,7 @@ function createDrillItem({
   checkbox.type = "checkbox";
   checkbox.className = "layer-checkbox";
   checkbox.checked = layer.visible;
+  checkbox.setAttribute("aria-label", `${layer.name} visibility`);
   checkbox.addEventListener("change", () => {
     onVisibilityChange(layer, checkbox.checked);
   });

--- a/js/main.js
+++ b/js/main.js
@@ -65,7 +65,7 @@ const COMPOSITE_MODE_VALUES = new Set([
   COMPOSITE_MODE_BLEND,
   COMPOSITE_MODE_STACK,
 ]);
-const DEFAULT_BOARD_OUTLINE_BOUNDS_MARGIN_MM = 20;
+const DEFAULT_BOARD_OUTLINE_BOUNDS_MARGIN_MM = 10;
 const MM_PER_INCH = 25.4;
 const BOARD_OUTLINE_BOUNDS_MARGIN_UNIT_MM = "mm";
 const BOARD_OUTLINE_BOUNDS_MARGIN_UNIT_INCH = "inch";
@@ -1962,10 +1962,73 @@ export class GerberViewer {
     );
     this.boardOutlineSelect.value = this.boardOutlineSelection;
     this.boardOutlineSelect.disabled = this.isRendererBusy() || this.layers.length === 0;
+    this.syncBoardOutlineStatus();
 
     if (currentValue !== this.boardOutlineSelection) {
       this.clearAllInvertedLayerCaches();
       this.requestRender();
+    }
+  }
+
+  syncBoardOutlineStatus() {
+    let statusText = "";
+    if (this.layers.length === 0) {
+      statusText = "No layers";
+      this.setBoardOutlineStatusText(statusText);
+      return;
+    }
+    const boundsStatusLabel = this.getBoardOutlineBoundsStatusLabel();
+
+    if (this.boardOutlineSelection === BOARD_OUTLINE_AUTO) {
+      const outlineLayer = this.findAutomaticBoardOutlineLayer();
+      if (outlineLayer) {
+        const selfFallback = outlineLayer.inverted
+          ? `, self uses ${boundsStatusLabel}`
+          : "";
+        statusText = `Auto outline: ${outlineLayer.name}${selfFallback}`;
+      } else {
+        statusText = `Auto fallback: ${boundsStatusLabel}`;
+      }
+      this.setBoardOutlineStatusText(statusText);
+      return;
+    }
+
+    if (this.boardOutlineSelection === BOARD_OUTLINE_BOUNDS) {
+      statusText = `Selected: ${boundsStatusLabel}`;
+      this.setBoardOutlineStatusText(statusText);
+      return;
+    }
+
+    const selectedLayer = this.layers.find(
+      (layer) => layer.id === this.boardOutlineSelection,
+    );
+    if (selectedLayer) {
+      const selfFallback = selectedLayer.inverted
+        ? `, self uses ${boundsStatusLabel}`
+        : "";
+      statusText = `Selected outline: ${selectedLayer.name}${selfFallback}`;
+    }
+    this.setBoardOutlineStatusText(statusText);
+  }
+
+  getBoardOutlineBoundsStatusLabel() {
+    const bounds = this.getVisibleGerberBounds();
+    if (!bounds) {
+      return "Bounds unavailable";
+    }
+    return `Bounds, margin ${this.getBoardOutlineBoundsMarginStatusLabel()}`;
+  }
+
+  getBoardOutlineBoundsMarginStatusLabel() {
+    return `${formatBoardOutlineBoundsMarginInputValue(
+      this.boardOutlineBoundsMarginMm,
+      this.boardOutlineBoundsMarginUnit,
+    )} ${this.boardOutlineBoundsMarginUnit}`;
+  }
+
+  setBoardOutlineStatusText(text) {
+    if (this.boardOutlineStatus.textContent !== text) {
+      this.boardOutlineStatus.textContent = text;
     }
   }
 
@@ -2287,6 +2350,7 @@ export class GerberViewer {
       this.boardOutlineBoundsMarginUnit,
     );
     this.syncOptionControls();
+    this.syncBoardOutlineStatus();
   }
 
   setDrillOutlinePixels(pixels) {
@@ -4987,6 +5051,7 @@ export class GerberViewer {
               layer,
               `${sourceKey}:fallback`,
               `${message}; using visible layer bounds instead.`,
+              "Inverted layer fallback",
             );
             return layer.invertedLayerId;
           } catch (fallbackError) {
@@ -5009,10 +5074,10 @@ export class GerberViewer {
     }
   }
 
-  reportInvertedLayerWarningOnce(layer, key, message) {
+  reportInvertedLayerWarningOnce(layer, key, message, title = "Inverted layer skipped") {
     if (layer.invertedErrorKey === key) return;
     layer.invertedErrorKey = key;
-    this.addDiagnostic("warning", `Inverted layer skipped: ${layer.name}`, message);
+    this.addDiagnostic("warning", `${title}: ${layer.name}`, message);
   }
 
   removeInvertedLayerCache(layer) {

--- a/js/screenshot-exporter.js
+++ b/js/screenshot-exporter.js
@@ -572,7 +572,7 @@ export class ScreenshotExporter {
       rawBoardOutlineBoundsMarginMm,
     )
       ? Math.max(0, rawBoardOutlineBoundsMarginMm)
-      : 20;
+      : 10;
     for (const layer of layers) {
       if (typeof layer.sourceContent !== "string") {
         throw new Error("Reload files before using high-resolution screenshot export.");

--- a/js/viewer-options.js
+++ b/js/viewer-options.js
@@ -2,7 +2,7 @@ const DEFAULT_VIEWER_OPTIONS = {
   preserveArcRegions: true,
   arcTessellationQuality: "normal",
   minimumFeaturePixels: 1,
-  boardOutlineBoundsMarginMm: 20,
+  boardOutlineBoundsMarginMm: 10,
   boardOutlineBoundsMarginUnit: "mm",
   drillOutlinePixels: 0,
   pthPlatingMicrometers: 20,


### PR DESCRIPTION
## Summary
- Adjust layer visibility checkbox colors so inverted layers use a darker orange and normal layers use blue
- Show the currently resolved Board Outline status below the selector
- Include Bounds margin in the Board Outline status when Bounds is used
- Change the default Bounds margin from 20 mm to 10 mm
- Improve checkbox accessibility labels and avoid repeated live-region announcements

## Notes
- No extra inverted-layer badge or icon was added
- Auto outline status now distinguishes outline selection from Bounds fallback availability

## Checks
- node --check js/main.js
- node --check js/layer-list.js
- node --check js/screenshot-exporter.js
- node --check js/viewer-options.js
- git diff --check
- node --test packages/wasm-gerber-renderer/test/layer-kind.test.mjs
