### PR TITLE
Load unknown Gerber files from ZIP archives

### DIFF
--- a/js/file-utils.js
+++ b/js/file-utils.js
@@ -20,6 +20,34 @@ export function isSupportedLayerPath(path) {
   return isSupportedGerberPath(path) || isSupportedDrillPath(path);
 }
 
+export function isLikelyTextBytes(bytes) {
+  const sampleLength = Math.min(bytes?.length ?? 0, 8192);
+  if (sampleLength === 0) {
+    return false;
+  }
+
+  let suspicious = 0;
+  for (let index = 0; index < sampleLength; index++) {
+    const byte = bytes[index];
+    if (byte === 0) {
+      return false;
+    }
+    if (
+      byte === 9 ||
+      byte === 10 ||
+      byte === 12 ||
+      byte === 13 ||
+      (byte >= 32 && byte <= 126) ||
+      byte >= 128
+    ) {
+      continue;
+    }
+    suspicious += 1;
+  }
+
+  return suspicious / sampleLength <= 0.01;
+}
+
 export function getLayerSourceKind(path, content = "") {
   if (isSupportedDrillPath(path)) {
     return "drill";
@@ -28,6 +56,25 @@ export function getLayerSourceKind(path, content = "") {
     return "drill";
   }
   return "gerber";
+}
+
+export function looksLikeGerberContent(content) {
+  const text = String(content ?? "").slice(0, 65536).toUpperCase();
+  if (!text.trim()) {
+    return false;
+  }
+
+  const markerCount = [
+    text.includes("%FS"),
+    text.includes("%MO"),
+    /%ADD\d+/.test(text),
+    /(?:^|\*)G0?[123]\*/.test(text),
+    /(?:^|\*)D0?[123]\*/.test(text),
+    /(?:^|\*)M02\*/.test(text),
+    /[XY][+\-]?\d+/.test(text),
+  ].filter(Boolean).length;
+
+  return markerCount >= 3;
 }
 
 export function isArchiveMetadataPath(path) {

--- a/js/source-loader.js
+++ b/js/source-loader.js
@@ -3,9 +3,14 @@ import {
   isAmbiguousDrdPath,
   getLayerSourceKind,
   isArchiveMetadataPath,
+  isLikelyTextBytes,
   isSupportedLayerPath,
   isZipFile,
+  looksLikeDrillContent,
+  looksLikeGerberContent,
 } from "./file-utils.js";
+
+const UNKNOWN_ZIP_LAYER_SNIFF_LINES = 30;
 
 export function getInitialSourceUrl(search = globalThis.location?.search ?? "") {
   const params = new URLSearchParams(search);
@@ -212,8 +217,7 @@ async function collectZipLayerSources(
       .filter(
         (entry) =>
           !entry.dir &&
-          !isArchiveMetadataPath(entry.name) &&
-          isSupportedLayerPath(entry.name),
+          !isArchiveMetadataPath(entry.name),
       )
       .sort((a, b) =>
         a.name.localeCompare(b.name, undefined, {
@@ -222,7 +226,17 @@ async function collectZipLayerSources(
         }),
       );
 
-    if (entries.length === 0) {
+    const sources = [];
+    for (const entry of entries) {
+      const source = isSupportedLayerPath(entry.name)
+        ? await createKnownZipLayerSource(entry, file.name, onArchiveWarning)
+        : await createUnknownZipLayerSource(entry, file.name, onArchiveWarning);
+      if (source) {
+        sources.push(source);
+      }
+    }
+
+    if (sources.length === 0) {
       onArchiveWarning(
         file.name,
         "No supported layer files found in archive",
@@ -230,31 +244,7 @@ async function collectZipLayerSources(
       return [];
     }
 
-    onArchiveInfo(file.name, `${entries.length} layer files found in archive`);
-
-    const sources = [];
-    for (const entry of entries) {
-      const readText = createSharedTextReader((onProgress = () => {}) =>
-        readZipEntryText(entry, onProgress),
-      );
-      let preview = "";
-      if (isAmbiguousDrdPath(entry.name)) {
-        try {
-          preview = await readZipEntryText(entry);
-        } catch (_error) {
-          onArchiveWarning(
-            file.name,
-            `Could not inspect ${getBaseFileName(entry.name)}; loading as Gerber`,
-          );
-        }
-      }
-      sources.push({
-        name: getBaseFileName(entry.name),
-        kind: getLayerSourceKind(entry.name, preview),
-        sizeBytes: getZipEntrySizeBytes(entry),
-        readText,
-      });
-    }
+    onArchiveInfo(file.name, `${sources.length} layer files found in archive`);
 
     return sources;
   } catch (error) {
@@ -263,10 +253,104 @@ async function collectZipLayerSources(
   }
 }
 
+async function createKnownZipLayerSource(entry, archiveName, onArchiveWarning) {
+  const readText = createSharedTextReader((onProgress = () => {}) =>
+    readZipEntryText(entry, onProgress),
+  );
+  let preview = "";
+  if (isAmbiguousDrdPath(entry.name)) {
+    try {
+      preview = await readZipEntryText(entry);
+    } catch (_error) {
+      onArchiveWarning(
+        archiveName,
+        `Could not inspect ${getBaseFileName(entry.name)}; loading as Gerber`,
+      );
+    }
+  }
+
+  return {
+    name: getBaseFileName(entry.name),
+    kind: getLayerSourceKind(entry.name, preview),
+    sizeBytes: getZipEntrySizeBytes(entry),
+    readText,
+  };
+}
+
+async function createUnknownZipLayerSource(entry, archiveName, onArchiveWarning) {
+  let bytes;
+  try {
+    bytes = await readZipEntryBytes(entry);
+  } catch (_error) {
+    onArchiveWarning(
+      archiveName,
+      `Could not inspect ${getBaseFileName(entry.name)}; skipping unknown file`,
+    );
+    return null;
+  }
+
+  const headBytes = getHeadLineBytes(bytes, UNKNOWN_ZIP_LAYER_SNIFF_LINES);
+  if (!isLikelyTextBytes(headBytes)) {
+    return null;
+  }
+
+  const headText = decodeZipEntryText(headBytes);
+  const looksLikeDrill = looksLikeDrillContent(headText);
+  if (!looksLikeDrill && !looksLikeGerberContent(headText)) {
+    return null;
+  }
+  const sizeBytes = getZipEntrySizeBytes(entry) ?? bytes.byteLength;
+
+  return {
+    name: getBaseFileName(entry.name),
+    kind: looksLikeDrill ? "drill" : "gerber",
+    sizeBytes,
+    readText: createSharedTextReader((onProgress = () => {}) =>
+      readZipEntryText(entry, onProgress),
+    ),
+  };
+}
+
 function readZipEntryText(entry, onProgress = () => {}) {
   return entry.async("string", (metadata) => {
     onProgress(Math.min(metadata.percent / 100, 1));
   });
+}
+
+function readZipEntryBytes(entry, onProgress = () => {}) {
+  return entry.async("uint8array", (metadata) => {
+    onProgress(Math.min(metadata.percent / 100, 1));
+  });
+}
+
+function decodeZipEntryText(bytes) {
+  if (typeof TextDecoder !== "undefined") {
+    return new TextDecoder("utf-8").decode(bytes);
+  }
+
+  let text = "";
+  for (const byte of bytes) {
+    text += String.fromCharCode(byte);
+  }
+  return text;
+}
+
+function getHeadLineBytes(bytes, maxLines) {
+  if (!bytes || bytes.byteLength === 0) {
+    return bytes;
+  }
+
+  let lines = 0;
+  for (let index = 0; index < bytes.byteLength; index++) {
+    if (bytes[index] === 10) {
+      lines += 1;
+      if (lines >= maxLines) {
+        return bytes.subarray(0, index + 1);
+      }
+    }
+  }
+
+  return bytes;
 }
 
 async function readLayerKindPreview(file) {

--- a/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
+++ b/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
@@ -87,6 +87,114 @@ test("viewer ZIP .drd preview failure does not poison readText", async () => {
   assert.equal(readCount, 2);
 });
 
+test("viewer ZIP loads unknown text entries that look like Gerber", async () => {
+  const sources = await collectLayerSources(
+    [makeFile("zip", "layers.zip", "application/zip")],
+    {
+      jsZip: {
+        async loadAsync() {
+          return {
+            files: {
+              "layers/board.ly3": makeZipEntry(GERBER_CONTENT, "layers/board.ly3"),
+              "layers/readme.txt": makeZipEntry("not a Gerber layer", "layers/readme.txt"),
+              "layers/image.bin": makeZipEntry(
+                new Uint8Array([137, 80, 78, 71, 0, 1, 2, 3]),
+                "layers/image.bin",
+              ),
+            },
+          };
+        },
+      },
+    },
+  );
+
+  assert.equal(sources.length, 1);
+  assert.equal(sources[0].name, "board.ly3");
+  assert.equal(sources[0].kind, "gerber");
+  assert.equal(await sources[0].readText(), GERBER_CONTENT);
+});
+
+test("viewer ZIP loads unknown text entries that look like drills", async () => {
+  const sources = await collectLayerSources(
+    [makeFile("zip", "layers.zip", "application/zip")],
+    {
+      jsZip: {
+        async loadAsync() {
+          return {
+            files: {
+              "layers/holes.tap": makeZipEntry(DRILL_CONTENT, "layers/holes.tap"),
+            },
+          };
+        },
+      },
+    },
+  );
+
+  assert.equal(sources.length, 1);
+  assert.equal(sources[0].name, "holes.tap");
+  assert.equal(sources[0].kind, "drill");
+  assert.equal(await sources[0].readText(), DRILL_CONTENT);
+});
+
+test("viewer ZIP preserves known extension behavior without sniffing", async () => {
+  const plainText = "not a Gerber layer";
+  const sources = await collectLayerSources(
+    [makeFile("zip", "layers.zip", "application/zip")],
+    {
+      jsZip: {
+        async loadAsync() {
+          return {
+            files: {
+              "layers/plain.gbr": makeZipEntry(plainText, "layers/plain.gbr"),
+              "layers/plain.drl": makeZipEntry(plainText, "layers/plain.drl"),
+              "layers/plain.ly3": makeZipEntry(plainText, "layers/plain.ly3"),
+            },
+          };
+        },
+      },
+    },
+  );
+
+  assert.equal(sources.length, 2);
+  assert.deepEqual(
+    sources.map((source) => [source.name, source.kind]),
+    [
+      ["plain.drl", "drill"],
+      ["plain.gbr", "gerber"],
+    ],
+  );
+  assert.equal(await sources[0].readText(), plainText);
+  assert.equal(await sources[1].readText(), plainText);
+});
+
+test("viewer ZIP sniffs only the first 30 lines for unknown entries", async () => {
+  const lateGerberContent = `${Array.from({ length: 30 }, (_, index) => (
+    `comment line ${index + 1}`
+  )).join("\n")}
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,1*%
+D10*
+X0Y0D03*
+M02*`;
+  const sources = await collectLayerSources(
+    [makeFile("zip", "layers.zip", "application/zip")],
+    {
+      jsZip: {
+        async loadAsync() {
+          return {
+            files: {
+              "layers/late.ly3": makeZipEntry(lateGerberContent, "layers/late.ly3"),
+            },
+          };
+        },
+      },
+    },
+  );
+
+  assert.equal(sources.length, 0);
+});
+
 function makeFile(content, name, type = "") {
   const blob = new Blob([content], { type });
   return {
@@ -95,6 +203,31 @@ function makeFile(content, name, type = "") {
     size: blob.size,
     slice: (...args) => blob.slice(...args),
     text: () => blob.text(),
+  };
+}
+
+function makeZipEntry(content, name, options = {}) {
+  const bytes = content instanceof Uint8Array
+    ? content
+    : new TextEncoder().encode(String(content));
+  const text = content instanceof Uint8Array
+    ? new TextDecoder("utf-8").decode(content)
+    : String(content);
+
+  return {
+    dir: false,
+    name,
+    _data: { uncompressedSize: options.uncompressedSize ?? bytes.byteLength },
+    async async(type, onProgress) {
+      if (options.unreadable) {
+        throw new Error("entry should not be read");
+      }
+      onProgress?.({ percent: 100 });
+      if (type === "uint8array") {
+        return bytes;
+      }
+      return text;
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Load ZIP entries with unknown extensions when their content looks like Gerber or drill text
- Preserve the existing lazy path for known Gerber/drill extensions
- Skip oversized unknown ZIP entries before sniffing to avoid unnecessary memory pressure

## Root Cause
ZIP loading filtered archive entries by known extensions before parsing, so valid Gerber files such as `.ly1`-`.ly6` were dropped before the renderer could inspect them

## Validation
- `npm --prefix packages/wasm-gerber-renderer run check`

Fixes #84
