### PR TITLE
Fix drill hole colors when switching canvas themes

### DIFF
--- a/js/core/viewer.js
+++ b/js/core/viewer.js
@@ -2984,6 +2984,7 @@ export class GerberViewer {
   toggleCanvasTheme() {
     this.isCanvasLight = !this.isCanvasLight;
     this.updateCanvasTheme();
+    this.requestRender();
   }
 
   updateCanvasTheme() {
@@ -3177,7 +3178,6 @@ export class GerberViewer {
 
       if (loadedCount > 0) {
         this.renderLayerList();
-        this.requestRender();
         this.fitView();
         this.addDiagnostic("info", "Remote file loaded", `${loadedCount} processed`);
       }
@@ -3234,7 +3234,6 @@ export class GerberViewer {
 
           if (loadedCount > 0) {
             this.renderLayerList();
-            this.requestRender();
             this.fitView();
             this.addDiagnostic("info", "Files loaded", `${loadedCount} processed`);
           }
@@ -5235,10 +5234,19 @@ export class GerberViewer {
   }
 
   fitView() {
-    this.flushLazyViewportRender();
-    this.flushPendingRenderFrame();
+    const hadLazyViewportState =
+      this.isLazyViewportPreviewActive() || this.isViewportTransformActive;
+    this.cancelLazyViewportRender();
     const fitView = this.calculateFitView();
-    if (!fitView) return;
+    if (!fitView) {
+      if (hadLazyViewportState) {
+        this.requestRender();
+      }
+      return;
+    }
+
+    // Supersede stale viewport work so only the fitted view is rendered.
+    this.cancelPendingRenderFrame();
 
     this.camera.zoom = this.clampZoom(fitView.zoom);
     this.fitViewZoom = this.camera.zoom;


### PR DESCRIPTION
## Summary

- Re-render the viewer when switching between light and dark canvas themes so drill hole fills match the new background.
- Cancel stale pending viewport renders before applying fit-to-view.
- Remove redundant render requests after local and remote file loading.

## Why

Drill hole fills are rendered with the current canvas background color. Switching the canvas theme updated the CSS background but did not schedule a WebGL render, leaving the previous drill fill color visible until another rendering event occurred.

The file-loading fit-to-view path also scheduled an intermediate render before the fitted viewport was applied.

## Impact

Drill holes now immediately match the selected light or dark canvas theme. Fit-to-view and file loading render only the final viewport state instead of rendering an unnecessary intermediate frame.

## Testing

- `node --check js/core/viewer.js`
- `npm run check --prefix packages/wasm-gerber-renderer`
- `git diff --check`

No new regression tests were added.