### PR TITLE
Preserve zero-width Gerber outline draws

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             type="file"
             id="file-input"
             multiple
-            accept="text/*,application/zip,application/x-zip-compressed,.zip,.gdo,.gbr,.ger,.art,.gtl,.gbl,.gts,.gbs,.gto,.gbo,.gtp,.gbp,.cmp,.drd,.gko,.plc,.sol,.stc,.sts,.drl,.nc,.xnc,.xln"
+            accept="text/*,application/zip,application/x-zip-compressed,.zip,.gdo,.gbr,.ger,.art,.gtl,.gbl,.gts,.gbs,.gto,.gbo,.gtp,.gbp,.cmp,.drd,.gko,.plc,.sol,.stc,.sts,.outline,.drl,.nc,.xnc,.xln"
           />
           <button
             type="button"

--- a/js/config.js
+++ b/js/config.js
@@ -31,6 +31,7 @@ export const GERBER_FILE_EXTENSIONS = new Set([
   ".gto",
   ".gtp",
   ".gts",
+  ".outline",
   ".pastebot",
   ".pastetop",
   ".pho",

--- a/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
+++ b/packages/wasm-gerber-renderer/test/layer-kind.test.mjs
@@ -148,6 +148,7 @@ test("viewer ZIP preserves known extension behavior without sniffing", async () 
               "layers/plain.gbr": makeZipEntry(plainText, "layers/plain.gbr"),
               "layers/plain.drl": makeZipEntry(plainText, "layers/plain.drl"),
               "layers/plain.ly3": makeZipEntry(plainText, "layers/plain.ly3"),
+              "layers/plain.outline": makeZipEntry(plainText, "layers/plain.outline"),
             },
           };
         },
@@ -155,16 +156,18 @@ test("viewer ZIP preserves known extension behavior without sniffing", async () 
     },
   );
 
-  assert.equal(sources.length, 2);
+  assert.equal(sources.length, 3);
   assert.deepEqual(
     sources.map((source) => [source.name, source.kind]),
     [
       ["plain.drl", "drill"],
       ["plain.gbr", "gerber"],
+      ["plain.outline", "gerber"],
     ],
   );
   assert.equal(await sources[0].readText(), plainText);
   assert.equal(await sources[1].readText(), plainText);
+  assert.equal(await sources[2].readText(), plainText);
 });
 
 test("viewer ZIP sniffs only the first 30 lines for unknown entries", async () => {

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -132,6 +132,10 @@ fn has_positive_extent(value: f32) -> bool {
     value.is_finite() && value > GEOMETRY_EPSILON
 }
 
+fn has_non_negative_extent(value: f32) -> bool {
+    value.is_finite() && value >= 0.0
+}
+
 fn points_are_distinct(start_x: f32, start_y: f32, end_x: f32, end_y: f32) -> bool {
     let dx = end_x - start_x;
     let dy = end_y - start_y;
@@ -168,7 +172,7 @@ fn primitive_is_renderable(primitive: &Primitive) -> bool {
         } => {
             finite_point(*x, *y)
                 && has_positive_extent(*radius)
-                && has_positive_extent(*thickness)
+                && has_non_negative_extent(*thickness)
                 && start_angle.is_finite()
                 && end_angle.is_finite()
                 && (*end_angle - *start_angle).abs() > GEOMETRY_EPSILON
@@ -201,7 +205,7 @@ fn primitive_is_renderable(primitive: &Primitive) -> bool {
         } => {
             finite_point(*start_x, *start_y)
                 && finite_point(*end_x, *end_y)
-                && has_positive_extent(*width)
+                && has_non_negative_extent(*width)
                 && points_are_distinct(*start_x, *start_y, *end_x, *end_y)
         }
         Primitive::TriangleTemplateFlash { template, x, y } => {

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -495,7 +495,7 @@ pub fn line_to_body(
     width: f32,
     exposure: f32,
 ) -> Option<Primitive> {
-    if width <= 0.0 || points_coincide(start_x, start_y, end_x, end_y) {
+    if !width.is_finite() || width < 0.0 || points_coincide(start_x, start_y, end_x, end_y) {
         return None;
     }
 

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -1864,7 +1864,7 @@ M02*",
 }
 
 #[test]
-fn zero_width_solid_circle_draw_does_not_create_line_body() {
+fn zero_width_solid_circle_draw_preserves_line_body() {
     let layers = parse_gerber(
         "\
 %FSLAX26Y26*%
@@ -1876,8 +1876,38 @@ X1000000Y0000000D01*
 M02*",
     )
     .expect("zero-width solid circle D01 should parse");
+    let layer = &layers[0];
 
-    assert!(layers.is_empty());
+    assert!(layer.circles.x.is_empty());
+    assert_eq!(layer.lines.start_x, vec![0.0]);
+    assert_eq!(layer.lines.start_y, vec![0.0]);
+    assert_eq!(layer.lines.end_x, vec![1.0]);
+    assert_eq!(layer.lines.end_y, vec![0.0]);
+    assert_eq!(layer.lines.width, vec![0.0]);
+}
+
+#[test]
+fn zero_width_solid_circle_arc_preserves_arc_body() {
+    let layers = parse_gerber(
+        "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,0.0*%
+D10*
+G03*
+X1000000Y0000000D02*
+X0000000Y1000000I-1000000J0000000D01*
+M02*",
+    )
+    .expect("zero-width solid circle arc should parse");
+    let layer = &layers[0];
+
+    assert!(layer.circles.x.is_empty());
+    assert_eq!(layer.arcs.x.len(), 1);
+    assert_approx_eq(layer.arcs.x[0], 0.0);
+    assert_approx_eq(layer.arcs.y[0], 0.0);
+    assert_approx_eq(layer.arcs.radius[0], 1.0);
+    assert_eq!(layer.arcs.thickness, vec![0.0]);
 }
 
 #[test]

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -624,7 +624,7 @@ impl Renderer {
             })?;
             for idx in 0..line_count {
                 let width = data.lines.width[idx];
-                if !width.is_finite() || width <= MIN_OUTLINE_WIDTH {
+                if !width.is_finite() || width < 0.0 {
                     continue;
                 }
 
@@ -659,7 +659,7 @@ impl Renderer {
             })?;
             for idx in 0..arc_count {
                 let thickness = data.arcs.thickness[idx];
-                if !thickness.is_finite() || thickness <= MIN_OUTLINE_WIDTH {
+                if !thickness.is_finite() || thickness < 0.0 {
                     continue;
                 }
                 let center = [data.arcs.x[idx], data.arcs.y[idx]];
@@ -5879,5 +5879,59 @@ M02*",
         assert!((fill_layers[0].boundary.max_x() - 4.0).abs() < 0.0001);
         assert!((fill_layers[0].boundary.min_y() - 0.0).abs() < 0.0001);
         assert!((fill_layers[0].boundary.max_y() - 4.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn inverted_outline_fill_uses_zero_width_aperture_lines() {
+        let outline_layers = parse_gerber_with_source_contours(
+            "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,0.0*%
+D10*
+X0000000Y0000000D02*
+X1000000Y0000000D01*
+X1000000Y1000000D01*
+X0000000Y1000000D01*
+X0000000Y0000000D01*
+M02*",
+        );
+
+        let (fill_layers, fill_contours) = Renderer::inverted_outline_fill_layers(&outline_layers)
+            .expect("zero-width line outline should build fill");
+
+        assert_eq!(fill_layers.len(), 1);
+        assert_eq!(fill_contours.len(), 1);
+        assert!((fill_layers[0].boundary.min_x() - 0.0).abs() < 0.0001);
+        assert!((fill_layers[0].boundary.max_x() - 1.0).abs() < 0.0001);
+        assert!((fill_layers[0].boundary.min_y() - 0.0).abs() < 0.0001);
+        assert!((fill_layers[0].boundary.max_y() - 1.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn inverted_outline_fill_uses_zero_width_aperture_arcs() {
+        let outline_layers = parse_gerber_with_source_contours(
+            "\
+%FSLAX26Y26*%
+%MOMM*%
+%ADD10C,0.0*%
+D10*
+G03*
+G75*
+X1000000Y0000000D02*
+X1000000Y0000000I-1000000J0000000D01*
+M02*",
+        );
+
+        let (fill_layers, fill_contours) = Renderer::inverted_outline_fill_layers(&outline_layers)
+            .expect("zero-width arc outline should build fill");
+
+        assert_eq!(fill_layers.len(), 1);
+        assert_eq!(fill_contours.len(), 1);
+        assert!(fill_contours[0].has_arc);
+        assert!((fill_layers[0].boundary.min_x() + 1.0).abs() < 0.0001);
+        assert!((fill_layers[0].boundary.max_x() - 1.0).abs() < 0.0001);
+        assert!((fill_layers[0].boundary.min_y() + 1.0).abs() < 0.0001);
+        assert!((fill_layers[0].boundary.max_y() - 1.0).abs() < 0.0001);
     }
 }

--- a/wasm/src/renderer/shaders/arc.frag.glsl
+++ b/wasm/src/renderer/shaders/arc.frag.glsl
@@ -21,6 +21,10 @@ float normalizeAngle(float angle) {
 }
 
 void main() {
+    if (vThickness <= 0.0 && vOutlineThickness <= 0.0) {
+        discard;
+    }
+
     float dist = length(vPosition);
     float angle = atan(vPosition.y, vPosition.x);
 


### PR DESCRIPTION
## Summary
- Preserve zero-width solid-circle D01 line and arc bodies instead of dropping the layer as empty geometry
- Let the existing Minimum Line Width option control visibility: Off keeps true zero-width geometry invisible, while 1px/2px makes centerlines visible
- Add `.outline` as a known Gerber file extension while keeping unknown ZIP extension sniffing intact

## Root Cause
The attached `tester.outline` uses `%ADD10C,0.0000*%` and draws the board outline with D01 commands. The parser previously filtered zero-width line and arc primitives before they reached the renderer, which caused the file to be treated as having no geometry.

## Validation
- `glslangValidator -S frag wasm/src/renderer/shaders/arc.frag.glsl`
- `cargo test --manifest-path wasm/Cargo.toml zero_width_solid_circle -- --nocapture`
- `cargo test --manifest-path wasm/Cargo.toml`
- `npm --prefix packages/wasm-gerber-renderer run check`
- `wasm-pack build wasm --target web --out-dir pkg --release`

Fixes #83
