### PR TITLE
Render arc regions with Lyon tessellation

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +35,21 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "i_float"
@@ -92,6 +119,68 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "lyon"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0578bdecb7d6d88987b8b2b1e3a4e2f81df9d0ece1078623324a567904e7b7"
+dependencies = [
+ "lyon_algorithms",
+ "lyon_tessellation",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e43b7e44161571868f5c931d12583592c223c5583eef86b08aa02b7048a3552"
+dependencies = [
+ "float_next_after",
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
 
 [[package]]
 name = "once_cell"
@@ -193,6 +282,7 @@ dependencies = [
  "i_overlay",
  "i_triangle",
  "js-sys",
+ "lyon",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -20,6 +20,7 @@ default = ["console_error_panic_hook"]
 wasm-bindgen = "0.2"
 i_triangle = "^0.38.0"
 i_overlay = "~4.1.1"
+lyon = "1.0.19"
 console_error_panic_hook = { version = "0.1", optional = true }
 js-sys = "0.3"
 web-sys = { version = "0.3", features = [

--- a/wasm/src/parser/geometry.rs
+++ b/wasm/src/parser/geometry.rs
@@ -11,6 +11,11 @@ use i_overlay::core::fill_rule::FillRule;
 use i_overlay::core::overlay_rule::OverlayRule;
 use i_overlay::float::single::SingleFloatOverlay;
 use i_triangle::float::triangulatable::Triangulatable;
+use lyon::math::{point, vector, Angle};
+use lyon::path::{FillRule as LyonFillRule, Path};
+use lyon::tessellation::{
+    geometry_builder::BuffersBuilder, FillOptions, FillTessellator, FillVertex, VertexBuffers,
+};
 use std::collections::HashMap;
 use std::mem::size_of;
 use std::mem::take;
@@ -1744,8 +1749,18 @@ fn append_path_region(
         clear_max_y,
     )?;
 
-    for contour in region_contours {
-        append_contour_segments(path_regions, contour, reference, offset_x, offset_y)?;
+    if region_contours_have_arcs(region_contours) {
+        append_lyon_path_region(
+            path_regions,
+            region_contours,
+            offset_x,
+            offset_y,
+            arc_tessellation_quality,
+        )?;
+    } else {
+        for contour in region_contours {
+            append_contour_segments(path_regions, contour, reference, offset_x, offset_y)?;
+        }
     }
 
     if collect_pick_contours {
@@ -1951,6 +1966,199 @@ fn append_contour_segments(
     }
 
     Ok(())
+}
+
+#[derive(Copy, Clone, Debug)]
+struct LyonPathVertex {
+    position: [f32; 2],
+}
+
+fn append_lyon_path_region(
+    path_regions: &mut PathRegions,
+    region_contours: &[RegionContour],
+    offset_x: f32,
+    offset_y: f32,
+    arc_tessellation_quality: u32,
+) -> Result<(), String> {
+    let path = build_lyon_path(region_contours, offset_x, offset_y)?;
+    let (vertex_capacity, index_capacity) = lyon_geometry_capacity(region_contours);
+    let mut geometry: VertexBuffers<LyonPathVertex, u32> =
+        VertexBuffers::with_capacity(vertex_capacity, index_capacity);
+    let tolerance = lyon_fill_tolerance(region_contours, arc_tessellation_quality);
+    let options = FillOptions::tolerance(tolerance).with_fill_rule(LyonFillRule::EvenOdd);
+    let mut tessellator = FillTessellator::new();
+
+    tessellator
+        .tessellate_path(
+            &path,
+            &options,
+            &mut BuffersBuilder::new(&mut geometry, |vertex: FillVertex| LyonPathVertex {
+                position: vertex.position().to_array(),
+            }),
+        )
+        .map_err(|error| format!("Gerber region with arcs failed to tessellate: {error:?}"))?;
+
+    let output_coord_count = geometry.indices.len().checked_mul(2).ok_or_else(|| {
+        "Gerber region with arcs is too large to render: tessellated vertex count overflow"
+            .to_string()
+    })?;
+    try_reserve_values(
+        &mut path_regions.wedge_vertices,
+        output_coord_count,
+        "path region lyon vertices",
+    )?;
+
+    for index in geometry.indices {
+        let Some(vertex) = geometry.vertices.get(index as usize) else {
+            return Err(
+                "Gerber region with arcs produced an invalid tessellation index".to_string(),
+            );
+        };
+        path_regions
+            .wedge_vertices
+            .extend_from_slice(&vertex.position);
+    }
+
+    Ok(())
+}
+
+fn build_lyon_path(
+    region_contours: &[RegionContour],
+    offset_x: f32,
+    offset_y: f32,
+) -> Result<Path, String> {
+    let mut builder = Path::builder().with_svg();
+    let (endpoint_capacity, control_point_capacity) = lyon_path_capacity(region_contours);
+    builder.reserve(endpoint_capacity, control_point_capacity);
+
+    for contour in region_contours {
+        if contour.segments.is_empty() {
+            let Some(first) = contour.points.first().copied() else {
+                continue;
+            };
+            builder.move_to(lyon_point(offset_point(first, offset_x, offset_y)));
+            for point in contour.points.iter().skip(1) {
+                builder.line_to(lyon_point(offset_point(*point, offset_x, offset_y)));
+            }
+            builder.close();
+            continue;
+        }
+
+        let Some(start) = contour_start_point(contour) else {
+            continue;
+        };
+        builder.move_to(lyon_point(offset_point(start, offset_x, offset_y)));
+        for segment in &contour.segments {
+            match *segment {
+                RegionSegment::Line { end, .. } => {
+                    builder.line_to(lyon_point(offset_point(end, offset_x, offset_y)));
+                }
+                RegionSegment::Arc {
+                    start,
+                    end,
+                    center,
+                    radius,
+                    sweep_angle,
+                    ..
+                } => {
+                    let start = offset_point(start, offset_x, offset_y);
+                    let end = offset_point(end, offset_x, offset_y);
+                    if radius > 0.0 && sweep_angle.is_finite() {
+                        builder.line_to(lyon_point(start));
+                        builder.arc(
+                            lyon_point(offset_point(center, offset_x, offset_y)),
+                            vector(radius, radius),
+                            Angle::radians(sweep_angle),
+                            Angle::radians(0.0),
+                        );
+                        builder.line_to(lyon_point(end));
+                    } else {
+                        builder.line_to(lyon_point(end));
+                    }
+                }
+            }
+        }
+        builder.close();
+    }
+
+    Ok(builder.build())
+}
+
+fn lyon_path_capacity(region_contours: &[RegionContour]) -> (usize, usize) {
+    let mut endpoints = region_contours.len();
+    let mut control_points = 0usize;
+
+    for contour in region_contours {
+        if contour.segments.is_empty() {
+            endpoints = endpoints.saturating_add(contour.points.len());
+            continue;
+        }
+
+        for segment in &contour.segments {
+            match *segment {
+                RegionSegment::Line { .. } => {
+                    endpoints = endpoints.saturating_add(1);
+                }
+                RegionSegment::Arc { sweep_angle, .. } => {
+                    let curve_count = lyon_arc_curve_count(sweep_angle);
+                    endpoints = endpoints.saturating_add(1 + curve_count);
+                    control_points = control_points.saturating_add(curve_count);
+                }
+            }
+        }
+    }
+
+    (endpoints.max(16), control_points)
+}
+
+fn lyon_geometry_capacity(region_contours: &[RegionContour]) -> (usize, usize) {
+    let (endpoint_capacity, _) = lyon_path_capacity(region_contours);
+    (
+        endpoint_capacity.max(512),
+        endpoint_capacity.saturating_mul(3).max(1024),
+    )
+}
+
+fn lyon_arc_curve_count(sweep_angle: f32) -> usize {
+    if !sweep_angle.is_finite() {
+        return 1;
+    }
+
+    let quarter_turns = (sweep_angle.abs() / (std::f32::consts::PI * 0.5)).ceil();
+    (quarter_turns as usize).clamp(1, 16)
+}
+
+fn contour_start_point(contour: &RegionContour) -> Option<[f32; 2]> {
+    contour.segments.first().map(|segment| match *segment {
+        RegionSegment::Line { start, .. } | RegionSegment::Arc { start, .. } => start,
+    })
+}
+
+fn lyon_point(position: [f32; 2]) -> lyon::math::Point {
+    point(position[0], position[1])
+}
+
+fn lyon_fill_tolerance(region_contours: &[RegionContour], arc_tessellation_quality: u32) -> f32 {
+    let mut max_radius = 0.0_f32;
+    for contour in region_contours {
+        for segment in &contour.segments {
+            if let RegionSegment::Arc { radius, .. } = *segment {
+                max_radius = max_radius.max(radius.abs());
+            }
+        }
+    }
+
+    let relative = match arc_tessellation_quality {
+        0 => 1.0 / 2048.0,
+        2 => 1.0 / 32768.0,
+        _ => 1.0 / 8192.0,
+    };
+    let minimum = match arc_tessellation_quality {
+        0 => 0.001,
+        2 => 0.00005,
+        _ => 0.00025,
+    };
+    (max_radius * relative).max(minimum)
 }
 
 fn path_region_bounds(

--- a/wasm/src/parser/tests.rs
+++ b/wasm/src/parser/tests.rs
@@ -477,8 +477,10 @@ M02*",
     let layer = &layers[0];
     assert!(layer.triangles.vertices.is_empty());
     assert_eq!(layer.path_regions.region_count(), 1);
-    assert_eq!(layer.path_regions.wedge_vertex_offsets, vec![0, 9]);
-    assert_eq!(layer.path_regions.sector_vertex_offsets, vec![0, 6]);
+    assert_eq!(layer.path_regions.wedge_vertex_offsets.len(), 2);
+    assert!(layer.path_regions.wedge_vertex_offsets[1] > 0);
+    assert_eq!(layer.path_regions.sector_vertex_offsets, vec![0, 0]);
+    assert!(layer.path_regions.sector_vertices.is_empty());
     assert_eq!(layer.path_regions.cover_vertices.len(), 12);
     assert_eq!(layer.path_regions.clear_vertices.len(), 12);
     assert!(layer.path_regions.pick_contours.is_empty());
@@ -802,6 +804,30 @@ M02*";
 }
 
 #[test]
+fn preserved_region_arc_quality_controls_lyon_tessellation_density() {
+    let data = "\
+%FSLAX24Y24*%
+%MOMM*%
+G75*
+G36*
+X010000Y000000D02*
+G03*
+X-010000Y000000I-010000J000000D01*
+G37*
+M02*";
+    let low_layers =
+        parse_gerber_with_options(data, true, 0).expect("low quality path region arc should parse");
+    let high_layers = parse_gerber_with_options(data, true, 2)
+        .expect("high quality path region arc should parse");
+
+    assert!(
+        high_layers[0].path_regions.wedge_vertices.len()
+            > low_layers[0].path_regions.wedge_vertices.len(),
+        "high quality should produce more Lyon-filled path vertices than low quality"
+    );
+}
+
+#[test]
 fn aperture_block_region_arc_is_preserved_for_path_renderer() {
     let layers = parse_gerber(
         "\
@@ -945,7 +971,7 @@ M02*",
 }
 
 #[test]
-fn path_region_translate_moves_arc_sector_bounds_and_center() {
+fn path_region_translate_moves_lyon_path_vertices() {
     let mut layers = parse_gerber(
         "\
 %FSLAX24Y24*%
@@ -960,12 +986,17 @@ M02*",
     )
     .expect("region arc should parse");
 
+    let before = layers[0].path_regions.wedge_vertices.clone();
     layers[0].translate(10.0, 20.0);
-    let sector = &layers[0].path_regions.sector_vertices;
-    assert_approx_eq(sector[0], 9.0);
-    assert_approx_eq(sector[1], 20.0);
-    assert_approx_eq(sector[2], 10.0);
-    assert_approx_eq(sector[3], 20.0);
+    assert!(!before.is_empty());
+    assert!(layers[0].path_regions.sector_vertices.is_empty());
+    for (before, after) in before
+        .chunks_exact(2)
+        .zip(layers[0].path_regions.wedge_vertices.chunks_exact(2))
+    {
+        assert_approx_eq(after[0], before[0] + 10.0);
+        assert_approx_eq(after[1], before[1] + 20.0);
+    }
 }
 
 #[test]

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -5817,7 +5817,8 @@ M02*",
 
         assert_eq!(fill_layers.len(), 1);
         assert!(fill_contours.iter().any(|contour| contour.has_arc));
-        assert!(!fill_layers[0].path_regions.sector_vertices.is_empty());
+        assert!(!fill_layers[0].path_regions.wedge_vertices.is_empty());
+        assert!(fill_layers[0].path_regions.sector_vertices.is_empty());
     }
 
     #[test]

--- a/wasm/src/shape.rs
+++ b/wasm/src/shape.rs
@@ -436,8 +436,8 @@ impl Thermals {
 /// Arc-containing region path data rendered by the WebGL stencil path renderer.
 ///
 /// Large regions are stored in flat buffers to avoid per-segment JS objects:
-/// - `wedge_vertices`: one or two stencil fan triangles per path segment
-/// - `sector_vertices`: expanded analytic arc-sector quads, 7 floats per vertex
+/// - `wedge_vertices`: stencil triangles for line-only fans or Lyon-filled arc regions
+/// - `sector_vertices`: legacy analytic arc-sector quads, 7 floats per vertex
 /// - `cover_vertices`: one screen-coverable bounding quad per region
 /// - `clear_vertices`: one quad covering all stencil writes per region
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary
- Render arc-containing Gerber regions through Lyon fill tessellation
- Keep line-only regions on the existing stencil fan path
- Store Lyon output in the existing flat `PathRegions.wedge_vertices` buffer
- Stop using the analytic arc-sector shader path for preserved arc regions

Fixes #90

## Details
The previous exact arc-region renderer combined stencil fan triangles with analytic sector quads. At very high zoom, tiny numeric mismatches around arc/chord boundaries could show stray geometry.

This change moves arc-containing regions to CPU-side Lyon tessellation before rendering. The renderer still uses the existing WebGL stencil path pipeline, but receives a stable triangle mesh for those regions. Line-only regions keep the old lightweight path.

`arcTessellationQuality` now also controls Lyon tolerance for preserved arc regions.

## Validation
- `cargo test --manifest-path wasm/Cargo.toml`
- `wasm-pack build wasm --target web --out-dir pkg --release`
- `npm run check --prefix packages/wasm-gerber-renderer`

## Notes
This may increase CPU tessellation work and triangle buffer size for arc-heavy regions, but the path is limited to regions that actually contain arcs. Large arc-region testing looked acceptable locally.
