### PR TITLE
Align renderer CLI docs with endpoint options

### DIFF
--- a/packages/wasm-gerber-renderer/README.kr.md
+++ b/packages/wasm-gerber-renderer/README.kr.md
@@ -129,6 +129,7 @@ type GerberLayer =
       alpha?: number;
       offsetX?: number;
       offsetY?: number;
+      kind?: LayerKind;
     };
 ```
 
@@ -156,6 +157,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     }
   | {
       path: string;
@@ -165,6 +167,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     };
 ```
 
@@ -215,7 +218,7 @@ await renderGerberToPngFile(
 - `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)`: 한 번에 배치 렌더링하고 PNG 바이트를 `Uint8Array`로 반환합니다.
 - `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`: 한 번에 배치 렌더링하고 PNG 바이트를 임시 파일에 스트리밍한 뒤 성공하면 `outputPath`를 교체합니다. 상위 directory는 미리 존재해야 합니다.
 - `renderGerberToPngStream(writable, layers, frameOptions, exportOptions, rendererOptions)`: 한 번에 배치 렌더링하고 PNG chunk를 Node writable stream에 씁니다.
-- `fileLayer(path, options)`: path 기반 Node layer config를 만듭니다. `options`는 `name`, `color`, `alpha`, `offsetX`, `offsetY`를 받습니다.
+- `fileLayer(path, options)`: path 기반 Node layer config를 만듭니다. `options`는 `name`, `color`, `alpha`, `offsetX`, `offsetY`, `inverted`, `kind`를 받습니다.
 - `packageRoot()`: 설치된 패키지 directory 경로를 반환합니다.
 - `renderer.loadLayer(layer, layerOptions)`: Node layer 하나를 한 번 파싱하고 여러 frame에서 재사용할 수 있는 prepared layer를 반환합니다.
 - `renderer.loadLayers(layers, options)`: 여러 layer를 파싱하고 `{ layers, loadedCount, failures }`를 반환합니다. 실패한 layer는 기본적으로 건너뜁니다.
@@ -276,6 +279,11 @@ Batch API(`renderGerberToCanvas`, `renderGerberToPng`, `renderGerberToPngStream`
 - `globalAlpha`: `blend` 모드에서 명시적인 layer `alpha`가 없는 Gerber layer에 적용되는 opacity입니다. 기본값은 `0.7`입니다.
 - `compositeMode`: layer 합성 모드입니다. `"blend"` 또는 `"stack"`을 받으며 기본값은 `"blend"`입니다. `blend`는 alpha additive blending을 사용하고, `stack`은 Gerber layer를 입력 순서대로 source-over 합성하므로 뒤 Gerber layer가 앞 Gerber layer를 덮으며 기본 opacity는 `1`입니다. Drill overlay는 Gerber layer 이후에 렌더링됩니다.
 - `invertedOutline`: Node 전용 inverted layer 기준 outline입니다. `"auto"`는 board outline layer를 자동 감지하고, `"bounds"`는 현재 Gerber bounds를 채우며, layer index/name selector도 사용할 수 있습니다. 기본값은 `"auto"`입니다.
+- `maxBandBytes`: Node 전용 streamed PNG row-buffer budget입니다. 기본값은 `512 MiB`입니다.
+- `maxFullFrameBytes`: Node 전용 full-frame PNG export 선택 기준 memory budget입니다. 기본값은 `512 MiB`입니다.
+- `maxRenderTargetBytes`: Node 전용 per-render-target memory cap입니다. 기본적으로 사용 가능한 GPU/driver budget을 probe하고 실패하면 `2 GiB`를 사용합니다.
+- `framebufferMemorySafetyFactor`: Node 전용 full-frame framebuffer memory estimate multiplier입니다. 기본값은 `2`입니다.
+- `strategy`: Node 전용 PNG export strategy입니다. `"auto"`, `"full-frame"`, `"stream"` 중 하나이며 기본값은 `"auto"`입니다.
 - `layerErrorMode`: `"skip"`은 남은 유효한 layer를 계속 렌더링하고, `"throw"`는 첫 실패에서 Promise를 reject합니다. 기본값은 `"skip"`입니다.
 - `onLayerError`: `"skip"` mode에서 건너뛴 layer를 받는 callback입니다. 전달 값은 `{ layer, name, error }`입니다.
 - `rendererOptions`: 브라우저 one-shot helper 전용입니다. 렌더러 생성 시 그대로 전달됩니다.
@@ -290,12 +298,22 @@ Batch API(`renderGerberToCanvas`, `renderGerberToPng`, `renderGerberToPngStream`
 - `kind`: source filename이 없거나 모호할 때 `"gerber"` 또는 `"drill"`을 강제로 지정합니다.
 - `name`: `{ source, name }` 또는 `{ path, name }` 같은 config object에서 쓰는 layer 표시 이름입니다.
 
+`loadLayer()`와 `loadLayers()`는 parse/load option도 받습니다.
+
+- `preserveArcRegions`: prepared layer에서 exact region arc를 유지합니다. 기본값은 `true`입니다.
+- `arcTessellationQuality`: region arc를 approximate할 때 prepared layer의 arc quality를 지정합니다.
+- `retainSourceContentForInversion`: Node 전용입니다. prepared layer를 나중에 inverted layer나 explicit outline source로 사용할 수 있도록 원본 Gerber text를 유지합니다.
+
 `exportOptions`는 PNG export를 제어합니다.
 
 - `type`: 브라우저 전용 export MIME type입니다. 기본값은 `image/png`이며, Node는 항상 PNG를 씁니다.
 - `quality`: 브라우저 전용 encoder quality이며 `canvas.toBlob`에 전달됩니다.
 - `background`: export background 재정의입니다. `null`을 사용하면 transparency를 유지합니다. 기본값은 마지막 frame background입니다.
 - `maxBandBytes`: streamed PNG export의 approximate row-buffer budget입니다. Node는 high-resolution tiled rendering에도 이 값을 사용합니다.
+- `maxFullFrameBytes`: Node 전용 full-frame PNG export memory budget입니다.
+- `maxRenderTargetBytes`: Node 전용 per-render-target memory cap입니다.
+- `framebufferMemorySafetyFactor`: Node 전용 framebuffer memory estimate multiplier입니다.
+- `strategy`: Node 전용 PNG export strategy입니다. `"auto"`, `"full-frame"`, `"stream"` 중 하나입니다.
 
 `rendererOptions`는 renderer 생성을 제어합니다.
 
@@ -354,6 +372,10 @@ CLI 옵션:
 - `--composite-mode <blend|stack>`: layer 합성 모드입니다. 기본값은 `blend`입니다.
 - `--minimum-feature-pixels <px>`: line/arc의 최소 렌더링 폭입니다. 기본값은 `1`입니다.
 - `--max-render-target-bytes <size>`: render target별 memory cap입니다. byte 또는 `512m`, `2g` 같은 suffix를 받습니다.
+- `--max-band-bytes <size>`: streamed PNG row-buffer cap입니다. byte 또는 `512m`, `2g` 같은 suffix를 받습니다.
+- `--max-full-frame-bytes <size>`: full-frame PNG memory cap입니다. byte 또는 `512m`, `2g` 같은 suffix를 받습니다.
+- `--framebuffer-memory-safety-factor <n>`: full-frame framebuffer memory estimate multiplier입니다. 기본값은 `2`입니다.
+- `--render-strategy <auto|full-frame|stream>`: PNG export strategy입니다. 기본값은 `auto`입니다.
 - `--approx-region-arcs`: 렌더링 전에 region arc를 line segment로 변환합니다.
 - `--arc-quality <0|1|2>`: arc 근사 품질입니다. 기본값은 `1`입니다.
 - `--invert-layer <selector>`: Gerber layer를 inverted/negative layer로 렌더링합니다. 여러 layer를 뒤집으려면 반복해서 지정합니다. Selector는 1-based layer index, exact layer name, basename을 지원합니다.

--- a/packages/wasm-gerber-renderer/README.md
+++ b/packages/wasm-gerber-renderer/README.md
@@ -140,6 +140,7 @@ type GerberLayer =
       alpha?: number;
       offsetX?: number;
       offsetY?: number;
+      kind?: LayerKind;
     };
 ```
 
@@ -170,6 +171,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     }
   | {
       path: string;
@@ -179,6 +181,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     };
 ```
 
@@ -234,7 +237,7 @@ await renderGerberToPngFile(
 - `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that returns PNG bytes as a `Uint8Array`.
 - `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that streams PNG bytes to a temporary file, then replaces `outputPath` after success. Parent directories must already exist.
 - `renderGerberToPngStream(writable, layers, frameOptions, exportOptions, rendererOptions)`: one-shot batch render that writes PNG chunks to a Node writable stream.
-- `fileLayer(path, options)`: creates a path-backed Node layer config. `options` accepts `name`, `color`, `alpha`, `offsetX`, and `offsetY`.
+- `fileLayer(path, options)`: creates a path-backed Node layer config. `options` accepts `name`, `color`, `alpha`, `offsetX`, `offsetY`, `inverted`, and `kind`.
 - `packageRoot()`: returns the installed package directory path.
 - `renderer.loadLayer(layer, layerOptions)`: parses a Node layer once and returns a prepared layer that can be reused across frames.
 - `renderer.loadLayers(layers, options)`: parses multiple layers and returns `{ layers, loadedCount, failures }`. Failed layers are skipped by default.
@@ -301,6 +304,11 @@ load. If every layer fails, the operation rejects with the first layer error.
 - `globalAlpha`: opacity for Gerber layers without an explicit layer `alpha` in `blend` mode. Defaults to `0.7`; drill layers render at full opacity unless their own `alpha` is set.
 - `compositeMode`: layer compositing mode, `"blend"` or `"stack"`. Defaults to `"blend"`. `blend` uses additive alpha blending; `stack` uses ordered source-over compositing for Gerber layers, so later Gerber layers cover earlier Gerber layers and default to opacity `1`. Drill overlays render after Gerber layers.
 - `invertedOutline`: Node-only outline source for inverted layers. Use `"auto"` to detect a board outline layer, `"bounds"` to fill the current Gerber bounds, or a layer index/name selector. Defaults to `"auto"`.
+- `maxBandBytes`: Node-only streamed PNG row-buffer budget. Defaults to `512 MiB`.
+- `maxFullFrameBytes`: Node-only memory budget for choosing full-frame PNG export. Defaults to `512 MiB`.
+- `maxRenderTargetBytes`: Node-only per-render-target memory cap. By default the renderer probes the available GPU/driver budget and falls back to `2 GiB`.
+- `framebufferMemorySafetyFactor`: Node-only multiplier for full-frame framebuffer memory estimates. Defaults to `2`.
+- `strategy`: Node-only PNG export strategy, `"auto"`, `"full-frame"`, or `"stream"`. Defaults to `"auto"`.
 - `layerErrorMode`: `"skip"` renders remaining valid layers; `"throw"` rejects on first failure. Defaults to `"skip"`.
 - `onLayerError`: callback for skipped layers in `"skip"` mode: `{ layer, name, error }`.
 - `rendererOptions`: browser one-shot helpers only; passed through when creating the renderer.
@@ -315,12 +323,22 @@ load. If every layer fails, the operation rejects with the first layer error.
 - `kind`: force `"gerber"` or `"drill"` when a source filename is unavailable or ambiguous.
 - `name`: layer display name for config objects such as `{ source, name }` or `{ path, name }`.
 
+`loadLayer()` and `loadLayers()` also accept parse/load options:
+
+- `preserveArcRegions`: keeps exact region arcs for prepared layers. Defaults to `true`.
+- `arcTessellationQuality`: arc approximation quality for prepared layers when region arcs are approximated.
+- `retainSourceContentForInversion`: Node-only; keeps the original Gerber text with a prepared layer so it can be used later as an inverted layer or selected outline source.
+
 `exportOptions` control PNG export:
 
 - `type`: browser-only export MIME type. Defaults to `image/png`; Node always writes PNG.
 - `quality`: browser-only encoder quality passed to `canvas.toBlob`.
 - `background`: export background override. Use `null` to keep transparency. Defaults to the last frame background.
 - `maxBandBytes`: approximate row-buffer budget for streamed PNG export. Node also uses it for high-resolution tiled rendering.
+- `maxFullFrameBytes`: Node-only memory budget for full-frame PNG export.
+- `maxRenderTargetBytes`: Node-only per-render-target memory cap.
+- `framebufferMemorySafetyFactor`: Node-only multiplier for framebuffer memory estimates.
+- `strategy`: Node-only PNG export strategy, `"auto"`, `"full-frame"`, or `"stream"`.
 
 `rendererOptions` control renderer creation:
 
@@ -379,6 +397,10 @@ CLI options:
 - `--composite-mode <blend|stack>`: layer compositing mode. Defaults to `blend`.
 - `--minimum-feature-pixels <px>`: minimum rendered line/arc width. Defaults to `1`.
 - `--max-render-target-bytes <size>`: per-render target memory cap. Accepts bytes or suffixes like `512m` and `2g`.
+- `--max-band-bytes <size>`: streamed PNG row-buffer cap. Accepts bytes or suffixes like `512m` and `2g`.
+- `--max-full-frame-bytes <size>`: full-frame PNG memory cap. Accepts bytes or suffixes like `512m` and `2g`.
+- `--framebuffer-memory-safety-factor <n>`: multiplier for full-frame framebuffer memory estimates. Defaults to `2`.
+- `--render-strategy <auto|full-frame|stream>`: PNG export strategy. Defaults to `auto`.
 - `--approx-region-arcs`: converts region arcs to line segments before rendering.
 - `--arc-quality <0|1|2>`: approximate arc quality. Defaults to `1`.
 - `--invert-layer <selector>`: renders a Gerber layer as an inverted/negative layer. Repeat for multiple layers. Selectors match 1-based layer index, exact layer name, or basename.

--- a/packages/wasm-gerber-renderer/README.zh-Hans.md
+++ b/packages/wasm-gerber-renderer/README.zh-Hans.md
@@ -129,6 +129,7 @@ type GerberLayer =
       alpha?: number;
       offsetX?: number;
       offsetY?: number;
+      kind?: LayerKind;
     };
 ```
 
@@ -156,6 +157,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     }
   | {
       path: string;
@@ -165,6 +167,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     };
 ```
 
@@ -215,7 +218,7 @@ await renderGerberToPngFile(
 - `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)`：一次调用即可批量渲染，并以 `Uint8Array` 返回 PNG 字节数据。
 - `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`：一次调用即可批量渲染，把 PNG 字节数据写入临时文件，成功后替换 `outputPath`。父目录必须已存在。
 - `renderGerberToPngStream(writable, layers, frameOptions, exportOptions, rendererOptions)`：一次调用即可批量渲染，把 PNG 数据块写入 Node 可写流。
-- `fileLayer(path, options)`：创建基于路径的 Node 图层配置。`options` 接受 `name`、`color`、`alpha`、`offsetX`、`offsetY`。
+- `fileLayer(path, options)`：创建基于路径的 Node 图层配置。`options` 接受 `name`、`color`、`alpha`、`offsetX`、`offsetY`、`inverted`、`kind`。
 - `packageRoot()`：返回已安装包的目录路径。
 - `renderer.loadLayer(layer, layerOptions)`：解析一个 Node 图层，并返回可跨帧复用的预加载图层。
 - `renderer.loadLayers(layers, options)`：解析多个图层，并返回 `{ layers, loadedCount, failures }`。失败的图层默认会被跳过。
@@ -276,6 +279,11 @@ try {
 - `globalAlpha`：`blend` 模式下没有显式图层 `alpha` 的 Gerber 图层透明度。默认 `0.7`。
 - `compositeMode`：图层合成模式，取 `"blend"` 或 `"stack"`。默认 `"blend"`。`blend` 使用 alpha additive blending；`stack` 对 Gerber 图层按输入顺序使用 source-over 合成，因此后面的 Gerber 图层覆盖前面的 Gerber 图层，默认透明度为 `1`。钻孔叠加层会在 Gerber 图层之后渲染。
 - `invertedOutline`：仅 Node 使用的反相图层外框来源。`"auto"` 会自动检测 board outline 图层，`"bounds"` 会填充当前 Gerber bounds，也可以使用图层序号或名称 selector。默认 `"auto"`。
+- `maxBandBytes`：仅 Node 使用的 streamed PNG row-buffer budget。默认 `512 MiB`。
+- `maxFullFrameBytes`：仅 Node 使用的 full-frame PNG export 选择用 memory budget。默认 `512 MiB`。
+- `maxRenderTargetBytes`：仅 Node 使用的 per-render-target memory cap。默认会探测可用 GPU/driver budget，失败时回退到 `2 GiB`。
+- `framebufferMemorySafetyFactor`：仅 Node 使用的 full-frame framebuffer memory estimate multiplier。默认 `2`。
+- `strategy`：仅 Node 使用的 PNG export strategy，可为 `"auto"`、`"full-frame"` 或 `"stream"`。默认 `"auto"`。
 - `layerErrorMode`：`"skip"` 会继续渲染剩余有效图层；`"throw"` 会在第一次失败时中断。默认 `"skip"`。
 - `onLayerError`：`"skip"` 模式下接收被跳过图层的回调函数，参数为 `{ layer, name, error }`。
 - `rendererOptions`：仅用于浏览器一次性辅助函数；创建渲染器时会原样传入。
@@ -290,12 +298,22 @@ try {
 - `kind`：当输入源文件名不存在或含义不明确时，强制指定 `"gerber"` 或 `"drill"`。
 - `name`：用于 `{ source, name }` 或 `{ path, name }` 等配置对象的图层显示名称。
 
+`loadLayer()` 和 `loadLayers()` 也接受 parse/load 选项：
+
+- `preserveArcRegions`：为 prepared layer 保留 exact region arc。默认 `true`。
+- `arcTessellationQuality`：当 region arc 需要 approximate 时，指定 prepared layer 的 arc quality。
+- `retainSourceContentForInversion`：仅 Node 使用；保留原始 Gerber text，使 prepared layer 之后可作为 inverted layer 或 explicit outline source 使用。
+
 `exportOptions` 控制 PNG 导出：
 
 - `type`：仅浏览器使用的导出 MIME 类型。默认 `image/png`；Node 始终写 PNG。
 - `quality`：仅浏览器使用的编码质量，会传给 `canvas.toBlob`。
 - `background`：导出时使用的背景，可覆盖最后一帧的背景。使用 `null` 保持透明。
 - `maxBandBytes`：流式 PNG 导出的近似行缓冲预算。Node 也会在高分辨率分块渲染中使用它。
+- `maxFullFrameBytes`：仅 Node 使用的 full-frame PNG export memory budget。
+- `maxRenderTargetBytes`：仅 Node 使用的 per-render-target memory cap。
+- `framebufferMemorySafetyFactor`：仅 Node 使用的 framebuffer memory estimate multiplier。
+- `strategy`：仅 Node 使用的 PNG export strategy，可为 `"auto"`、`"full-frame"` 或 `"stream"`。
 
 `rendererOptions` 控制渲染器创建：
 
@@ -354,6 +372,10 @@ CLI 选项：
 - `--composite-mode <blend|stack>`：图层合成模式。默认 `blend`。
 - `--minimum-feature-pixels <px>`：线段/圆弧的最小渲染宽度。默认 `1`。
 - `--max-render-target-bytes <size>`：每个渲染目标的内存上限。接受字节数或 `512m`、`2g` 这样的后缀。
+- `--max-band-bytes <size>`：streamed PNG row-buffer cap。接受字节数或 `512m`、`2g` 这样的后缀。
+- `--max-full-frame-bytes <size>`：full-frame PNG memory cap。接受字节数或 `512m`、`2g` 这样的后缀。
+- `--framebuffer-memory-safety-factor <n>`：full-frame framebuffer memory estimate multiplier。默认 `2`。
+- `--render-strategy <auto|full-frame|stream>`：PNG export strategy。默认 `auto`。
 - `--approx-region-arcs`：渲染前把 region 圆弧转换为线段。
 - `--arc-quality <0|1|2>`：圆弧近似质量。默认 `1`。
 - `--invert-layer <selector>`：把 Gerber 图层渲染为反相/negative 图层。需要反相多个图层时可重复指定。Selector 支持 1-based 图层序号、完整图层名和 basename。

--- a/packages/wasm-gerber-renderer/README.zh-Hant.md
+++ b/packages/wasm-gerber-renderer/README.zh-Hant.md
@@ -129,6 +129,7 @@ type GerberLayer =
       alpha?: number;
       offsetX?: number;
       offsetY?: number;
+      kind?: LayerKind;
     };
 ```
 
@@ -156,6 +157,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     }
   | {
       path: string;
@@ -165,6 +167,7 @@ type GerberNodeLayer =
       offsetX?: number;
       offsetY?: number;
       inverted?: boolean;
+      kind?: LayerKind;
     };
 ```
 
@@ -215,7 +218,7 @@ await renderGerberToPngFile(
 - `renderGerberToPngBuffer(layers, frameOptions, exportOptions, rendererOptions)`：一次呼叫即可批次渲染，並以 `Uint8Array` 回傳 PNG 位元組資料。
 - `renderGerberToPngFile(outputPath, layers, frameOptions, exportOptions, rendererOptions)`：一次呼叫即可批次渲染，把 PNG 位元組資料寫入暫存檔，成功後替換 `outputPath`。父目錄必須已存在。
 - `renderGerberToPngStream(writable, layers, frameOptions, exportOptions, rendererOptions)`：一次呼叫即可批次渲染，把 PNG 資料區塊寫入 Node 可寫串流。
-- `fileLayer(path, options)`：建立基於路徑的 Node 圖層設定。`options` 接受 `name`、`color`、`alpha`、`offsetX`、`offsetY`。
+- `fileLayer(path, options)`：建立基於路徑的 Node 圖層設定。`options` 接受 `name`、`color`、`alpha`、`offsetX`、`offsetY`、`inverted`、`kind`。
 - `packageRoot()`：回傳已安裝套件的目錄路徑。
 - `renderer.loadLayer(layer, layerOptions)`：解析一個 Node 圖層，並回傳可跨渲染幀重複使用的預載圖層。
 - `renderer.loadLayers(layers, options)`：解析多個圖層，並回傳 `{ layers, loadedCount, failures }`。失敗的圖層預設會被跳過。
@@ -276,6 +279,11 @@ try {
 - `globalAlpha`：`blend` 模式下沒有明確圖層 `alpha` 的 Gerber 圖層透明度。預設 `0.7`。
 - `compositeMode`：圖層合成模式，取 `"blend"` 或 `"stack"`。預設 `"blend"`。`blend` 使用 alpha additive blending；`stack` 對 Gerber 圖層按輸入順序使用 source-over 合成，因此後面的 Gerber 圖層覆蓋前面的 Gerber 圖層，預設透明度為 `1`。鑽孔疊加層會在 Gerber 圖層之後渲染。
 - `invertedOutline`：僅 Node 使用的反相圖層外框來源。`"auto"` 會自動偵測 board outline 圖層，`"bounds"` 會填充目前 Gerber bounds，也可以使用圖層序號或名稱 selector。預設 `"auto"`。
+- `maxBandBytes`：僅 Node 使用的 streamed PNG row-buffer budget。預設 `512 MiB`。
+- `maxFullFrameBytes`：僅 Node 使用的 full-frame PNG export 選擇用 memory budget。預設 `512 MiB`。
+- `maxRenderTargetBytes`：僅 Node 使用的 per-render-target memory cap。預設會探測可用 GPU/driver budget，失敗時回退到 `2 GiB`。
+- `framebufferMemorySafetyFactor`：僅 Node 使用的 full-frame framebuffer memory estimate multiplier。預設 `2`。
+- `strategy`：僅 Node 使用的 PNG export strategy，可為 `"auto"`、`"full-frame"` 或 `"stream"`。預設 `"auto"`。
 - `layerErrorMode`：`"skip"` 會繼續渲染剩餘有效圖層；`"throw"` 會在第一次失敗時中斷。預設 `"skip"`。
 - `onLayerError`：`"skip"` 模式下接收被跳過圖層的回呼函式，參數為 `{ layer, name, error }`。
 - `rendererOptions`：僅用於瀏覽器一次性輔助函式；建立渲染器時會原樣傳入。
@@ -290,12 +298,22 @@ try {
 - `kind`：當輸入來源檔名不存在或含義不明確時，強制指定 `"gerber"` 或 `"drill"`。
 - `name`：用於 `{ source, name }` 或 `{ path, name }` 等設定物件的圖層顯示名稱。
 
+`loadLayer()` 與 `loadLayers()` 也接受 parse/load 選項：
+
+- `preserveArcRegions`：為 prepared layer 保留 exact region arc。預設 `true`。
+- `arcTessellationQuality`：當 region arc 需要 approximate 時，指定 prepared layer 的 arc quality。
+- `retainSourceContentForInversion`：僅 Node 使用；保留原始 Gerber text，使 prepared layer 之後可作為 inverted layer 或 explicit outline source 使用。
+
 `exportOptions` 控制 PNG 匯出：
 
 - `type`：僅瀏覽器使用的匯出 MIME 類型。預設 `image/png`；Node 始終寫 PNG。
 - `quality`：僅瀏覽器使用的編碼品質，會傳給 `canvas.toBlob`。
 - `background`：匯出時使用的背景，可覆蓋最後一個渲染幀的背景。使用 `null` 保持透明。
 - `maxBandBytes`：串流 PNG 匯出的近似列緩衝預算。Node 也會在高解析度分塊渲染中使用它。
+- `maxFullFrameBytes`：僅 Node 使用的 full-frame PNG export memory budget。
+- `maxRenderTargetBytes`：僅 Node 使用的 per-render-target memory cap。
+- `framebufferMemorySafetyFactor`：僅 Node 使用的 framebuffer memory estimate multiplier。
+- `strategy`：僅 Node 使用的 PNG export strategy，可為 `"auto"`、`"full-frame"` 或 `"stream"`。
 
 `rendererOptions` 控制渲染器建立：
 
@@ -354,6 +372,10 @@ CLI 選項：
 - `--composite-mode <blend|stack>`：圖層合成模式。預設 `blend`。
 - `--minimum-feature-pixels <px>`：線段/圓弧的最小渲染寬度。預設 `1`。
 - `--max-render-target-bytes <size>`：每個渲染目標的記憶體上限。接受位元組數或 `512m`、`2g` 這類後綴。
+- `--max-band-bytes <size>`：streamed PNG row-buffer cap。接受位元組數或 `512m`、`2g` 這類後綴。
+- `--max-full-frame-bytes <size>`：full-frame PNG memory cap。接受位元組數或 `512m`、`2g` 這類後綴。
+- `--framebuffer-memory-safety-factor <n>`：full-frame framebuffer memory estimate multiplier。預設 `2`。
+- `--render-strategy <auto|full-frame|stream>`：PNG export strategy。預設 `auto`。
 - `--approx-region-arcs`：渲染前把 region 圓弧轉換為線段。
 - `--arc-quality <0|1|2>`：圓弧近似品質。預設 `1`。
 - `--invert-layer <selector>`：把 Gerber 圖層渲染為反相/negative 圖層。需要反相多個圖層時可重複指定。Selector 支援 1-based 圖層序號、完整圖層名和 basename。

--- a/packages/wasm-gerber-renderer/SKILL.md
+++ b/packages/wasm-gerber-renderer/SKILL.md
@@ -69,6 +69,10 @@ Useful CLI options:
 - `--composite-mode <blend|stack>` sets additive blending or ordered stack compositing.
 - `--minimum-feature-pixels <px>` keeps thin lines/arcs visible.
 - `--max-render-target-bytes <size>` caps per-render target memory, e.g. `512m` or `2g`.
+- `--max-band-bytes <size>` caps streamed PNG row-buffer memory.
+- `--max-full-frame-bytes <size>` caps full-frame PNG export memory.
+- `--framebuffer-memory-safety-factor <n>` adjusts full-frame memory estimates.
+- `--render-strategy <auto|full-frame|stream>` chooses the Node PNG export path.
 - `--approx-region-arcs` uses faster approximate region arcs.
 - `--arc-quality <0|1|2>` controls approximate arc quality.
 - `--invert-layer <selector>` renders a Gerber layer as an inverted/negative layer. Repeat it for multiple layers.
@@ -252,8 +256,15 @@ Layer options:
 - `alpha` overrides the frame default for that layer; in `stack` mode explicit Gerber alpha overrides the full-opacity default, and drill layers default to full opacity unless set
 - `offsetX`
 - `offsetY`
+- `kind` forces `"gerber"` or `"drill"` when a filename is unavailable or ambiguous
+- Node-only `inverted` renders a Gerber layer as an inverted/negative layer
 
 Colors are normalized RGB arrays in browser APIs, e.g. `[1, 0, 0]`. Node APIs also accept CSS-like color strings such as `"#ff3b30"` and `"rgba(255,0,0,0.8)"`.
+
+Node prepared layers can be loaded with `preserveArcRegions`,
+`arcTessellationQuality`, and `retainSourceContentForInversion`.
+Use `retainSourceContentForInversion: true` when a prepared layer must later be
+rendered as inverted or used as the explicit inverted outline source.
 
 ## Error Handling
 

--- a/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
+++ b/packages/wasm-gerber-renderer/bin/wasm-gerber-renderer.js
@@ -17,6 +17,11 @@ Options:
   --composite-mode <blend|stack>   blend=additive, stack=ordered source-over
   --minimum-feature-pixels <px>    Minimum line/arc display width (default: 1)
   --max-render-target-bytes <size> Per-render target memory cap, e.g. 2g, 512m
+  --max-band-bytes <size>          Streamed PNG row-buffer cap, e.g. 512m
+  --max-full-frame-bytes <size>    Full-frame PNG memory cap, e.g. 512m
+  --framebuffer-memory-safety-factor <n>
+                                  Full-frame memory estimate safety factor
+  --render-strategy <strategy>     PNG strategy: auto, full-frame, or stream
   --approx-region-arcs             Approximate region arcs before rendering (default: false)
   --arc-quality <0|1|2>            Approx arc quality: low, normal, high (default: 1)
   --invert-layer <selector>        Invert a Gerber layer by 1-based index or name (repeatable)
@@ -112,6 +117,14 @@ function parseArgs(args) {
       frameOptions.minimumFeaturePixels = readNumber(args, ++index, arg);
     } else if (arg === "--max-render-target-bytes") {
       frameOptions.maxRenderTargetBytes = readByteSize(args, ++index, arg);
+    } else if (arg === "--max-band-bytes") {
+      frameOptions.maxBandBytes = readByteSize(args, ++index, arg);
+    } else if (arg === "--max-full-frame-bytes") {
+      frameOptions.maxFullFrameBytes = readByteSize(args, ++index, arg);
+    } else if (arg === "--framebuffer-memory-safety-factor") {
+      frameOptions.framebufferMemorySafetyFactor = readNumber(args, ++index, arg);
+    } else if (arg === "--render-strategy") {
+      frameOptions.strategy = readRenderStrategy(args, ++index, arg);
     } else if (arg === "--approx-region-arcs") {
       frameOptions.preserveArcRegions = false;
     } else if (arg === "--arc-quality") {
@@ -145,6 +158,14 @@ function readCompositeMode(args, index, flag) {
     return value;
   }
   throw new Error(`${flag} must be blend or stack.`);
+}
+
+function readRenderStrategy(args, index, flag) {
+  const value = readOptionValue(args, index, flag);
+  if (value === "auto" || value === "full-frame" || value === "stream") {
+    return value;
+  }
+  throw new Error(`${flag} must be auto, full-frame, or stream.`);
 }
 
 function inferOutputPath(inputs) {

--- a/packages/wasm-gerber-renderer/test/cli-options.test.mjs
+++ b/packages/wasm-gerber-renderer/test/cli-options.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const cliPath = fileURLToPath(new URL("../bin/wasm-gerber-renderer.js", import.meta.url));
+
+test("CLI help lists Node PNG memory and strategy options", async () => {
+  const { stdout } = await execFileAsync(process.execPath, [
+    cliPath,
+    "--help",
+  ]);
+
+  assert.match(stdout, /--max-band-bytes <size>/);
+  assert.match(stdout, /--max-full-frame-bytes <size>/);
+  assert.match(stdout, /--framebuffer-memory-safety-factor <n>/);
+  assert.match(stdout, /--render-strategy <strategy>/);
+});
+
+test("CLI validates render strategy before rendering", async () => {
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      cliPath,
+      "--render-strategy",
+      "invalid",
+      "board.gbr",
+    ]),
+    /--render-strategy must be auto, full-frame, or stream\./,
+  );
+});


### PR DESCRIPTION
## Summary
- Add CLI coverage for Node PNG memory and render strategy options.
- Document the current renderer layer, frame, export, and prepared-layer options in the renderer README files and skill guide.
- Add CLI tests for the newly documented options and render strategy validation.

## Why
The renderer package exposed some Node rendering controls in code, but the CLI endpoint and docs did not fully match that surface.

## Validation
- `npm --prefix packages/wasm-gerber-renderer run check`
- `git diff --check`