### PR TITLE
Create stencil FBOs for render payload path regions

### DIFF
--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -1053,7 +1053,7 @@ impl Renderer {
 
         for sublayer in sublayers.iter() {
             let path_regions = Self::decode_path_region_metadata(&sublayer)?;
-            needs_stencil |= path_regions.has_geometry();
+            needs_stencil |= path_regions.region_count() > 0;
             let boundary = match Self::decode_render_payload_boundary(&sublayer) {
                 Ok(boundary) => boundary,
                 Err(error) => {


### PR DESCRIPTION
## Summary
- Create stencil FBOs when a render-payload sublayer contains path regions.
- Keep the path-region render pass available after CPU geometry has been released.

## Root cause
`add_layer_from_render_payload` decided stencil allocation from `PathRegions::has_geometry()`.

In the render-payload path, CPU geometry can already be released while path-region offsets still exist. In that state, the old check could skip stencil FBO creation even though the layer still needs path-region rendering.

## Validation
- `cargo test --manifest-path wasm/Cargo.toml`